### PR TITLE
feat(generation): add structured resources to RAG context

### DIFF
--- a/backend/src/requirements_graphrag_api/core/generation.py
+++ b/backend/src/requirements_graphrag_api/core/generation.py
@@ -259,8 +259,7 @@ def _build_context_from_results(
                 if defn.get("acronym"):
                     term_display = f"{defn['term']} ({defn['acronym']})"
                 context_parts.append(
-                    f"[Definition: {term_display}]\n{defn['definition']}\n"
-                    f"URL: {defn_url}\n"
+                    f"[Definition: {term_display}]\n{defn['definition']}\nURL: {defn_url}\n"
                 )
                 sources.append(
                     {
@@ -327,7 +326,7 @@ def _build_context_from_results(
                         source_title=title,
                     )
                 )
-                source_resources.append(f"- 🖼️ Image: \"{alt_text}\" - {img_url}")
+                source_resources.append(f'- 🖼️ Image: "{alt_text}" - {img_url}')
 
             # Extract webinars (limit per source)
             source_webinar_count = 0
@@ -347,7 +346,7 @@ def _build_context_from_results(
                         source_title=title,
                     )
                 )
-                source_resources.append(f"- 📹 Webinar: \"{webinar_title}\" - {webinar_url}")
+                source_resources.append(f'- 📹 Webinar: "{webinar_title}" - {webinar_url}')
 
             # Extract videos (limit per source)
             source_video_count = 0
@@ -367,7 +366,7 @@ def _build_context_from_results(
                         source_title=title,
                     )
                 )
-                source_resources.append(f"- 🎬 Video: \"{video_title}\" - {video_url}")
+                source_resources.append(f'- 🎬 Video: "{video_title}" - {video_url}')
 
         # Add resources section to source context if any resources found
         if source_resources:

--- a/backend/tests/test_core/test_generation.py
+++ b/backend/tests/test_core/test_generation.py
@@ -690,9 +690,7 @@ class TestContextBuildResultDataclass:
 class TestBuildContextFromResults:
     """Tests for _build_context_from_results function."""
 
-    def test_extracts_webinars_from_media(
-        self, mock_search_results_with_media: list[dict]
-    ) -> None:
+    def test_extracts_webinars_from_media(self, mock_search_results_with_media: list[dict]) -> None:
         """Verify webinars are extracted from search_results[].media.webinars."""
         result = _build_context_from_results(
             definitions=[],
@@ -706,9 +704,7 @@ class TestBuildContextFromResults:
         assert "Traceability Best Practices" in titles
         assert "Modern Requirements Management" in titles
 
-    def test_extracts_videos_from_media(
-        self, mock_search_results_with_media: list[dict]
-    ) -> None:
+    def test_extracts_videos_from_media(self, mock_search_results_with_media: list[dict]) -> None:
         """Verify videos are extracted from search_results[].media.videos."""
         result = _build_context_from_results(
             definitions=[],
@@ -747,9 +743,7 @@ class TestBuildContextFromResults:
 
         webinars = result.resources["webinars"]
         # First webinar should be from "Traceability Article"
-        traceability_webinar = next(
-            w for w in webinars if w.title == "Traceability Best Practices"
-        )
+        traceability_webinar = next(w for w in webinars if w.title == "Traceability Best Practices")
         assert traceability_webinar.source_title == "Traceability Article"
 
     def test_context_string_groups_resources_by_source(
@@ -937,15 +931,9 @@ class TestStreamChatResourceEvents:
     ) -> None:
         """Verify SOURCES event has resources.images/webinars/videos."""
         with (
-            patch(
-                "requirements_graphrag_api.core.generation.graph_enriched_search"
-            ) as mock_search,
-            patch(
-                "requirements_graphrag_api.core.generation.search_terms"
-            ) as mock_terms,
-            patch(
-                "requirements_graphrag_api.core.generation.ChatOpenAI"
-            ) as mock_llm_class,
+            patch("requirements_graphrag_api.core.generation.graph_enriched_search") as mock_search,
+            patch("requirements_graphrag_api.core.generation.search_terms") as mock_terms,
+            patch("requirements_graphrag_api.core.generation.ChatOpenAI") as mock_llm_class,
         ):
             mock_search.return_value = mock_search_results_with_media
             mock_terms.return_value = []
@@ -978,15 +966,9 @@ class TestStreamChatResourceEvents:
     ) -> None:
         """Verify resource objects have title, url, alt_text, source_title."""
         with (
-            patch(
-                "requirements_graphrag_api.core.generation.graph_enriched_search"
-            ) as mock_search,
-            patch(
-                "requirements_graphrag_api.core.generation.search_terms"
-            ) as mock_terms,
-            patch(
-                "requirements_graphrag_api.core.generation.ChatOpenAI"
-            ) as mock_llm_class,
+            patch("requirements_graphrag_api.core.generation.graph_enriched_search") as mock_search,
+            patch("requirements_graphrag_api.core.generation.search_terms") as mock_terms,
+            patch("requirements_graphrag_api.core.generation.ChatOpenAI") as mock_llm_class,
         ):
             mock_search.return_value = mock_search_results_with_media
             mock_terms.return_value = []


### PR DESCRIPTION
## Summary
- Add `Resource` and `ContextBuildResult` dataclasses for structured data handling
- Rewrite `_build_context_from_results()` to extract media resources from graph enrichment
- Group resources by source in LLM context string with emoji prefixes (🖼️ 📹 🎬)
- Apply 3-per-type limit per source with global URL deduplication
- Include image alt_text in context for LLM reasoning
- Add 19 new tests for resource extraction, limits, and deduplication

## Breaking Change
Response structure changes from `{images: [...]}` to `{resources: {images: [...], webinars: [...], videos: [...]}}`

Frontend will need a follow-up PR to handle the new structure.

## Test plan
- [ ] Run `uv run pytest backend/tests/test_core/test_generation.py` - 34 tests pass
- [ ] Verify existing `/chat` endpoint continues to work
- [ ] Check LangSmith traces show resources in SOURCES event

🤖 Generated with [Claude Code](https://claude.ai/claude-code)