### PR TITLE
chore: update gitignore and vscode extensions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -85,3 +85,4 @@ frontend/.cache/
 
 # Benchmarks
 .benchmarks/
+.vercel

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -26,7 +26,6 @@
     // Productivity
     "usernamehw.errorlens",
     "christian-kohler.path-intellisense",
-    "streetsidesoftware.code-spell-checker",
 
     // Docker (optional)
     "ms-azuretools.vscode-docker"

--- a/frontend/.gitignore
+++ b/frontend/.gitignore
@@ -22,3 +22,4 @@ dist-ssr
 *.njsproj
 *.sln
 *.sw?
+.vercel


### PR DESCRIPTION
## Summary
- Add `.vercel` to root and frontend gitignore (per Vercel recommendations)
- Remove code-spell-checker from recommended VS Code extensions

## Context
The `.vercel` folder contains project-specific settings that should not be committed per Vercel's documentation:
> Should I commit the ".vercel" folder? No, you should not share the ".vercel" folder with anyone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)