### PR TITLE
chore: add .vercel to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -72,3 +72,7 @@ comparison_results.json
 
 # Runtime data
 data/
+
+# Vercel
+.vercel/
+.env.vercel


### PR DESCRIPTION
## Summary

- Add `.vercel/` directory to gitignore (contains project-specific IDs)
- Add `.env.vercel` to gitignore (created by `vercel env pull`)

Both are local development configuration that should not be committed to the repository.

## Test plan

- [x] Verify `.vercel/` no longer shows in `git status`

🤖 Generated with [Claude Code](https://claude.com/claude-code)