### PR TITLE
fix(ci): use LANGSMITH_TENANT_ID env var

### DIFF
--- a/.github/workflows/sync-prompts.yml
+++ b/.github/workflows/sync-prompts.yml
@@ -40,8 +40,7 @@ jobs:
           # LangSmith Hub requires an owner (user or org) for prompts
           LANGSMITH_ORG: ${{ secrets.LANGSMITH_ORG }}
           # Required for org-scoped API keys (workspace UUID from LangSmith settings)
-          # SDK uses LANGCHAIN_TENANT_ID for the X-Tenant-ID header
-          LANGCHAIN_TENANT_ID: ${{ secrets.LANGSMITH_WORKSPACE }}
+          LANGSMITH_TENANT_ID: ${{ secrets.LANGSMITH_WORKSPACE }}
 
       - name: Summary
         run: |


### PR DESCRIPTION
Quick fix: use correct env var name for LangSmith SDK.