### PR TITLE
fix(ci): add LANGSMITH_WORKSPACE for org-scoped API keys

### DIFF
--- a/.github/workflows/sync-prompts.yml
+++ b/.github/workflows/sync-prompts.yml
@@ -39,6 +39,8 @@ jobs:
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
           # LangSmith Hub requires an owner (user or org) for prompts
           LANGSMITH_ORG: ${{ secrets.LANGSMITH_ORG }}
+          # Required for org-scoped API keys (workspace UUID from LangSmith settings)
+          LANGCHAIN_WORKSPACE: ${{ secrets.LANGSMITH_WORKSPACE }}
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary

Adds support for org-scoped LangSmith API keys by passing the workspace ID.

## Problem

Org-scoped LangSmith API keys require a workspace specification:
```
403 Client Error: Forbidden
{"detail":"This API key is org-scoped and requires workspace specification. Please provide 'X-Tenant-ID' header."}
```

## Solution

Added `LANGCHAIN_WORKSPACE` environment variable from the `LANGSMITH_WORKSPACE` secret.

## Action Required

Add the `LANGSMITH_WORKSPACE` secret to your GitHub repository:
1. Go to **Settings** → **Secrets and variables** → **Actions**
2. Click **New repository secret**
3. Name: `LANGSMITH_WORKSPACE`
4. Value: Your workspace UUID from [LangSmith Settings](https://smith.langchain.com/settings)

🤖 Generated with [Claude Code](https://claude.com/claude-code)