### PR TITLE
fix: use workspace-scoped prompts without org prefix

### DIFF
--- a/backend/src/requirements_graphrag_api/prompts/catalog.py
+++ b/backend/src/requirements_graphrag_api/prompts/catalog.py
@@ -34,7 +34,8 @@ LANGSMITH_API_KEY_ENV: Final[str] = "LANGSMITH_API_KEY"
 PROMPT_ENVIRONMENT_ENV: Final[str] = "PROMPT_ENVIRONMENT"
 
 # Default configuration
-DEFAULT_ORG: Final[str] = "requirements-graphrag"
+# Empty string means workspace-scoped prompts (no org prefix)
+DEFAULT_ORG: Final[str] = ""
 DEFAULT_CACHE_TTL: Final[int] = 300  # 5 minutes
 
 
@@ -95,9 +96,12 @@ class PromptCatalog:
             name: Prompt name identifier.
 
         Returns:
-            Full hub path in format: organization/prompt-name
+            Full hub path. If organization is set, returns organization/prompt-name.
+            If organization is empty, returns just prompt-name (workspace-scoped).
         """
-        return f"{self.organization}/{name.value}"
+        if self.organization:
+            return f"{self.organization}/{name.value}"
+        return name.value
 
     def _is_cache_valid(self, key: str) -> bool:
         """Check if a cache entry is still valid.


### PR DESCRIPTION
## Summary
The prompts in the `jama-graphrag` LangSmith workspace were pushed without an organization prefix (`owner: null`). The application was constructing paths like `requirements-graphrag/graphrag-rag-generation` which returned 404 errors, causing it to always fall back to local definitions.

## Root Cause
- Prompts are **workspace-scoped** (not org-scoped)
- Hub path should be just `graphrag-rag-generation`, not `requirements-graphrag/graphrag-rag-generation`

## Changes
- Change `DEFAULT_ORG` from `"requirements-graphrag"` to `""` (empty)
- Update `_get_hub_path()` to return just the prompt name when org is empty

## Verification
```python
# Before fix - FAILS
client.pull_prompt('requirements-graphrag/graphrag-rag-generation')
# 404 Not Found

# After fix - SUCCESS  
client.pull_prompt('graphrag-rag-generation')
# Returns ChatPromptTemplate
```

## Test plan
- [x] All 132 tests pass
- [ ] Deploy to Railway and verify prompts are pulled from Hub (check download counts)

🤖 Generated with [Claude Code](https://claude.com/claude-code)