### PR TITLE
feat: add Neo4j timeouts, chat memory, and LangSmith Threads

### DIFF
--- a/backend/src/requirements_graphrag_api/api.py
+++ b/backend/src/requirements_graphrag_api/api.py
@@ -77,9 +77,10 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
     # Create Neo4j driver with serverless-optimized settings
     logger.info(
-        "Connecting to Neo4j: %s (pool_size=%d)",
+        "Connecting to Neo4j: %s (pool_size=%d, max_lifetime=%ds)",
         config.neo4j_uri.split("@")[-1] if "@" in config.neo4j_uri else config.neo4j_uri,
         config.neo4j_max_connection_pool_size,
+        config.neo4j_max_connection_lifetime,
     )
 
     driver = GraphDatabase.driver(
@@ -87,6 +88,8 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
         auth=(config.neo4j_username, config.neo4j_password),
         max_connection_pool_size=config.neo4j_max_connection_pool_size,
         connection_acquisition_timeout=config.neo4j_connection_acquisition_timeout,
+        liveness_check_timeout=config.neo4j_liveness_check_timeout,
+        max_connection_lifetime=config.neo4j_max_connection_lifetime,
     )
 
     # Verify connectivity (fail fast)

--- a/backend/src/requirements_graphrag_api/config.py
+++ b/backend/src/requirements_graphrag_api/config.py
@@ -82,6 +82,8 @@ class AppConfig:
     # Neo4j driver settings optimized for serverless (Vercel/Lambda)
     neo4j_max_connection_pool_size: int = 5
     neo4j_connection_acquisition_timeout: float = 30.0
+    neo4j_liveness_check_timeout: float = 30.0  # Timeout for connection liveness checks
+    neo4j_max_connection_lifetime: int = 300  # Max seconds a connection can live (5 min)
     # LangSmith observability settings
     langsmith_api_key: str = ""
     langsmith_project: str = "requirements-graphrag"
@@ -166,6 +168,8 @@ def get_config() -> AppConfig:
         log_level=os.getenv("LOG_LEVEL", "INFO"),
         neo4j_max_connection_pool_size=int(os.getenv("NEO4J_MAX_POOL_SIZE", "5")),
         neo4j_connection_acquisition_timeout=float(os.getenv("NEO4J_CONNECTION_TIMEOUT", "30.0")),
