### PR TITLE
fix(prompts): handle 409 Conflict when prompt unchanged

### DIFF
--- a/backend/scripts/push_prompts.py
+++ b/backend/scripts/push_prompts.py
@@ -115,17 +115,27 @@ async def push_prompts(
         logger.info("\n🚀 Pushing all prompts to LangSmith Hub\n")
         results = await catalog.push_all()
 
-        success_count = sum(1 for url in results.values() if not str(url).startswith("ERROR"))
-        error_count = len(results) - success_count
+        pushed_count = sum(
+            1 for url in results.values() if not str(url).startswith(("ERROR", "[UNCHANGED]"))
+        )
+        unchanged_count = sum(1 for url in results.values() if str(url).startswith("[UNCHANGED]"))
+        error_count = sum(1 for url in results.values() if str(url).startswith("ERROR"))
 
         logger.info("\n📊 Results:")
         for name, url in results.items():
             if str(url).startswith("ERROR"):
                 logger.error("   ❌ %s: %s", name, url)
+            elif str(url).startswith("[UNCHANGED]"):
+                logger.info("   ⏭️  %s: %s", name, url)
             else:
                 logger.info("   ✅ %s: %s", name, url)
 
-        logger.info("\n📈 Summary: %d succeeded, %d failed", success_count, error_count)
+        logger.info(
+            "\n📈 Summary: %d pushed, %d unchanged, %d failed",
+            pushed_count,
+            unchanged_count,
+            error_count,
+        )
 
         if error_count > 0:
             sys.exit(1)

--- a/backend/src/requirements_graphrag_api/prompts/catalog.py
+++ b/backend/src/requirements_graphrag_api/prompts/catalog.py
@@ -398,6 +398,11 @@ class PromptCatalog:
             logger.info("Pushed prompt to hub: %s -> %s", name.value, url)
             return str(url)
         except Exception as e:
+            # Handle 409 Conflict when prompt hasn't changed - treat as success
+            error_str = str(e)
+            if "409" in error_str and "Nothing to commit" in error_str:
+                logger.info("Prompt unchanged, no commit needed: %s", name.value)
+                return f"[UNCHANGED] {hub_path}"
             logger.error("Failed to push prompt %s: %s", name.value, e)
             raise
 


### PR DESCRIPTION
## Summary
- Treat LangSmith Hub 409 "Nothing to commit" responses as success, not failure
- Return `[UNCHANGED]` marker for prompts that haven't changed
- Update push_prompts.py to show separate counts for pushed/unchanged/failed prompts
- Display ⏭️ icon for unchanged prompts in results

## Problem
The Sync Prompts workflow was failing because LangSmith Hub returns a 409 Conflict error when pushing a prompt that hasn't changed since the last commit. This is expected behavior (idempotency), not an actual error.

## Solution
Catch the specific 409 "Nothing to commit" error and treat it as success, returning an `[UNCHANGED]` marker that the script can use to display appropriate feedback.

## Test plan
- [x] Existing tests pass
- [x] Ruff linter passes
- [ ] Verify Sync Prompts workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)