### PR TITLE
feat(prompts): add LangSmith Hub sync automation

### DIFF
--- a/.github/workflows/sync-prompts.yml
+++ b/.github/workflows/sync-prompts.yml
@@ -1,0 +1,49 @@
+# Sync prompts to LangSmith Hub when definitions change
+name: Sync Prompts
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'backend/src/requirements_graphrag_api/prompts/definitions.py'
+  workflow_dispatch:
+    # Allow manual trigger from GitHub Actions UI
+
+env:
+  PYTHON_VERSION: "3.12"
+
+jobs:
+  sync-prompts:
+    name: Sync Prompts to LangSmith Hub
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: backend
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v4
+        with:
+          version: "latest"
+
+      - name: Set up Python
+        run: uv python install ${{ env.PYTHON_VERSION }}
+
+      - name: Install dependencies
+        run: uv sync
+
+      - name: Push prompts to LangSmith Hub
+        run: uv run python scripts/push_prompts.py
+        env:
+          LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
+          # Empty org means workspace-scoped prompts
+          LANGSMITH_ORG: ""
+
+      - name: Summary
+        run: |
+          echo "## Prompt Sync Complete" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "Prompts have been synchronized to LangSmith Hub." >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+          echo "View prompts at: https://smith.langchain.com/hub" >> $GITHUB_STEP_SUMMARY


### PR DESCRIPTION
## Summary
- Add `push()` and `push_all()` methods to `PromptCatalog` for pushing prompts to LangSmith Hub
- Fix `push_prompts.py` script to work with new methods and default to workspace-scoped prompts
- Add GitHub Action workflow for automatic prompt synchronization

## Background
Previously, there was no automated way to keep LangSmith Hub prompts synchronized with the local prompt definitions. The `push_prompts.py` script was broken (referenced non-existent methods), and prompts had to be manually pushed.

## Changes

### `catalog.py`
- Added `push(name: PromptName)` method to push a single prompt
- Added `push_all()` method to push all prompts
- Both methods use async/await with `asyncio.to_thread` for non-blocking Hub API calls

### `push_prompts.py`
- Fixed to use the new `PromptCatalog.push()` and `push_all()` methods
- Removed reference to non-existent `catalog._initialized`
- Changed default org to empty string (workspace-scoped prompts)

### `.github/workflows/sync-prompts.yml` (New)
- Triggers on push to `main` when `definitions.py` changes
- Also supports manual trigger via `workflow_dispatch`
- Requires `LANGSMITH_API_KEY` secret

## Test plan
- [x] All 143 tests pass
- [x] Ruff linting passes
- [x] `push_prompts.py --dry-run` works correctly
- [ ] CI passes
- [ ] After merge, manually update `definitions.py` and verify workflow runs

## Setup Required
After merging, ensure `LANGSMITH_API_KEY` is added as a repository secret for the workflow to function.

🤖 Generated with [Claude Code](https://claude.com/claude-code)