### PR TITLE
fix(vercel): modernize configuration to remove build warning

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,19 +1,15 @@
 {
   "$schema": "https://openapi.vercel.sh/vercel.json",
   "version": 2,
-  "builds": [
-    {
-      "src": "api/index.py",
-      "use": "@vercel/python",
-      "config": {
-        "runtime": "python3.12"
-      }
+  "functions": {
+    "api/**/*.py": {
+      "excludeFiles": "{tests/**,__tests__/**,**/*.test.py,**/test_*.py,docs/**,scripts/**,.github/**}"
     }
-  ],
-  "routes": [
+  },
+  "rewrites": [
     {
-      "src": "/(.*)",
-      "dest": "api/index.py"
+      "source": "/(.*)",
+      "destination": "/api/index.py"
     }
   ],
   "env": {


### PR DESCRIPTION
## Summary

- Replace legacy `builds` property with modern `functions` property
- Replace `routes` with `rewrites` for URL routing
- Add `excludeFiles` to reduce bundle size by excluding tests, docs, scripts
- Remove explicit runtime config (auto-detected from pyproject.toml)

This eliminates the build warning:
> "Due to builds existing in your configuration file, the Build and Development Settings defined in your Project Settings will not apply."

## Test plan

- [x] Deploy to Vercel production
- [x] Verify `/health` endpoint returns 200
- [x] Verify build warning is gone
- [x] Verify bundle size is similar or smaller (73.69MB vs 73.77MB)

🤖 Generated with [Claude Code](https://claude.com/claude-code)