### PR TITLE
fix(ci): correct artifact paths in evaluation workflow

### DIFF
--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -74,7 +74,7 @@ jobs:
         if: always()
         with:
           name: tier3-benchmark-results-${{ github.ref_name || github.sha }}
-          path: tier3_results.json
+          path: backend/tier3_results.json
 
       - name: Comment on release with results
         if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
@@ -82,7 +82,7 @@ jobs:
         with:
           script: |
             const fs = require('fs');
-            const results = JSON.parse(fs.readFileSync('tier3_results.json', 'utf8'));
+            const results = JSON.parse(fs.readFileSync('backend/tier3_results.json', 'utf8'));
 
             const body = `## 📊 Release Evaluation Results
 
@@ -143,7 +143,7 @@ jobs:
         if: always()
         with:
           name: tier4-deep-eval-${{ github.run_number }}
-          path: tier4_results.json
+          path: backend/tier4_results.json
 
       - name: Create issue on failure
         if: failure()
@@ -154,7 +154,7 @@ jobs:
             let resultsInfo = 'Results file not available';
 
             try {
-              const results = JSON.parse(fs.readFileSync('tier4_results.json', 'utf8'));
+              const results = JSON.parse(fs.readFileSync('backend/tier4_results.json', 'utf8'));
               resultsInfo = `
               - Average Score: ${results.avg_score.toFixed(4)}
               - Threshold: ${results.min_score_threshold.toFixed(4)}


### PR DESCRIPTION
## Description

Fixes the warning: `No files were found with the provided path: tier3_results.json. No artifacts will be uploaded.`

## Type of Change

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)

## Changes Made

The workflow sets `working-directory: backend` for `run` steps, so result files are created in `backend/`. However, `actions/upload-artifact` and `actions/github-script` don't inherit this working directory context.

**Fixed paths:**
- `tier3_results.json` → `backend/tier3_results.json`
- `tier4_results.json` → `backend/tier4_results.json`

## Testing

- [x] Linting passes
- [x] YAML validation passes

```release-notes
Fixed evaluation workflow artifact upload paths
```

## Checklist

- [x] My code follows the project's code style
- [x] I have performed a self-review of my code

🤖 Generated with [Claude Code](https://claude.com/claude-code)