### PR TITLE
fix(evaluation): update import to use generate_answer

### DIFF
--- a/backend/src/requirements_graphrag_api/evaluation/__init__.py
+++ b/backend/src/requirements_graphrag_api/evaluation/__init__.py
@@ -147,20 +147,21 @@ async def _generate_answer(
     Returns:
         Tuple of (generated_answer, retrieved_contexts).
     """
-    from requirements_graphrag_api.core.generation import generate_response
-    from requirements_graphrag_api.core.retrieval import graph_enriched_search
+    from requirements_graphrag_api.core.generation import generate_answer
 
-    # Retrieve relevant contexts
-    results = await graph_enriched_search(retriever, driver, question, limit=6)
-    contexts = [r["content"] for r in results if r.get("content")]
-
-    # Generate answer
-    answer = await generate_response(
+    # Generate answer using the updated RAG pipeline
+    result = await generate_answer(
         config=config,
+        retriever=retriever,
+        driver=driver,
         question=question,
-        contexts=contexts,
-        stream=False,
+        retrieval_limit=6,
     )
+
+    # Extract answer and contexts from result
+    answer = result.get("answer", "")
+    sources = result.get("sources", [])
+    contexts = [s.get("content", "") for s in sources if s.get("content")]
 
     return answer, contexts
 


### PR DESCRIPTION
## Summary
- Update evaluation module to use `generate_answer` instead of deprecated `generate_response`
- Pass `retriever` and `driver` to the function as required by new signature
- Extract answer and contexts from result dictionary

## Problem
The Evaluation workflow was failing with:
```
cannot import name 'generate_response' from 'requirements_graphrag_api.core.generation'
```

The function was renamed to `generate_answer` with a different signature during recent refactoring.

## Test plan
- [x] Existing tests pass
- [x] Ruff linter passes
- [ ] Evaluation workflow succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)