### PR TITLE
fix(railway): update Dockerfile for Railway deployment

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -23,15 +23,14 @@ FROM base AS builder
 # Install uv
 COPY --from=ghcr.io/astral-sh/uv:latest /uv /uvx /bin/
 
-# Copy dependency files
-COPY pyproject.toml uv.lock ./
+# Copy dependency files (from repo root context)
+COPY backend/pyproject.toml backend/uv.lock ./
 
 # Copy README for build (required by pyproject.toml)
-COPY README.md ./
+COPY backend/README.md ./
 
 # Install dependencies (no dev dependencies for production)
-RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --frozen --no-dev --no-editable
+RUN uv sync --frozen --no-dev --no-editable
 
 # ============================================================================
 # Production stage
@@ -45,8 +44,8 @@ RUN groupadd --gid 1000 appuser && \
 # Copy virtual environment from builder
 COPY --from=builder /app/.venv /app/.venv
 
-# Copy application code
-COPY src/ ./src/
+# Copy application code (from repo root context)
+COPY backend/src/ ./src/
 
 # Set ownership
 RUN chown -R appuser:appuser /app
@@ -60,9 +59,10 @@ ENV PATH="/app/.venv/bin:$PATH"
 # Expose port for HTTP transport
 EXPOSE 8000
 
-# Health check
-HEALTHCHECK --interval=30s --timeout=10s --start-period=5s --retries=3 \
-    CMD curl -f http://localhost:8000/health || exit 1
+# Health check (Railway uses its own healthcheck, this is for local Docker)
+HEALTHCHECK --interval=30s --timeout=10s --start-period=30s --retries=3 \
+    CMD curl -f http://localhost:${PORT:-8000}/health || exit 1
 
 # Default command - REST API mode for Railway deployment
-CMD ["python", "-m", "uvicorn", "requirements_graphrag_api.api:app", "--host", "0.0.0.0", "--port", "8000"]
+# Use $PORT for Railway (defaults to 8000 for local development)
+CMD ["sh", "-c", "python -m uvicorn requirements_graphrag_api.api:app --host 0.0.0.0 --port ${PORT:-8000}"]

--- a/railway.toml
+++ b/railway.toml
@@ -3,6 +3,7 @@
 [build]
 builder = "dockerfile"
 dockerfilePath = "backend/Dockerfile"
+watchPatterns = ["backend/**"]
 
 [deploy]
 healthcheckPath = "/health"


### PR DESCRIPTION
## Summary
- Updates `backend/Dockerfile` for Railway's monorepo deployment context
- Adds dynamic `$PORT` support for Railway's port assignment
- Removes BuildKit cache mount (unsupported by Railway)

## Changes
- **Dockerfile paths**: Use `backend/` prefix for COPY commands since build context is repo root
- **Port binding**: Use `${PORT:-8000}` for Railway compatibility
- **Healthcheck**: Increased start-period to 30s and use dynamic port
- **railway.toml**: Added `watchPatterns` for backend changes

## Test plan
- [x] Backend deployed successfully to Railway
- [x] Health check passes: https://api-production-f1cf.up.railway.app/health
- [x] Frontend deployed to Vercel and connected to backend

🤖 Generated with [Claude Code](https://claude.com/claude-code)