### PR TITLE
fix(ci): use LANGCHAIN_TENANT_ID for workspace specification

### DIFF
--- a/.github/workflows/sync-prompts.yml
+++ b/.github/workflows/sync-prompts.yml
@@ -40,7 +40,8 @@ jobs:
           # LangSmith Hub requires an owner (user or org) for prompts
           LANGSMITH_ORG: ${{ secrets.LANGSMITH_ORG }}
           # Required for org-scoped API keys (workspace UUID from LangSmith settings)
-          LANGCHAIN_WORKSPACE: ${{ secrets.LANGSMITH_WORKSPACE }}
+          # SDK uses LANGCHAIN_TENANT_ID for the X-Tenant-ID header
+          LANGCHAIN_TENANT_ID: ${{ secrets.LANGSMITH_WORKSPACE }}
 
       - name: Summary
         run: |


### PR DESCRIPTION
## Summary

Fixes the environment variable name for workspace specification.

## Problem

The LangSmith SDK uses `LANGCHAIN_TENANT_ID` (not `LANGCHAIN_WORKSPACE`) to set the `X-Tenant-ID` header required for org-scoped API keys.

## Solution

Changed `LANGCHAIN_WORKSPACE` to `LANGCHAIN_TENANT_ID`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)