### PR TITLE
fix(cors): use CORS_ORIGINS environment variable for allowed origins

### DIFF
--- a/backend/src/requirements_graphrag_api/api.py
+++ b/backend/src/requirements_graphrag_api/api.py
@@ -20,6 +20,7 @@ Updated Data Model (2026-01):
 from __future__ import annotations
 
 import logging
+import os
 from contextlib import asynccontextmanager
 from typing import TYPE_CHECKING
 
@@ -130,13 +131,17 @@ app = FastAPI(
 )
 
 # Configure CORS for frontend access
+# Use CORS_ORIGINS env var (comma-separated) or defaults for local development
+_cors_origins_env = os.getenv("CORS_ORIGINS", "")
+_cors_origins = (
+    [origin.strip() for origin in _cors_origins_env.split(",") if origin.strip()]
+    if _cors_origins_env
+    else ["http://localhost:3000", "http://localhost:5173"]
+)
+
 app.add_middleware(
     CORSMiddleware,
-    allow_origins=[
-        "http://localhost:3000",  # Local development
-        "http://localhost:5173",  # Vite dev server
-        "https://*.vercel.app",  # Vercel preview deployments
-    ],
+    allow_origins=_cors_origins,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],


### PR DESCRIPTION
## Summary
- Fix CORS configuration to use the `CORS_ORIGINS` environment variable (comma-separated)
- FastAPI's CORSMiddleware doesn't support wildcard patterns like `https://*.vercel.app`
- Falls back to localhost defaults for local development when env var is not set

## Problem
The frontend at `https://frontend-norfolk-ai-bi.vercel.app` was getting CORS errors:
```
OPTIONS /chat HTTP/1.1" 400 Bad Request
Disallowed CORS origin
```

## Test plan
- [x] All 115 backend tests pass
- [x] Ruff linter passes
- [ ] After merge, verify CORS preflight requests succeed from frontend

🤖 Generated with [Claude Code](https://claude.com/claude-code)