### PR TITLE
fix(ci): use LANGSMITH_ORG secret for prompt sync

### DIFF
--- a/.github/workflows/sync-prompts.yml
+++ b/.github/workflows/sync-prompts.yml
@@ -37,8 +37,8 @@ jobs:
         run: uv run python scripts/push_prompts.py
         env:
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
-          # Empty org means workspace-scoped prompts
-          LANGSMITH_ORG: ""
+          # LangSmith Hub requires an owner (user or org) for prompts
+          LANGSMITH_ORG: ${{ secrets.LANGSMITH_ORG }}
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary

Fixes the failing "Sync Prompts" workflow by using the `LANGSMITH_ORG` secret instead of an empty string.

## Problem

LangSmith Hub requires an owner (user or organization) when pushing prompts. The workflow was configured with `LANGSMITH_ORG: ""` which caused:
```
400 Client Error: Bad Request
{"detail":"No prompt owner specified"}
```

## Solution

Changed the workflow to use `${{ secrets.LANGSMITH_ORG }}` instead of an empty string.

## Action Required

Add the `LANGSMITH_ORG` secret to your GitHub repository:
1. Go to **Settings** → **Secrets and variables** → **Actions**
2. Click **New repository secret**
3. Name: `LANGSMITH_ORG`
4. Value: Your LangSmith username or organization name

🤖 Generated with [Claude Code](https://claude.com/claude-code)