### PR TITLE
fix: use absolute paths for Claude Code hooks in monorepo

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -6,7 +6,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/validate-bash.sh \"$TOOL_INPUT\""
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/validate-bash.sh \"$TOOL_INPUT\""
           }
         ]
       }
@@ -17,7 +17,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/format-python.sh \"$TOOL_INPUT\""
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/format-python.sh \"$TOOL_INPUT\""
           }
         ]
       }
@@ -28,7 +28,7 @@
         "hooks": [
           {
             "type": "command",
-            "command": ".claude/hooks/post-task-check.sh"
+            "command": "$(git rev-parse --show-toplevel)/.claude/hooks/post-task-check.sh"
           }
         ]
       }


### PR DESCRIPTION
## Summary
- Fix Claude Code hook scripts failing with "No such file or directory" error
- Hooks now work correctly from any subdirectory in the monorepo

## Problem
The hook paths in `.claude/settings.json` were relative (e.g., `.claude/hooks/post-task-check.sh`), which failed when the working directory was `backend/` instead of the project root.

## Solution
Use `$(git rev-parse --show-toplevel)` to dynamically resolve the repository root, making hooks work from any subdirectory.

## Test plan
- [x] Verify hooks run without error from `backend/` directory
- [x] Verify hooks run without error from project root

🤖 Generated with [Claude Code](https://claude.ai/code)