### PR TITLE
chore(ci): disable LangSmith tracing for unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,6 +60,8 @@ jobs:
           NEO4J_USERNAME: neo4j
           NEO4J_PASSWORD: test
           OPENAI_API_KEY: sk-test
+          # Disable LangSmith tracing for unit tests (mocked LLMs produce 0-token noise)
+          LANGSMITH_TRACING: "false"
 
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v4
@@ -138,6 +140,8 @@ jobs:
           NEO4J_URI: neo4j://localhost:7687
           NEO4J_USERNAME: neo4j
           NEO4J_PASSWORD: test
+          # Disable LangSmith tracing for prompt validation (no real LLM calls)
+          LANGSMITH_TRACING: "false"
 
       - name: Upload Tier 1 results
         uses: actions/upload-artifact@v4


### PR DESCRIPTION
## Summary
- Disable LangSmith tracing for `test` job (unit tests with mocked LLMs)
- Disable LangSmith tracing for `prompt-validation` job (Tier 1, no real LLM calls)
- Keep tracing enabled for `integration-test` and `smoke-evaluation` jobs

## Why
Mocked LLM calls produce traces with 0 tokens, $0.00 cost, and 0.00s latency that clutter the LangSmith dashboard. These traces provide no value since they don't represent real API calls.

## Test plan
- [ ] CI passes (lint, test, build-docker, prompt-validation)
- [ ] Verify no new traces appear in LangSmith from future CI unit test runs

🤖 Generated with [Claude Code](https://claude.com/claude-code)