### PR TITLE
fix(deps): move langsmith-fetch to dev dependencies

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -149,6 +149,8 @@ This project has LangSmith integration for debugging and observability.
 
 ### CLI Tool: langsmith-fetch
 
+**Note:** This is a dev dependency. Install with `uv sync --extra dev`
+
 ```bash
 # Fetch recent traces (after running app with LANGSMITH_TRACING=true)
 uv run langsmith-fetch traces --limit 5 --format json

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ dependencies = [
     "httpx>=0.27.0",
     # Observability (LangSmith)
     "langsmith>=0.1.0",
-    "langsmith-fetch>=0.3.1",
 ]
 
 [project.optional-dependencies]
@@ -55,6 +54,8 @@ dev = [
     "pytest-cov>=4.1.0",
     "pytest-mock>=3.12.0",
     "ruff>=0.6.0",
+    # LangSmith CLI for local debugging (not deployed to Vercel)
+    "langsmith-fetch>=0.3.1",
 ]
 
 [project.urls]

--- a/uv.lock
+++ b/uv.lock
@@ -326,7 +326,6 @@ dependencies = [
     { name = "langchain-core" },
     { name = "langchain-openai" },
     { name = "langsmith" },
-    { name = "langsmith-fetch" },
     { name = "neo4j" },
     { name = "neo4j-graphrag" },
     { name = "pydantic" },
@@ -339,6 +338,7 @@ dependencies = [
 
 [package.optional-dependencies]
 dev = [
+    { name = "langsmith-fetch" },
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-cov" },
@@ -353,7 +353,7 @@ requires-dist = [
     { name = "langchain-core", specifier = ">=0.3.0" },
     { name = "langchain-openai", specifier = ">=0.2.0" },
     { name = "langsmith", specifier = ">=0.1.0" },
-    { name = "langsmith-fetch", specifier = ">=0.3.1" },
+    { name = "langsmith-fetch", marker = "extra == 'dev'", specifier = ">=0.3.1" },
     { name = "neo4j", specifier = ">=5.15.0" },
     { name = "neo4j-graphrag", specifier = ">=1.0.0" },
     { name = "pydantic", specifier = ">=2.0.0" },


### PR DESCRIPTION
## Summary

Fixes Vercel deployment failure: "Serverless Function has exceeded the unzipped maximum size of 250 MB"

- Move `langsmith-fetch` from main dependencies to dev dependencies
- `langsmith-fetch` is a CLI tool for local debugging, not needed in production
- Update CLAUDE.md with install instructions for dev dependency

## Root Cause

The `langsmith-fetch` package (and its dependencies like `rich`) was being bundled into the Vercel serverless function, pushing it over the 250 MB limit.

## Fix

```diff
# pyproject.toml
dependencies = [
    "langsmith>=0.1.0",
-   "langsmith-fetch>=0.3.1",  # Removed from production deps
]

[project.optional-dependencies]
dev = [
+   "langsmith-fetch>=0.3.1",  # Added to dev deps
]
```

## Test Plan

- [ ] Vercel deployment succeeds after merge
- [ ] Local development still works: `uv sync --extra dev && uv run langsmith-fetch --help`

🤖 Generated with [Claude Code](https://claude.ai/code)