+        neo4j_liveness_check_timeout=float(os.getenv("NEO4J_LIVENESS_CHECK_TIMEOUT", "30.0")),
+        neo4j_max_connection_lifetime=int(os.getenv("NEO4J_MAX_CONNECTION_LIFETIME", "300")),
         langsmith_api_key=os.getenv("LANGSMITH_API_KEY", os.getenv("LANGCHAIN_API_KEY", "")),
         langsmith_project=os.getenv(
             "LANGSMITH_PROJECT", os.getenv("LANGCHAIN_PROJECT", "requirements-graphrag")

--- a/backend/src/requirements_graphrag_api/core/generation.py
+++ b/backend/src/requirements_graphrag_api/core/generation.py
@@ -320,7 +320,9 @@ async def stream_chat(
     message: str,
     *,
     conversation_history: list[dict[str, str]] | None = None,
+    conversation_id: str | None = None,
     max_sources: int = 5,
+    langsmith_extra: dict[str, Any] | None = None,  # For thread metadata
 ) -> AsyncIterator[StreamEvent]:
     """Stream chat response with progressive events.
 
@@ -330,6 +332,7 @@ async def stream_chat(
     3. DONE event with complete answer
 
     This enables LangSmith to capture streaming metrics like TTFT.
+    When conversation_id is provided, traces are grouped into LangSmith Threads.
 
     Args:
         config: Application configuration.
@@ -337,12 +340,16 @@ async def stream_chat(
         driver: Neo4j driver for graph queries.
         message: User's message.
         conversation_history: Optional list of previous messages for multi-turn.
+        conversation_id: Optional conversation ID for LangSmith thread grouping.
         max_sources: Maximum sources to retrieve.
+        langsmith_extra: Optional LangSmith metadata (used internally for threading).
 
     Yields:
         StreamEvent objects for sources, tokens, and completion.
     """
-    logger.info("Streaming chat: message='%s'", message[:50])
+    # Note: langsmith_extra is consumed by the @traceable decorator, not used here
+    _ = langsmith_extra  # Suppress unused variable warning
+    logger.info("Streaming chat: message='%s', conversation_id=%s", message[:50], conversation_id)
 
     try:
         # 1. Retrieval (non-streamed)

--- a/backend/src/requirements_graphrag_api/observability.py
+++ b/backend/src/requirements_graphrag_api/observability.py
@@ -170,6 +170,35 @@ def traceable_safe(
     return decorator
 
 
+def create_thread_metadata(conversation_id: str | None) -> dict[str, Any] | None:
+    """Create LangSmith metadata for conversation threading.
+
+    This helper creates the metadata dict needed to group traces into
+    LangSmith Threads. Use this with the `langsmith_extra` parameter
+    when calling @traceable decorated functions.
+
+    Args:
+        conversation_id: Unique ID for the conversation thread.
+
+    Returns:
+        Metadata dict with conversation_id, or None if no ID provided.
+
+    Example:
+        @traceable_safe(name="stream_chat", run_type="chain")
+        async def stream_chat(..., langsmith_extra=None):
+            ...
+
+        # At call time:
+        await stream_chat(
+            ...,
+            langsmith_extra=create_thread_metadata("conversation-123")
+        )
+    """
+    if not conversation_id:
+        return None
+    return {"metadata": {"conversation_id": conversation_id}}
+
+
 def configure_tracing(config: AppConfig) -> bool:
     """Configure LangSmith tracing from application config.
 
@@ -245,6 +274,7 @@ __all__ = [
     "REDACTED",
     "SENSITIVE_FIELD_PATTERNS",
     "configure_tracing",
+    "create_thread_metadata",
     "disable_tracing",
     "get_tracing_status",
     "sanitize_inputs",

--- a/backend/tests/test_observability.py
+++ b/backend/tests/test_observability.py
@@ -12,6 +12,7 @@ from requirements_graphrag_api.config import AppConfig
 from requirements_graphrag_api.observability import (
     REDACTED,
     configure_tracing,
+    create_thread_metadata,
     disable_tracing,
     get_tracing_status,
     sanitize_inputs,
@@ -391,3 +392,28 @@ class TestTraceableSafe:
 
         result = asyncio.run(func_with_config(config, "test"))
         assert result == "Query: test"
+
+
+class TestCreateThreadMetadata:
+    """Tests for create_thread_metadata function."""
+
+    def test_create_thread_metadata_with_id(self) -> None:
+        """Test that metadata is created with conversation_id."""
+        result = create_thread_metadata("conversation-123")
+
+        assert result is not None
+        assert "metadata" in result
+        assert result["metadata"]["conversation_id"] == "conversation-123"
+
+    def test_create_thread_metadata_without_id(self) -> None:
+        """Test that None is returned without conversation_id."""
+        assert create_thread_metadata(None) is None
+        assert create_thread_metadata("") is None
+
+    def test_create_thread_metadata_preserves_uuid_format(self) -> None:
+        """Test that UUID-style conversation IDs are preserved."""
+        uuid_id = "550e8400-e29b-41d4-a716-446655440000"
+        result = create_thread_metadata(uuid_id)
+
+        assert result is not None
+        assert result["metadata"]["conversation_id"] == uuid_id


### PR DESCRIPTION
## Summary
- **Neo4j Connection Stability**: Add `liveness_check_timeout` (30s) and `max_connection_lifetime` (5 min) to prevent "Unable to retrieve routing information" errors
- **Frontend Chat Memory**: Generate stable conversation ID per session and send `conversation_history` with each request for multi-turn context
- **LangSmith Threads**: Add `create_thread_metadata()` helper to group traces by `conversation_id`, enabling multi-turn conversation views in LangSmith UI

## Test plan
- [x] All 132 tests pass
- [x] New tests for `create_thread_metadata` function (3 tests)
- [ ] Manual test: Deploy to Railway and verify Neo4j connection stability
- [ ] Manual test: Deploy to Vercel and verify chat history is maintained across turns
- [ ] Manual test: Verify LangSmith shows conversation threads grouped together

🤖 Generated with [Claude Code](https://claude.com/claude-code)