### PR TITLE
feat(frontend): Display enhanced SSE context data with rich UI components

### DIFF
--- a/backend/src/requirements_graphrag_api/api.py
+++ b/backend/src/requirements_graphrag_api/api.py
@@ -33,6 +33,7 @@ from requirements_graphrag_api.observability import configure_tracing
 from requirements_graphrag_api.routes import (
     chat_router,
     definitions_router,
+    feedback_router,
     health_router,
     schema_router,
     search_router,
@@ -153,6 +154,7 @@ app.add_middleware(
 # Mount routers
 app.include_router(health_router, tags=["Health"])
 app.include_router(chat_router, tags=["Chat"])
+app.include_router(feedback_router, tags=["Feedback"])
 app.include_router(search_router, tags=["Search"])
 app.include_router(definitions_router, tags=["Definitions"])
 app.include_router(standards_router, tags=["Standards"])

--- a/backend/src/requirements_graphrag_api/core/retrieval.py
+++ b/backend/src/requirements_graphrag_api/core/retrieval.py
@@ -580,8 +580,15 @@ def _enrich_with_media(
                      alt_text: img.alt_text,
                      context: img.context
                  })[..$max_items] AS images,
-                 collect(DISTINCT {title: web.title, url: web.url})[..$max_items] AS webinars,
-                 collect(DISTINCT {title: vid.title, url: vid.url})[..$max_items] AS videos
+                 collect(DISTINCT {
+                     title: web.title,
+                     url: web.url,
+                     thumbnail_url: web.thumbnail_url
+                 })[..$max_items] AS webinars,
+                 collect(DISTINCT {
+                     title: vid.title,
+                     url: vid.url
+                 })[..$max_items] AS videos
             RETURN chunk_id, images, webinars, videos
             """,
             chunk_ids=chunk_ids,

--- a/backend/src/requirements_graphrag_api/prompts/definitions.py
+++ b/backend/src/requirements_graphrag_api/prompts/definitions.py
@@ -407,7 +407,7 @@ Key Node Types:
 - Entity: name, display_name (subtypes: Tool, Concept, Standard, Industry, Methodology)
 - Definition: term, definition, url, acronym
 - Standard: name, display_name, organization
-- Webinar: title, url
+- Webinar: title, url, thumbnail_url
 - Video: title, url
 - Image: url, alt_text, context
 

--- a/backend/src/requirements_graphrag_api/routes/__init__.py
+++ b/backend/src/requirements_graphrag_api/routes/__init__.py
@@ -7,12 +7,14 @@ This package contains all route handlers organized by domain:
 - standards: Industry standards queries
 - schema: Knowledge graph schema introspection
 - health: Health check endpoints
+- feedback: User feedback collection for LangSmith
 """
 
 from __future__ import annotations
 
 from requirements_graphrag_api.routes.chat import router as chat_router
 from requirements_graphrag_api.routes.definitions import router as definitions_router
+from requirements_graphrag_api.routes.feedback import router as feedback_router
 from requirements_graphrag_api.routes.health import router as health_router
 from requirements_graphrag_api.routes.schema import router as schema_router
 from requirements_graphrag_api.routes.search import router as search_router
@@ -21,6 +23,7 @@ from requirements_graphrag_api.routes.standards import router as standards_route
 __all__ = [
     "chat_router",
     "definitions_router",
+    "feedback_router",
     "health_router",
     "schema_router",
     "search_router",

--- a/backend/src/requirements_graphrag_api/routes/feedback.py
+++ b/backend/src/requirements_graphrag_api/routes/feedback.py
@@ -1,0 +1,177 @@
+"""User feedback endpoint for collecting response quality ratings.
+
+This endpoint allows the frontend to submit user feedback (thumbs up/down)
+which is then forwarded to LangSmith for tracking and analysis.
+
+Feedback is correlated with LangSmith runs via run_id, enabling:
+- Quality monitoring and dashboards
+- Annotation queue population for human review
+- Dataset generation for prompt optimization
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+from fastapi import APIRouter, HTTPException, Request
+from pydantic import BaseModel, Field
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter()
+
+
+class FeedbackRequest(BaseModel):
+    """Request body for feedback submission."""
+
+    run_id: str = Field(
+        ...,
+        min_length=1,
+        description="LangSmith run ID to associate feedback with",
+    )
+    score: float = Field(
+        ...,
+        ge=0.0,
+        le=1.0,
+        description="Feedback score: 0 for negative (thumbs down), 1 for positive (thumbs up)",
+    )
+    category: str | None = Field(
+        default=None,
+        description="Optional feedback category (e.g., 'incorrect', 'missing', 'irrelevant')",
+    )
+    correction: str | None = Field(
+        default=None,
+        description="Optional user-provided correction for the answer",
+    )
+    comment: str | None = Field(
+        default=None,
+        max_length=2000,
+        description="Optional additional comment",
+    )
+    message_id: str | None = Field(
+        default=None,
+        description="Optional frontend message ID for correlation",
+    )
+    conversation_id: str | None = Field(
+        default=None,
+        description="Optional conversation ID for context",
+    )
+
+
+class FeedbackResponse(BaseModel):
+    """Response body for feedback submission."""
+
+    status: str = Field(
+        default="received",
+        description="Status of feedback submission",
+    )
+    feedback_id: str | None = Field(
+        default=None,
+        description="LangSmith feedback ID if successfully created",
+    )
+
+
+@router.post("/feedback", response_model=FeedbackResponse)
+async def submit_feedback(
+    request: Request,
+    body: FeedbackRequest,
+) -> FeedbackResponse:
+    """Submit user feedback for a chat response.
+
+    Feedback is sent to LangSmith and associated with the original run.
+    This enables quality monitoring, annotation queues, and prompt optimization.
+
+    **Feedback Scores:**
+    - `1.0` = Thumbs up (positive/helpful)
+    - `0.0` = Thumbs down (negative/not helpful)
+
+    **Optional Fields:**
+    - `category`: Type of issue (for negative feedback)
+    - `correction`: User-provided correct answer
+    - `comment`: Additional context
+
+    Args:
+        request: FastAPI request object.
+        body: Feedback request body.
+
+    Returns:
+        FeedbackResponse with status and optional feedback ID.
+
+    Raises:
+        HTTPException: If LangSmith is not configured or feedback submission fails.
+    """
+    # Check if LangSmith is configured
+    api_key = os.getenv("LANGSMITH_API_KEY")
+    if not api_key:
+        logger.warning("Feedback received but LangSmith not configured - storing locally only")
+        # Still return success - we don't want to break the UX if tracing is disabled
+        return FeedbackResponse(status="received_local")
+
+    try:
+        from langsmith import Client
+
+        client = Client()
+
+        # Build feedback value dict with optional fields
+        value: dict = {}
+        if body.category:
+            value["category"] = body.category
+        if body.correction:
+            value["correction"] = body.correction
+        if body.message_id:
+            value["message_id"] = body.message_id
+        if body.conversation_id:
+            value["conversation_id"] = body.conversation_id
+
+        # Build comment string
+        comment = body.comment or ""
+        if body.category and not comment:
+            comment = f"Issue category: {body.category}"
+
+        # Create feedback in LangSmith
+        feedback = client.create_feedback(
+            run_id=body.run_id,
+            key="user-feedback",
+            score=body.score,
+            comment=comment if comment else None,
+            value=value if value else None,
+        )
+
+        feedback_id = str(feedback.id) if feedback else None
+
+        # Log for monitoring
+        feedback_type = "positive" if body.score >= 0.5 else "negative"
+        logger.info(
+            "User feedback submitted: run_id=%s, type=%s, category=%s",
+            body.run_id,
+            feedback_type,
+            body.category,
+        )
+
+        # If negative feedback, consider adding to annotation queue
+        # This is commented out for now - enable when annotation queue is set up
+        # if body.score < 0.5:
+        #     try:
+        #         client.add_runs_to_annotation_queue(
+        #             queue_name="user-reported-issues",
+        #             run_ids=[body.run_id],
+        #         )
+        #     except Exception as e:
+        #         logger.warning("Failed to add to annotation queue: %s", e)
+
+        return FeedbackResponse(status="received", feedback_id=feedback_id)
+
+    except ImportError:
+        logger.error("langsmith package not installed")
+        raise HTTPException(
+            status_code=500,
+            detail="Feedback system not available - langsmith not installed",
+        ) from None
+    except Exception:
+        logger.exception("Failed to submit feedback to LangSmith")
+        # Don't expose internal errors to the client
+        raise HTTPException(
+            status_code=500,
+            detail="Failed to submit feedback",
+        ) from None

--- a/backend/src/requirements_graphrag_api/routes/search.py
+++ b/backend/src/requirements_graphrag_api/routes/search.py
@@ -101,6 +101,7 @@ class WebinarContent(BaseModel):
 
     title: str | None = None
     url: str | None = None
+    thumbnail_url: str | None = None
 
 
 class VideoContent(BaseModel):

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,8 +5,8 @@ services:
   # GraphRAG REST API Backend
   backend:
     build:
-      context: ./backend
-      dockerfile: Dockerfile
+      context: .
+      dockerfile: backend/Dockerfile
       target: production
     container_name: requirements-graphrag-backend
     ports:

--- a/frontend/eslint.config.js
+++ b/frontend/eslint.config.js
@@ -23,7 +23,7 @@ export default defineConfig([
       },
     },
     rules: {
-      'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
+      'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]', argsIgnorePattern: '^[A-Z_]' }],
     },
   },
 ])

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,9 +8,11 @@
       "name": "frontend",
       "version": "0.0.0",
       "dependencies": {
+        "@tailwindcss/typography": "^0.5.19",
         "@tailwindcss/vite": "^4.1.18",
         "react": "^19.2.0",
-        "react-dom": "^19.2.0"
+        "react-dom": "^19.2.0",
+        "react-markdown": "^10.1.0"
       },
       "devDependencies": {
         "@eslint/js": "^9.39.1",
@@ -1554,6 +1556,18 @@
         "node": ">= 10"
       }
     },
+    "node_modules/@tailwindcss/typography": {
+      "version": "0.5.19",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/typography/-/typography-0.5.19.tgz",
+      "integrity": "sha512-w31dd8HOx3k9vPtcQh5QHP9GwKcgbMp87j58qi6xgiBnFFtKEAgCWnDw4qUT8aHwkCp8bKvb/KGKWWHedP0AAg==",
+      "license": "MIT",
+      "dependencies": {
+        "postcss-selector-parser": "6.0.10"
+      },
+      "peerDependencies": {
+        "tailwindcss": ">=3.0.0 || insiders || >=4.0.0-alpha.20 || >=4.0.0-beta.1"
+      }
+    },
     "node_modules/@tailwindcss/vite": {
       "version": "4.1.18",
       "resolved": "https://registry.npmjs.org/@tailwindcss/vite/-/vite-4.1.18.tgz",
@@ -1613,11 +1627,38 @@
         "@babel/types": "^7.28.2"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.12",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.12.tgz",
+      "integrity": "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
       "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
       "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
+      "integrity": "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
     },
     "node_modules/@types/json-schema": {
       "version": "7.0.15",
@@ -1626,11 +1667,25 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/react": {
       "version": "19.2.9",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.9.tgz",
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -1645,6 +1700,18 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.0.tgz",
+      "integrity": "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==",
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "5.1.2",
@@ -1767,6 +1834,16 @@
         "postcss": "^8.1.0"
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -1860,6 +1937,16 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -1875,6 +1962,46 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/color-convert": {
@@ -1896,6 +2023,16 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -1926,18 +2063,28 @@
         "node": ">= 8"
       }
     },
+    "node_modules/cssesc": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==",
+      "license": "MIT",
+      "bin": {
+        "cssesc": "bin/cssesc"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/debug": {
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -1951,12 +2098,34 @@
         }
       }
     },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
       "integrity": "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1965,6 +2134,19 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/electron-to-chromium": {
@@ -2225,6 +2407,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2234,6 +2426,12 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
@@ -2404,6 +2602,46 @@
         "node": ">=8"
       }
     },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/hermes-estree": {
       "version": "0.25.1",
       "resolved": "https://registry.npmjs.org/hermes-estree/-/hermes-estree-0.25.1.tgz",
@@ -2419,6 +2657,16 @@
       "license": "MIT",
       "dependencies": {
         "hermes-estree": "0.25.1"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/ignore": {
@@ -2458,6 +2706,46 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -2479,6 +2767,28 @@
       },
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/isexe": {
@@ -2860,6 +3170,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -2879,6 +3199,601 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.2.tgz",
+      "integrity": "sha512-uZhTV/8NBuw0WHkPTrCqDOl0zVe1BIng5ZtHoDk49ME1qqcjYmmLmOf0gELgcRMxN4w2iuIeVso5/6QymSrgmA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -2896,7 +3811,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/nanoid": {
@@ -2994,6 +3908,31 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3060,6 +3999,19 @@
         "node": "^10 || ^12 || >=14"
       }
     },
+    "node_modules/postcss-selector-parser": {
+      "version": "6.0.10",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.10.tgz",
+      "integrity": "sha512-IQ7TZdoaqbT+LCpShg46jnZVlhWD2w6iQYAcYXfHARZ7X1t/UGhhceQDs5X0cGqKvYlHNOuv7Oa1xmb0oQuA3w==",
+      "license": "MIT",
+      "dependencies": {
+        "cssesc": "^3.0.0",
+        "util-deprecate": "^1.0.2"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
     "node_modules/postcss-value-parser": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
@@ -3075,6 +4027,16 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.1.0.tgz",
+      "integrity": "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/punycode": {
@@ -3108,6 +4070,33 @@
         "react": "^19.2.3"
       }
     },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
     "node_modules/react-refresh": {
       "version": "0.18.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.18.0.tgz",
@@ -3116,6 +4105,39 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/resolve-from": {
@@ -3220,6 +4242,30 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -3231,6 +4277,24 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
       }
     },
     "node_modules/supports-color": {
@@ -3281,6 +4345,26 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3292,6 +4376,93 @@
       },
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/update-browserslist-db": {
@@ -3333,6 +4504,40 @@
       "license": "BSD-2-Clause",
       "dependencies": {
         "punycode": "^2.1.0"
+      }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/vite": {
@@ -3476,6 +4681,16 @@
       },
       "peerDependencies": {
         "zod": "^3.25.0 || ^4.0.0"
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -10,9 +10,11 @@
     "preview": "vite preview"
   },
   "dependencies": {
+    "@tailwindcss/typography": "^0.5.19",
     "@tailwindcss/vite": "^4.1.18",
     "react": "^19.2.0",
-    "react-dom": "^19.2.0"
+    "react-dom": "^19.2.0",
+    "react-markdown": "^10.1.0"
   },
   "devDependencies": {
     "@eslint/js": "^9.39.1",

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -1,176 +1,36 @@
-import { useState, useMemo } from 'react'
-
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
-
-// Generate a unique conversation ID (UUID v4)
-function generateConversationId() {
-  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function(c) {
-    const r = Math.random() * 16 | 0
-    const v = c === 'x' ? r : (r & 0x3 | 0x8)
-    return v.toString(16)
-  })
-}
+import { useSSEChat } from './hooks/useSSEChat'
+import { MessageList, ChatInput } from './components/chat'
 
 function App() {
-  const [messages, setMessages] = useState([])
-  const [input, setInput] = useState('')
-  const [isLoading, setIsLoading] = useState(false)
-
-  // Generate a stable conversation ID for this session
-  const conversationId = useMemo(() => generateConversationId(), [])
-
-  const sendMessage = async (e) => {
-    e.preventDefault()
-    if (!input.trim() || isLoading) return
-
-    const userMessage = { role: 'user', content: input }
-    setMessages(prev => [...prev, userMessage])
-    setInput('')
-    setIsLoading(true)
-
-    // Add placeholder for streaming response
-    setMessages(prev => [...prev, { role: 'assistant', content: '' }])
-
-    try {
-      // Build conversation history from completed messages (exclude empty placeholders)
-      const conversationHistory = messages
-        .filter(m => m.content && m.content.trim())
-        .map(m => ({ role: m.role, content: m.content }))
-
-      const response = await fetch(`${API_URL}/chat`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          message: input,
-          conversation_id: conversationId,
-          conversation_history: conversationHistory.length > 0 ? conversationHistory : null,
-        }),
-      })
-
-      if (!response.ok) throw new Error('Failed to get response')
-
-      // Handle SSE streaming response
-      const reader = response.body.getReader()
-      const decoder = new TextDecoder()
-      let buffer = ''
-
-      while (true) {
-        const { done, value } = await reader.read()
-        if (done) break
-
-        buffer += decoder.decode(value, { stream: true })
-        const lines = buffer.split('\n')
-        buffer = lines.pop() || ''
-
-        for (const line of lines) {
-          if (line.startsWith('data: ')) {
-            try {
-              const data = JSON.parse(line.slice(6))
-              if (data.token !== undefined) {
-                // Append token to the last message
-                setMessages(prev => {
-                  const updated = [...prev]
-                  const lastIdx = updated.length - 1
-                  updated[lastIdx] = {
-                    ...updated[lastIdx],
-                    content: updated[lastIdx].content + data.token
-                  }
-                  return updated
-                })
-              }
-            } catch {
-              // Skip malformed JSON
-            }
-          }
-        }
-      }
-    } catch (error) {
-      // Replace the placeholder with error message
-      setMessages(prev => {
-        const updated = [...prev]
-        const lastIdx = updated.length - 1
-        updated[lastIdx] = {
-          role: 'assistant',
-          content: 'Sorry, there was an error processing your request.'
-        }
-        return updated
-      })
-    } finally {
-      setIsLoading(false)
-    }
-  }
+  const { messages, isLoading, sendMessage } = useSSEChat()
 
   return (
     <div className="min-h-screen bg-gray-50 flex flex-col">
       {/* Header */}
-      <header className="bg-white border-b border-gray-200 px-6 py-4">
+      <header className="bg-white border-b border-gray-200 px-6 py-4 relative z-10">
         <h1 className="text-xl font-semibold text-gray-900">
           Requirements Management Assistant
         </h1>
         <p className="text-sm text-gray-500">
-          Ask questions about the Jama Essential Guide to Requirements Management
+          Ask questions about Jama Software's{' '}
+          <a
+            href="https://www.jamasoftware.com/requirements-management-guide"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-semibold italic text-jama-orange hover:text-jama-orange-dark hover:underline"
+          >
+            The Essential Guide to Requirements Management and Traceability
+          </a>
         </p>
       </header>
 
       {/* Messages */}
       <main className="flex-1 overflow-y-auto p-6 space-y-4">
-        {messages.length === 0 && (
-          <div className="text-center text-gray-400 mt-20">
-            <p className="text-lg">Welcome! Ask me anything about requirements management.</p>
-            <p className="text-sm mt-2">For example: &quot;What is requirements traceability?&quot;</p>
-          </div>
-        )}
-
-        {messages.map((message, index) => (
-          <div
-            key={index}
-            className={`flex ${message.role === 'user' ? 'justify-end' : 'justify-start'}`}
-          >
-            <div
-              className={`max-w-2xl px-4 py-3 rounded-lg ${
-                message.role === 'user'
-                  ? 'bg-blue-600 text-white'
-                  : 'bg-white border border-gray-200 text-gray-800'
-              }`}
-            >
-              <p className="whitespace-pre-wrap">{message.content}</p>
-            </div>
-          </div>
-        ))}
-
-        {isLoading && (
-          <div className="flex justify-start">
-            <div className="bg-white border border-gray-200 px-4 py-3 rounded-lg">
-              <div className="flex space-x-2">
-                <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" />
-                <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '0.1s' }} />
-                <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" style={{ animationDelay: '0.2s' }} />
-              </div>
-            </div>
-          </div>
-        )}
+        <MessageList messages={messages} />
       </main>
 
       {/* Input */}
-      <footer className="bg-white border-t border-gray-200 p-4">
-        <form onSubmit={sendMessage} className="max-w-4xl mx-auto flex gap-4">
-          <input
-            type="text"
-            value={input}
-            onChange={(e) => setInput(e.target.value)}
-            placeholder="Ask a question about requirements management..."
-            className="flex-1 px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-            disabled={isLoading}
-          />
-          <button
-            type="submit"
-            disabled={isLoading || !input.trim()}
-            className="px-6 py-3 bg-blue-600 text-white rounded-lg font-medium hover:bg-blue-700 disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-          >
-            Send
-          </button>
-        </form>
-      </footer>
+      <ChatInput onSend={sendMessage} disabled={isLoading} />
     </div>
   )
 }

--- a/frontend/src/components/chat/AssistantMessage.jsx
+++ b/frontend/src/components/chat/AssistantMessage.jsx
@@ -1,0 +1,153 @@
+import ReactMarkdown from 'react-markdown'
+import { SourceCitationRenderer } from './SourceCitationRenderer'
+import { QueryIntentBadge } from '../metadata/QueryIntentBadge'
+import { EntityBadges } from '../metadata/EntityBadges'
+import { SourcesPanel } from '../metadata/SourcesPanel'
+import { ResourceGallery } from '../metadata/ResourceGallery'
+import { WebinarsGallery } from '../metadata/WebinarsGallery'
+import { CypherDisplay } from '../metadata/CypherDisplay'
+import { ResultsTable } from '../metadata/ResultsTable'
+import { ResponseActions } from '../feedback'
+
+/**
+ * Assistant message component with rich metadata display
+ *
+ * Handles both explanatory (RAG) and structured (Cypher) response types
+ */
+export function AssistantMessage({ message }) {
+  const {
+    id,
+    content,
+    intent,
+    sources,
+    entities,
+    resources,
+    cypher,
+    results,
+    rowCount,
+    status,
+    error,
+    runId,
+  } = message
+
+  const isStructured = intent === 'structured'
+  const isExplanatory = intent === 'explanatory'
+  const hasContent = content && content.trim()
+  const hasSources = sources && sources.length > 0
+  const hasEntities = entities && entities.length > 0
+  const hasImages = resources?.images?.length > 0
+  const hasWebinars = resources?.webinars?.length > 0
+  const hasCypher = cypher && cypher.trim()
+  const hasResults = results && results.length > 0
+
+  return (
+    <div className="flex justify-start">
+      <div className="max-w-2xl w-full bg-white border border-gray-200 rounded-lg">
+        {/* Header with intent badge */}
+        {intent && (
+          <div className="flex justify-end px-4 pt-3">
+            <QueryIntentBadge intent={intent} />
+          </div>
+        )}
+
+        {/* Structured: Cypher query display */}
+        {isStructured && hasCypher && (
+          <div className="px-4 pt-3">
+            <CypherDisplay query={cypher} />
+          </div>
+        )}
+
+        {/* Structured: Results table */}
+        {isStructured && hasResults && (
+          <div className="px-4 pt-3">
+            <ResultsTable results={results} rowCount={rowCount} />
+          </div>
+        )}
+
+        {/* Explanatory: Main content with Markdown rendering and clickable citations */}
+        {isExplanatory && hasContent && (
+          <div className="px-4 pt-3">
+            <div className="prose prose-sm prose-gray max-w-none prose-p:my-2 prose-ul:my-2 prose-ol:my-2 prose-li:my-0.5 prose-headings:mt-4 prose-headings:mb-2">
+              {hasSources ? (
+                <SourceCitationRenderer content={content} sources={sources} />
+              ) : (
+                <ReactMarkdown>{content}</ReactMarkdown>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Fallback: Show content when no intent yet (streaming) */}
+        {!intent && hasContent && (
+          <div className="px-4 pt-3">
+            <div className="prose prose-sm prose-gray max-w-none prose-p:my-2 prose-ul:my-2 prose-ol:my-2 prose-li:my-0.5 prose-headings:mt-4 prose-headings:mb-2">
+              <ReactMarkdown>{content}</ReactMarkdown>
+            </div>
+          </div>
+        )}
+
+        {/* Streaming indicator */}
+        {status === 'streaming' && !hasContent && (
+          <div className="px-4 py-3">
+            <div className="flex space-x-2">
+              <div className="w-2 h-2 bg-gray-400 rounded-full animate-bounce" />
+              <div
+                className="w-2 h-2 bg-gray-400 rounded-full animate-bounce"
+                style={{ animationDelay: '0.1s' }}
+              />
+              <div
+                className="w-2 h-2 bg-gray-400 rounded-full animate-bounce"
+                style={{ animationDelay: '0.2s' }}
+              />
+            </div>
+          </div>
+        )}
+
+        {/* Error display */}
+        {status === 'error' && (
+          <div className="px-4 pt-3">
+            <p className="text-red-600">{error || 'An error occurred'}</p>
+          </div>
+        )}
+
+        {/* Sources panel */}
+        {hasSources && (
+          <div className="px-4 pt-3">
+            <SourcesPanel sources={sources} />
+          </div>
+        )}
+
+        {/* Terms (Entity badges) */}
+        {hasEntities && (
+          <div className="px-4 pt-3">
+            <EntityBadges entities={entities} />
+          </div>
+        )}
+
+        {/* Images gallery */}
+        {hasImages && (
+          <div className="px-4 pt-3">
+            <ResourceGallery resources={resources} />
+          </div>
+        )}
+
+        {/* Webinars gallery */}
+        {hasWebinars && (
+          <div className="px-4 pt-3">
+            <WebinarsGallery resources={resources} />
+          </div>
+        )}
+
+        {/* Response actions - show when complete */}
+        {status === 'complete' && (
+          <div className="px-4 pt-3">
+            <ResponseActions content={content} runId={runId} messageId={id} />
+          </div>
+        )}
+
+        {/* Bottom padding */}
+        <div className="h-3" />
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/chat/ChatInput.jsx
+++ b/frontend/src/components/chat/ChatInput.jsx
@@ -1,0 +1,37 @@
+import { useState } from 'react'
+
+/**
+ * Chat input form component
+ */
+export function ChatInput({ onSend, disabled }) {
+  const [input, setInput] = useState('')
+
+  const handleSubmit = (e) => {
+    e.preventDefault()
+    if (!input.trim() || disabled) return
+    onSend(input)
+    setInput('')
+  }
+
+  return (
+    <footer className="bg-white border-t border-gray-200 p-4">
+      <form onSubmit={handleSubmit} className="max-w-4xl mx-auto flex gap-4">
+        <input
+          type="text"
+          value={input}
+          onChange={(e) => setInput(e.target.value)}
+          placeholder="Ask a question about requirements management..."
+          className="flex-1 px-4 py-3 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent"
+          disabled={disabled}
+        />
+        <button
+          type="submit"
+          disabled={disabled || !input.trim()}
+          className="px-6 py-3 bg-jama-orange text-white rounded-lg font-medium hover:bg-jama-orange-dark disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
+        >
+          Send
+        </button>
+      </form>
+    </footer>
+  )
+}

--- a/frontend/src/components/chat/MessageList.jsx
+++ b/frontend/src/components/chat/MessageList.jsx
@@ -1,0 +1,50 @@
+import { AssistantMessage } from './AssistantMessage'
+
+/**
+ * User message component
+ * Uses Jama brand orange for the message bubble
+ */
+function UserMessage({ content }) {
+  return (
+    <div className="flex justify-end">
+      <div className="max-w-2xl px-4 py-3 rounded-lg bg-jama-orange text-white">
+        <p className="whitespace-pre-wrap">{content}</p>
+      </div>
+    </div>
+  )
+}
+
+/**
+ * Empty state component shown when no messages
+ */
+function EmptyState() {
+  return (
+    <div className="text-center text-gray-400 mt-20">
+      <p className="text-lg">Welcome! Ask me anything about requirements management.</p>
+      <p className="text-sm mt-2">For example: &quot;What is requirements traceability?&quot;</p>
+    </div>
+  )
+}
+
+/**
+ * Message list component that renders all messages
+ */
+export function MessageList({ messages }) {
+  if (messages.length === 0) {
+    return <EmptyState />
+  }
+
+  return (
+    <>
+      {messages.map((message) => (
+        <div key={message.id}>
+          {message.role === 'user' ? (
+            <UserMessage content={message.content} />
+          ) : (
+            <AssistantMessage message={message} />
+          )}
+        </div>
+      ))}
+    </>
+  )
+}

--- a/frontend/src/components/chat/SourceCitationRenderer.jsx
+++ b/frontend/src/components/chat/SourceCitationRenderer.jsx
@@ -1,0 +1,222 @@
+import { useState, useRef } from 'react'
+import ReactMarkdown from 'react-markdown'
+import { TooltipPortal, TooltipContent } from '../ui/Tooltip'
+
+/**
+ * Single source citation link with tooltip
+ *
+ * Displays as a styled link that shows source details on hover
+ * and opens the source URL on click.
+ */
+function SourceCitation({ sourceNumber, source }) {
+  const [showTooltip, setShowTooltip] = useState(false)
+  const linkRef = useRef(null)
+
+  if (!source) {
+    // Source not found, render as plain text
+    return <span className="text-gray-500">[Source {sourceNumber}]</span>
+  }
+
+  const { title, url, relevance_score } = source
+  const percentage = relevance_score ? Math.round(relevance_score * 100) : null
+
+  return (
+    <>
+      <a
+        ref={linkRef}
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="inline-flex items-center px-1.5 py-0.5 mx-0.5 rounded text-xs font-medium bg-emerald-50 text-emerald-700 border border-emerald-200 hover:bg-emerald-100 hover:border-emerald-300 transition-colors no-underline"
+        onMouseEnter={() => setShowTooltip(true)}
+        onMouseLeave={() => setShowTooltip(false)}
+      >
+        {sourceNumber}
+      </a>
+
+      <TooltipPortal targetRef={linkRef} show={showTooltip} position="top">
+        <TooltipContent
+          title={title || `Source ${sourceNumber}`}
+          description={
+            percentage
+              ? `${percentage}% relevance. Click to open source article.`
+              : 'Click to open source article.'
+          }
+          position="top"
+          color="emerald"
+        />
+      </TooltipPortal>
+    </>
+  )
+}
+
+/**
+ * Parse and render source citations within text
+ *
+ * Finds patterns like [Source 1], [Source 1, Source 4], [Sources 1-3]
+ * and replaces them with clickable SourceCitation components.
+ */
+function renderTextWithCitations(text, sources) {
+  if (!text || typeof text !== 'string') return text
+
+  // Pattern matches any bracketed content starting with "Source" or "Sources"
+  // Examples: [Source 1], [Source 1, Source 4], [Sources 1, 2, 3], [Source 1 and Source 2]
+  // Captures everything inside the brackets for further parsing
+  const citationPattern = /\[(Sources?[^\]]+)\]/gi
+
+  const parts = []
+  let lastIndex = 0
+  let match
+
+  // Reset lastIndex for global regex
+  citationPattern.lastIndex = 0
+
+  while ((match = citationPattern.exec(text)) !== null) {
+    // Add text before the citation
+    if (match.index > lastIndex) {
+      parts.push(text.slice(lastIndex, match.index))
+    }
+
+    // Parse the source numbers from the full matched content
+    const fullContent = match[1]
+    const sourceNumbers = extractSourceNumbers(fullContent)
+
+    // Create citation links
+    parts.push(
+      <span key={match.index} className="inline-flex items-center">
+        <span className="text-gray-500">[</span>
+        {sourceNumbers.map((num, idx) => (
+          <span key={num}>
+            {idx > 0 && <span className="text-gray-500">, </span>}
+            <SourceCitation
+              sourceNumber={num}
+              source={sources?.[num - 1]} // Convert 1-indexed to 0-indexed
+            />
+          </span>
+        ))}
+        <span className="text-gray-500">]</span>
+      </span>
+    )
+
+    lastIndex = match.index + match[0].length
+  }
+
+  // Add remaining text after last citation
+  if (lastIndex < text.length) {
+    parts.push(text.slice(lastIndex))
+  }
+
+  return parts.length > 0 ? parts : text
+}
+
+/**
+ * Extract source numbers from citation content
+ * Handles various formats:
+ * - "Source 1" → [1]
+ * - "Source 1, Source 4" → [1, 4]
+ * - "Sources 1, 2, 3" → [1, 2, 3]
+ * - "Source 1 and Source 2" → [1, 2]
+ * - "Sources 1-3" → [1, 2, 3]
+ */
+function extractSourceNumbers(str) {
+  const numbers = []
+
+  // First, check for ranges like "1-3" or "1–3" (en-dash)
+  const rangePattern = /(\d+)\s*[-–]\s*(\d+)/g
+  let rangeMatch
+  while ((rangeMatch = rangePattern.exec(str)) !== null) {
+    const start = parseInt(rangeMatch[1], 10)
+    const end = parseInt(rangeMatch[2], 10)
+    if (!isNaN(start) && !isNaN(end)) {
+      for (let i = start; i <= end; i++) {
+        numbers.push(i)
+      }
+    }
+  }
+
+  // Then extract all standalone numbers (not part of a range we already processed)
+  // Remove range patterns first to avoid double-counting
+  const strWithoutRanges = str.replace(/(\d+)\s*[-–]\s*(\d+)/g, '')
+  const numberPattern = /\d+/g
+  let numMatch
+  while ((numMatch = numberPattern.exec(strWithoutRanges)) !== null) {
+    const num = parseInt(numMatch[0], 10)
+    if (!isNaN(num)) {
+      numbers.push(num)
+    }
+  }
+
+  return [...new Set(numbers)].sort((a, b) => a - b) // Remove duplicates and sort
+}
+
+/**
+ * Custom text renderer for react-markdown that handles source citations
+ */
+function createTextRenderer(sources) {
+  return function TextRenderer({ children }) {
+    if (typeof children === 'string') {
+      return <>{renderTextWithCitations(children, sources)}</>
+    }
+    return <>{children}</>
+  }
+}
+
+/**
+ * Markdown renderer with clickable source citations
+ *
+ * Renders markdown content and transforms [Source N] references
+ * into styled, clickable links that show source details on hover.
+ *
+ * @param {string} content - Markdown content to render
+ * @param {Array} sources - Array of source objects with title, url, relevance_score
+ */
+export function SourceCitationRenderer({ content, sources }) {
+  const TextRenderer = createTextRenderer(sources)
+
+  return (
+    <ReactMarkdown
+      components={{
+        // Override text rendering to handle citations
+        p: ({ children }) => (
+          <p>
+            {processChildren(children, sources)}
+          </p>
+        ),
+        li: ({ children }) => (
+          <li>
+            {processChildren(children, sources)}
+          </li>
+        ),
+        // Keep other elements as-is but process their text content
+        strong: ({ children }) => (
+          <strong>{processChildren(children, sources)}</strong>
+        ),
+        em: ({ children }) => (
+          <em>{processChildren(children, sources)}</em>
+        ),
+      }}
+    >
+      {content}
+    </ReactMarkdown>
+  )
+}
+
+/**
+ * Recursively process children to find and transform text with citations
+ */
+function processChildren(children, sources) {
+  if (typeof children === 'string') {
+    return renderTextWithCitations(children, sources)
+  }
+
+  if (Array.isArray(children)) {
+    return children.map((child, index) => {
+      if (typeof child === 'string') {
+        return <span key={index}>{renderTextWithCitations(child, sources)}</span>
+      }
+      return child
+    })
+  }
+
+  return children
+}

--- a/frontend/src/components/chat/index.js
+++ b/frontend/src/components/chat/index.js
@@ -1,0 +1,3 @@
+export { ChatInput } from './ChatInput'
+export { MessageList } from './MessageList'
+export { AssistantMessage } from './AssistantMessage'

--- a/frontend/src/components/feedback/FeedbackBar.jsx
+++ b/frontend/src/components/feedback/FeedbackBar.jsx
@@ -1,0 +1,147 @@
+import { useState } from 'react'
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+
+/**
+ * Thumbs up icon
+ */
+function ThumbsUpIcon({ filled }) {
+  return (
+    <svg
+      className="w-4 h-4"
+      fill={filled ? 'currentColor' : 'none'}
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M14 10h4.764a2 2 0 011.789 2.894l-3.5 7A2 2 0 0115.263 21h-4.017c-.163 0-.326-.02-.485-.06L7 20m7-10V5a2 2 0 00-2-2h-.095c-.5 0-.905.405-.905.905 0 .714-.211 1.412-.608 2.006L7 11v9m7-10h-2M7 20H5a2 2 0 01-2-2v-6a2 2 0 012-2h2.5"
+      />
+    </svg>
+  )
+}
+
+/**
+ * Thumbs down icon
+ */
+function ThumbsDownIcon({ filled }) {
+  return (
+    <svg
+      className="w-4 h-4"
+      fill={filled ? 'currentColor' : 'none'}
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M10 14H5.236a2 2 0 01-1.789-2.894l3.5-7A2 2 0 018.736 3h4.018a2 2 0 01.485.06l3.76.94m-7 10v5a2 2 0 002 2h.096c.5 0 .905-.405.905-.904 0-.715.211-1.413.608-2.008L17 13V4m-7 10h2m5-10h2a2 2 0 012 2v6a2 2 0 01-2 2h-2.5"
+      />
+    </svg>
+  )
+}
+
+/**
+ * Feedback bar component with thumbs up/down
+ *
+ * Sends feedback to the backend which forwards to LangSmith
+ */
+export function FeedbackBar({ runId, messageId, disabled }) {
+  const [feedback, setFeedback] = useState(null) // 'positive' | 'negative' | null
+  const [isSubmitting, setIsSubmitting] = useState(false)
+  const [showThanks, setShowThanks] = useState(false)
+
+  const submitFeedback = async (score) => {
+    if (!runId || isSubmitting) return
+
+    const isPositive = score === 1
+    setFeedback(isPositive ? 'positive' : 'negative')
+    setIsSubmitting(true)
+
+    try {
+      const response = await fetch(`${API_URL}/feedback`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          run_id: runId,
+          score: score, // 1 for positive, 0 for negative
+          message_id: messageId,
+        }),
+      })
+
+      if (response.ok) {
+        setShowThanks(true)
+        setTimeout(() => setShowThanks(false), 3000)
+      }
+    } catch (error) {
+      console.error('Failed to submit feedback:', error)
+      // Keep the UI state even if submission fails
+    } finally {
+      setIsSubmitting(false)
+    }
+  }
+
+  const handleThumbsUp = () => {
+    if (feedback !== 'positive') {
+      submitFeedback(1)
+    }
+  }
+
+  const handleThumbsDown = () => {
+    if (feedback !== 'negative') {
+      submitFeedback(0)
+    }
+  }
+
+  // Don't render if no runId (can't correlate feedback)
+  if (!runId) return null
+
+  return (
+    <div className="flex items-center gap-2 pt-2 border-t border-gray-100">
+      {/* Feedback buttons */}
+      <div className="flex items-center gap-1">
+        <button
+          onClick={handleThumbsUp}
+          disabled={disabled || isSubmitting}
+          className={`p-1.5 rounded transition-colors ${
+            feedback === 'positive'
+              ? 'text-green-600 bg-green-50'
+              : 'text-gray-400 hover:text-green-600 hover:bg-green-50'
+          } disabled:opacity-50 disabled:cursor-not-allowed`}
+          title="Helpful"
+          aria-label="Mark as helpful"
+        >
+          <ThumbsUpIcon filled={feedback === 'positive'} />
+        </button>
+        <button
+          onClick={handleThumbsDown}
+          disabled={disabled || isSubmitting}
+          className={`p-1.5 rounded transition-colors ${
+            feedback === 'negative'
+              ? 'text-red-600 bg-red-50'
+              : 'text-gray-400 hover:text-red-600 hover:bg-red-50'
+          } disabled:opacity-50 disabled:cursor-not-allowed`}
+          title="Not helpful"
+          aria-label="Mark as not helpful"
+        >
+          <ThumbsDownIcon filled={feedback === 'negative'} />
+        </button>
+      </div>
+
+      {/* Thank you message */}
+      {showThanks && (
+        <span className="text-xs text-gray-500 animate-fade-in">
+          Thanks for your feedback!
+        </span>
+      )}
+
+      {/* Feedback label when not yet submitted */}
+      {!feedback && !showThanks && (
+        <span className="text-xs text-gray-400">Was this helpful?</span>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/feedback/FeedbackModal.jsx
+++ b/frontend/src/components/feedback/FeedbackModal.jsx
@@ -1,0 +1,80 @@
+import { useState } from 'react'
+
+/**
+ * Feedback modal for collecting optional details
+ */
+export function FeedbackModal({ isOpen, isPositive, onSubmit, onCancel }) {
+  const [details, setDetails] = useState('')
+
+  if (!isOpen) return null
+
+  const handleSubmit = () => {
+    onSubmit(details)
+    setDetails('')
+  }
+
+  const handleCancel = () => {
+    setDetails('')
+    onCancel()
+  }
+
+  const placeholder = isPositive
+    ? 'What was satisfying about this response?'
+    : 'What was unsatisfying about this response?'
+
+  return (
+    <div className="fixed inset-0 z-50 flex items-center justify-center">
+      {/* Backdrop */}
+      <div className="absolute inset-0 bg-black/30" onClick={handleCancel} />
+
+      {/* Modal */}
+      <div className="relative bg-white rounded-lg shadow-xl w-full max-w-md mx-4">
+        {/* Header */}
+        <div className="flex items-center justify-between px-6 py-4 border-b border-gray-200">
+          <h2 className="text-lg font-semibold text-gray-900">Feedback</h2>
+          <button
+            onClick={handleCancel}
+            className="text-gray-400 hover:text-gray-600 transition-colors"
+          >
+            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M6 18L18 6M6 6l12 12" />
+            </svg>
+          </button>
+        </div>
+
+        {/* Content */}
+        <div className="px-6 py-4">
+          <label className="block text-sm text-gray-600 mb-2">
+            Please provide details: (optional)
+          </label>
+          <textarea
+            value={details}
+            onChange={(e) => setDetails(e.target.value)}
+            placeholder={placeholder}
+            rows={4}
+            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-blue-500 focus:border-transparent resize-none"
+          />
+          <p className="mt-3 text-xs text-gray-500">
+            Submitting this feedback will help improve future responses.
+          </p>
+        </div>
+
+        {/* Footer */}
+        <div className="flex justify-end gap-3 px-6 py-4 border-t border-gray-100">
+          <button
+            onClick={handleCancel}
+            className="px-4 py-2 text-sm text-gray-600 hover:text-gray-800 transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            className="px-4 py-2 text-sm bg-gray-900 text-white rounded-md hover:bg-gray-800 transition-colors"
+          >
+            Submit
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/feedback/ResponseActions.jsx
+++ b/frontend/src/components/feedback/ResponseActions.jsx
@@ -1,0 +1,162 @@
+import { useState } from 'react'
+import { FeedbackModal } from './FeedbackModal'
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+
+// Copy icon (outline style like Claude Desktop)
+function CopyIcon() {
+  return (
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z" />
+    </svg>
+  )
+}
+
+// Thumbs up icon (outline style)
+function ThumbsUpIcon() {
+  return (
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M14 10h4.764a2 2 0 011.789 2.894l-3.5 7A2 2 0 0115.263 21h-4.017c-.163 0-.326-.02-.485-.06L7 20m7-10V5a2 2 0 00-2-2h-.095c-.5 0-.905.405-.905.905 0 .714-.211 1.412-.608 2.006L7 11v9m7-10h-2M7 20H5a2 2 0 01-2-2v-6a2 2 0 012-2h2.5" />
+    </svg>
+  )
+}
+
+// Thumbs down icon (outline style)
+function ThumbsDownIcon() {
+  return (
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={1.5} d="M10 14H5.236a2 2 0 01-1.789-2.894l3.5-7A2 2 0 018.736 3h4.018a2 2 0 01.485.06l3.76.94m-7 10v5a2 2 0 002 2h.096c.5 0 .905-.405.905-.904 0-.715.211-1.413.608-2.008L17 13V4m-7 10h2m5-10h2a2 2 0 012 2v6a2 2 0 01-2 2h-2.5" />
+    </svg>
+  )
+}
+
+/**
+ * Response action bar with Copy, Thumbs Up, Thumbs Down
+ * Styled similar to Claude Desktop
+ */
+export function ResponseActions({ content, runId, messageId }) {
+  const [copied, setCopied] = useState(false)
+  const [feedbackGiven, setFeedbackGiven] = useState(null) // 'positive' | 'negative' | null
+  const [modalOpen, setModalOpen] = useState(false)
+  const [pendingFeedback, setPendingFeedback] = useState(null) // 'positive' | 'negative'
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(content || '')
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Fallback
+      const textArea = document.createElement('textarea')
+      textArea.value = content || ''
+      document.body.appendChild(textArea)
+      textArea.select()
+      document.execCommand('copy')
+      document.body.removeChild(textArea)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
+  }
+
+  const handleThumbsUp = () => {
+    if (feedbackGiven) return
+    setPendingFeedback('positive')
+    setModalOpen(true)
+  }
+
+  const handleThumbsDown = () => {
+    if (feedbackGiven) return
+    setPendingFeedback('negative')
+    setModalOpen(true)
+  }
+
+  const submitFeedback = async (details) => {
+    setModalOpen(false)
+    const isPositive = pendingFeedback === 'positive'
+    setFeedbackGiven(pendingFeedback)
+
+    if (!runId) return
+
+    try {
+      await fetch(`${API_URL}/feedback`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          run_id: runId,
+          score: isPositive ? 1.0 : 0.0,
+          comment: details || null, // Goes to feedback_notes in LangSmith
+          message_id: messageId,
+          category: isPositive ? 'positive' : 'negative',
+        }),
+      })
+    } catch (error) {
+      console.error('Failed to submit feedback:', error)
+    }
+  }
+
+  const cancelFeedback = () => {
+    setModalOpen(false)
+    setPendingFeedback(null)
+  }
+
+  return (
+    <>
+      <div className="flex items-center gap-1 pt-2 border-t border-gray-100">
+        {/* Copy button */}
+        <button
+          onClick={handleCopy}
+          className="p-1.5 text-gray-400 hover:text-gray-600 rounded transition-colors"
+          title={copied ? 'Copied!' : 'Copy'}
+        >
+          {copied ? (
+            <svg className="w-4 h-4 text-green-500" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+            </svg>
+          ) : (
+            <CopyIcon />
+          )}
+        </button>
+
+        {/* Thumbs up */}
+        <button
+          onClick={handleThumbsUp}
+          disabled={feedbackGiven !== null}
+          className={`p-1.5 rounded transition-colors ${
+            feedbackGiven === 'positive'
+              ? 'text-green-600'
+              : feedbackGiven
+              ? 'text-gray-300 cursor-not-allowed'
+              : 'text-gray-400 hover:text-gray-600'
+          }`}
+          title="Good response"
+        >
+          <ThumbsUpIcon />
+        </button>
+
+        {/* Thumbs down */}
+        <button
+          onClick={handleThumbsDown}
+          disabled={feedbackGiven !== null}
+          className={`p-1.5 rounded transition-colors ${
+            feedbackGiven === 'negative'
+              ? 'text-red-600'
+              : feedbackGiven
+              ? 'text-gray-300 cursor-not-allowed'
+              : 'text-gray-400 hover:text-gray-600'
+          }`}
+          title="Bad response"
+        >
+          <ThumbsDownIcon />
+        </button>
+      </div>
+
+      {/* Feedback Modal */}
+      <FeedbackModal
+        isOpen={modalOpen}
+        isPositive={pendingFeedback === 'positive'}
+        onSubmit={submitFeedback}
+        onCancel={cancelFeedback}
+      />
+    </>
+  )
+}

--- a/frontend/src/components/feedback/index.js
+++ b/frontend/src/components/feedback/index.js
@@ -1,0 +1,3 @@
+export { FeedbackBar } from './FeedbackBar'
+export { FeedbackModal } from './FeedbackModal'
+export { ResponseActions } from './ResponseActions'

--- a/frontend/src/components/metadata/CypherDisplay.jsx
+++ b/frontend/src/components/metadata/CypherDisplay.jsx
@@ -1,0 +1,81 @@
+import { useState } from 'react'
+
+/**
+ * Copy icon component
+ */
+function CopyIcon() {
+  return (
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M8 16H6a2 2 0 01-2-2V6a2 2 0 012-2h8a2 2 0 012 2v2m-6 12h8a2 2 0 002-2v-8a2 2 0 00-2-2h-8a2 2 0 00-2 2v8a2 2 0 002 2z"
+      />
+    </svg>
+  )
+}
+
+/**
+ * Check icon for copied state
+ */
+function CheckIcon() {
+  return (
+    <svg className="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M5 13l4 4L19 7" />
+    </svg>
+  )
+}
+
+/**
+ * Cypher query display component
+ *
+ * Shows the Cypher query in a monospace code block with copy functionality
+ */
+export function CypherDisplay({ query }) {
+  const [copied, setCopied] = useState(false)
+
+  if (!query) return null
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(query)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    } catch {
+      // Fallback for older browsers
+      const textArea = document.createElement('textarea')
+      textArea.value = query
+      document.body.appendChild(textArea)
+      textArea.select()
+      document.execCommand('copy')
+      document.body.removeChild(textArea)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 2000)
+    }
+  }
+
+  return (
+    <div className="border border-gray-200 rounded-lg overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-2 bg-gray-50 border-b border-gray-200">
+        <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">Query</span>
+        <button
+          onClick={handleCopy}
+          className="flex items-center gap-1 text-xs text-gray-500 hover:text-gray-700 transition-colors"
+          title={copied ? 'Copied!' : 'Copy query'}
+        >
+          {copied ? <CheckIcon /> : <CopyIcon />}
+          <span>{copied ? 'Copied' : 'Copy'}</span>
+        </button>
+      </div>
+
+      {/* Query content */}
+      <div className="p-3 bg-gray-900 overflow-x-auto">
+        <pre className="text-sm text-green-400 font-mono whitespace-pre-wrap break-words">
+          {query}
+        </pre>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/metadata/EntityBadges.jsx
+++ b/frontend/src/components/metadata/EntityBadges.jsx
@@ -1,0 +1,234 @@
+import { useState, useRef } from 'react'
+import { Tooltip, TooltipPortal, TooltipContent } from '../ui/Tooltip'
+
+const MAX_VISIBLE = 8
+
+/**
+ * Info icon for tooltip trigger
+ */
+function InfoIcon() {
+  return (
+    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+    </svg>
+  )
+}
+
+/**
+ * Color configuration for Neo4j node labels
+ *
+ * Each node label gets distinct colors for visual differentiation.
+ * Colors are chosen to be accessible and semantically meaningful:
+ * - Purple: Concepts (abstract ideas)
+ * - Blue: Definitions (formal explanations)
+ * - Teal: Entities (general extracted terms)
+ * - Amber: Challenges (problems/issues)
+ * - Green: Best Practices (recommendations)
+ * - Slate: Fallback for unknown labels
+ */
+const LABEL_COLORS = {
+  Concept: {
+    bg: 'bg-purple-50',
+    text: 'text-purple-700',
+    border: 'border-purple-200',
+    hoverBg: 'hover:bg-purple-100',
+    hoverBorder: 'hover:border-purple-300',
+    indicator: 'text-purple-400',
+    tooltipColor: 'purple',
+  },
+  Definition: {
+    bg: 'bg-blue-50',
+    text: 'text-blue-700',
+    border: 'border-blue-200',
+    hoverBg: 'hover:bg-blue-100',
+    hoverBorder: 'hover:border-blue-300',
+    indicator: 'text-blue-400',
+    tooltipColor: 'blue',
+  },
+  Entity: {
+    bg: 'bg-teal-50',
+    text: 'text-teal-700',
+    border: 'border-teal-200',
+    hoverBg: 'hover:bg-teal-100',
+    hoverBorder: 'hover:border-teal-300',
+    indicator: 'text-teal-400',
+    tooltipColor: 'gray',
+  },
+  Challenge: {
+    bg: 'bg-amber-50',
+    text: 'text-amber-700',
+    border: 'border-amber-200',
+    hoverBg: 'hover:bg-amber-100',
+    hoverBorder: 'hover:border-amber-300',
+    indicator: 'text-amber-400',
+    tooltipColor: 'amber',
+  },
+  Bestpractice: {
+    bg: 'bg-green-50',
+    text: 'text-green-700',
+    border: 'border-green-200',
+    hoverBg: 'hover:bg-green-100',
+    hoverBorder: 'hover:border-green-300',
+    indicator: 'text-green-400',
+    tooltipColor: 'emerald',
+  },
+  Standard: {
+    bg: 'bg-indigo-50',
+    text: 'text-indigo-700',
+    border: 'border-indigo-200',
+    hoverBg: 'hover:bg-indigo-100',
+    hoverBorder: 'hover:border-indigo-300',
+    indicator: 'text-indigo-400',
+    tooltipColor: 'purple',
+  },
+  // Default fallback for unknown labels
+  default: {
+    bg: 'bg-slate-50',
+    text: 'text-slate-700',
+    border: 'border-slate-200',
+    hoverBg: 'hover:bg-slate-100',
+    hoverBorder: 'hover:border-slate-300',
+    indicator: 'text-slate-400',
+    tooltipColor: 'gray',
+  },
+}
+
+/**
+ * Get color configuration for a node label
+ */
+function getLabelColors(label) {
+  return LABEL_COLORS[label] || LABEL_COLORS.default
+}
+
+/**
+ * Single concept badge with optional definition popover
+ *
+ * Color-coded by Neo4j node label for visual distinction.
+ * Desktop: hover to show definition
+ * Mobile: tap to toggle definition
+ */
+function ConceptBadge({ entity }) {
+  const [showTooltip, setShowTooltip] = useState(false)
+  const buttonRef = useRef(null)
+
+  // Handle both string entities (legacy) and object entities {name, definition, label}
+  const name = typeof entity === 'string' ? entity : entity.name
+  const definition = typeof entity === 'string' ? null : entity.definition
+  const label = typeof entity === 'string' ? 'Entity' : (entity.label || 'Entity')
+
+  const colors = getLabelColors(label)
+
+  // No popover needed if no definition
+  if (!definition) {
+    return (
+      <span
+        className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium ${colors.bg} ${colors.text} border ${colors.border}`}
+        title={`${label} node`}
+      >
+        {name}
+      </span>
+    )
+  }
+
+  return (
+    <>
+      <button
+        ref={buttonRef}
+        type="button"
+        className={`inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium ${colors.bg} ${colors.text} border ${colors.border} ${colors.hoverBg} ${colors.hoverBorder} transition-colors cursor-help`}
+        onMouseEnter={() => setShowTooltip(true)}
+        onMouseLeave={() => setShowTooltip(false)}
+        onClick={() => setShowTooltip(!showTooltip)}
+        aria-describedby={showTooltip ? `tooltip-${name}` : undefined}
+        title={`${label} node - click for definition`}
+      >
+        {name}
+        {/* Small indicator that definition is available */}
+        <span className={`ml-1 ${colors.indicator} text-[10px]`}>?</span>
+      </button>
+
+      {/* Popover tooltip rendered via portal */}
+      <TooltipPortal targetRef={buttonRef} show={showTooltip}>
+        <TooltipContent
+          title={`${name} (${label})`}
+          description={definition}
+          position="top"
+          color={colors.tooltipColor}
+        />
+      </TooltipPortal>
+    </>
+  )
+}
+
+/**
+ * Concepts component displaying extracted knowledge graph concepts
+ *
+ * Shows "CONCEPTS" section header with up to MAX_VISIBLE entities
+ * and a "+N more" overflow indicator.
+ * Concepts are color-coded by their Neo4j node label.
+ * Terms with definitions show a popover on hover/tap.
+ */
+export function EntityBadges({ entities }) {
+  const [showAll, setShowAll] = useState(false)
+
+  if (!entities || entities.length === 0) return null
+
+  const visibleEntities = showAll ? entities : entities.slice(0, MAX_VISIBLE)
+  const hiddenCount = entities.length - MAX_VISIBLE
+  const hasOverflow = hiddenCount > 0 && !showAll
+
+  // Get name for key - handles both string and object entities
+  const getEntityKey = (entity, index) => {
+    const name = typeof entity === 'string' ? entity : entity.name
+    return `${name}-${index}`
+  }
+
+  return (
+    <div className="space-y-2">
+      {/* Section header */}
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs font-medium text-purple-600 uppercase tracking-wide">
+          Concepts
+        </span>
+        <Tooltip
+          title="Knowledge Graph Concepts"
+          description="Extracted concepts from the knowledge graph. Colors indicate node labels: purple for Concepts, blue for Definitions, teal for Entities. Items with a ? have definitions on hover."
+          color="purple"
+          position="top"
+        >
+          <span className="text-gray-400 hover:text-purple-600 transition-colors">
+            <InfoIcon />
+          </span>
+        </Tooltip>
+      </div>
+
+      {/* Entity badges */}
+      <div className="flex flex-wrap gap-2 items-center">
+        {visibleEntities.map((entity, index) => (
+          <ConceptBadge key={getEntityKey(entity, index)} entity={entity} />
+        ))}
+        {hasOverflow && (
+          <button
+            onClick={() => setShowAll(true)}
+            className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-gray-50 text-gray-500 hover:bg-gray-100 transition-colors"
+          >
+            +{hiddenCount} more
+          </button>
+        )}
+        {showAll && entities.length > MAX_VISIBLE && (
+          <button
+            onClick={() => setShowAll(false)}
+            className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-gray-50 text-gray-500 hover:bg-gray-100 transition-colors"
+          >
+            Show less
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/metadata/QueryIntentBadge.jsx
+++ b/frontend/src/components/metadata/QueryIntentBadge.jsx
@@ -1,0 +1,22 @@
+/**
+ * Badge component to display query intent type
+ *
+ * Shows "GraphRAG" for explanatory queries or "Cypher" for structured queries
+ */
+export function QueryIntentBadge({ intent }) {
+  if (!intent) return null
+
+  const isStructured = intent === 'structured'
+
+  return (
+    <span
+      className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
+        isStructured
+          ? 'bg-purple-100 text-purple-800'
+          : 'bg-blue-100 text-blue-800'
+      }`}
+    >
+      {isStructured ? 'Cypher' : 'GraphRAG'}
+    </span>
+  )
+}

--- a/frontend/src/components/metadata/ResourceGallery.jsx
+++ b/frontend/src/components/metadata/ResourceGallery.jsx
@@ -1,0 +1,150 @@
+import { useState, useRef } from 'react'
+import { Tooltip, TooltipPortal, TooltipContent } from '../ui/Tooltip'
+
+// Number of images to show in a single row (based on w-16 thumbnails in max-w-2xl container)
+const MAX_VISIBLE_ROW = 8
+
+/**
+ * Info icon for tooltip trigger
+ */
+function InfoIcon() {
+  return (
+    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+    </svg>
+  )
+}
+
+/**
+ * Image icon component (fallback)
+ */
+function ImageIcon() {
+  return (
+    <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={1.5}
+        d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
+      />
+    </svg>
+  )
+}
+
+/**
+ * Image thumbnail component with styled tooltip
+ */
+function ImageThumbnail({ image }) {
+  const [showTooltip, setShowTooltip] = useState(false)
+  const thumbnailRef = useRef(null)
+  const { url, title, alt, source_title } = image
+
+  const displayTitle = title || alt || 'Image'
+  const description = source_title ? `From: ${source_title}. Click to view full size.` : 'Click to view full size.'
+
+  return (
+    <>
+      <a
+        ref={thumbnailRef}
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="group relative block w-16 h-16 rounded-lg overflow-hidden bg-amber-50 border border-amber-200 hover:border-amber-400 transition-colors"
+        onMouseEnter={() => setShowTooltip(true)}
+        onMouseLeave={() => setShowTooltip(false)}
+      >
+        <img
+          src={url}
+          alt={alt || title || 'Resource image'}
+          className="w-full h-full object-cover"
+          onError={(e) => {
+            e.target.style.display = 'none'
+            e.target.nextSibling.style.display = 'flex'
+          }}
+        />
+        <div className="hidden w-full h-full items-center justify-center text-amber-400">
+          <ImageIcon />
+        </div>
+      </a>
+
+      <TooltipPortal targetRef={thumbnailRef} show={showTooltip} position="top">
+        <TooltipContent
+          title={displayTitle}
+          description={description}
+          position="top"
+          color="amber"
+        />
+      </TooltipPortal>
+    </>
+  )
+}
+
+/**
+ * Images gallery component
+ *
+ * Displays images as clickable thumbnails with "IMAGES" section header.
+ * Shows one row by default with "+N more" expand control.
+ */
+export function ResourceGallery({ resources }) {
+  const [showAll, setShowAll] = useState(false)
+
+  if (!resources) return null
+
+  const { images = [] } = resources
+  const hasImages = images.length > 0
+
+  if (!hasImages) return null
+
+  const visibleImages = showAll ? images : images.slice(0, MAX_VISIBLE_ROW)
+  const hiddenCount = images.length - MAX_VISIBLE_ROW
+  const hasOverflow = hiddenCount > 0 && !showAll
+
+  return (
+    <div className="space-y-2">
+      {/* Section header */}
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs font-medium text-amber-600 uppercase tracking-wide">
+          Images
+        </span>
+        <Tooltip
+          title="Visual Resources"
+          description="Diagrams and illustrations from the source articles. Click any image to view full size."
+          color="amber"
+          position="top"
+        >
+          <span className="text-gray-400 hover:text-amber-600 transition-colors">
+            <InfoIcon />
+          </span>
+        </Tooltip>
+      </div>
+
+      {/* Images row with expand control */}
+      <div className="flex flex-wrap gap-2 items-center">
+        {visibleImages.map((image, index) => (
+          <ImageThumbnail key={`img-${index}`} image={image} />
+        ))}
+        {hasOverflow && (
+          <button
+            onClick={() => setShowAll(true)}
+            className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-gray-50 text-gray-500 hover:bg-gray-100 transition-colors h-16"
+          >
+            +{hiddenCount} more
+          </button>
+        )}
+        {showAll && images.length > MAX_VISIBLE_ROW && (
+          <button
+            onClick={() => setShowAll(false)}
+            className="inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-gray-50 text-gray-500 hover:bg-gray-100 transition-colors"
+          >
+            Show less
+          </button>
+        )}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/metadata/ResultsTable.jsx
+++ b/frontend/src/components/metadata/ResultsTable.jsx
@@ -1,0 +1,106 @@
+const MAX_ROWS = 50
+
+/**
+ * Format a cell value for display
+ */
+function formatCellValue(value) {
+  if (value === null || value === undefined) {
+    return <span className="text-gray-400 italic">null</span>
+  }
+  if (typeof value === 'object') {
+    return JSON.stringify(value)
+  }
+  if (typeof value === 'boolean') {
+    return value ? 'true' : 'false'
+  }
+  // Check if it's a URL
+  if (typeof value === 'string' && (value.startsWith('http://') || value.startsWith('https://'))) {
+    return (
+      <a
+        href={value}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="text-blue-600 hover:underline truncate block max-w-xs"
+        title={value}
+      >
+        {value}
+      </a>
+    )
+  }
+  return String(value)
+}
+
+/**
+ * Results table component for structured query responses
+ *
+ * Displays query results in a clean data table format
+ * Limits display to MAX_ROWS with total count indicator
+ */
+export function ResultsTable({ results, rowCount }) {
+  if (!results || results.length === 0) {
+    return (
+      <div className="border border-gray-200 rounded-lg p-4 text-center text-gray-500 text-sm">
+        No results found
+      </div>
+    )
+  }
+
+  // Get column headers from first result
+  const columns = Object.keys(results[0])
+  const displayResults = results.slice(0, MAX_ROWS)
+  const totalRows = rowCount ?? results.length
+  const hasMore = totalRows > MAX_ROWS
+
+  return (
+    <div className="border border-gray-200 rounded-lg overflow-hidden">
+      {/* Header */}
+      <div className="flex items-center justify-between px-3 py-2 bg-gray-50 border-b border-gray-200">
+        <span className="text-xs font-medium text-gray-500 uppercase tracking-wide">
+          Results
+        </span>
+        <span className="text-xs text-gray-500">
+          {hasMore ? `Showing ${MAX_ROWS} of ${totalRows} rows` : `${totalRows} row${totalRows !== 1 ? 's' : ''}`}
+        </span>
+      </div>
+
+      {/* Table */}
+      <div className="overflow-x-auto">
+        <table className="min-w-full divide-y divide-gray-200">
+          <thead className="bg-gray-50">
+            <tr>
+              {columns.map((column) => (
+                <th
+                  key={column}
+                  className="px-3 py-2 text-left text-xs font-medium text-gray-500 uppercase tracking-wider"
+                >
+                  {column}
+                </th>
+              ))}
+            </tr>
+          </thead>
+          <tbody className="bg-white divide-y divide-gray-100">
+            {displayResults.map((row, rowIndex) => (
+              <tr key={rowIndex} className="hover:bg-gray-50">
+                {columns.map((column) => (
+                  <td
+                    key={`${rowIndex}-${column}`}
+                    className="px-3 py-2 text-sm text-gray-700 whitespace-nowrap"
+                  >
+                    {formatCellValue(row[column])}
+                  </td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+
+      {/* More rows indicator */}
+      {hasMore && (
+        <div className="px-3 py-2 bg-gray-50 border-t border-gray-200 text-center text-xs text-gray-500">
+          {totalRows - MAX_ROWS} more row{totalRows - MAX_ROWS !== 1 ? 's' : ''} not shown
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/metadata/SourcesPanel.jsx
+++ b/frontend/src/components/metadata/SourcesPanel.jsx
@@ -1,0 +1,141 @@
+import { useState } from 'react'
+import { Tooltip } from '../ui/Tooltip'
+
+/**
+ * Info icon for tooltip trigger
+ */
+function InfoIcon() {
+  return (
+    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+    </svg>
+  )
+}
+
+/**
+ * Chevron icon component
+ */
+function ChevronIcon({ isOpen }) {
+  return (
+    <svg
+      className={`w-4 h-4 transition-transform ${isOpen ? 'rotate-90' : ''}`}
+      fill="none"
+      stroke="currentColor"
+      viewBox="0 0 24 24"
+    >
+      <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 5l7 7-7 7" />
+    </svg>
+  )
+}
+
+/**
+ * External link icon
+ */
+function LinkIcon() {
+  return (
+    <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+      />
+    </svg>
+  )
+}
+
+/**
+ * Relevance indicator bar
+ */
+function RelevanceBar({ score }) {
+  if (score === undefined || score === null) return null
+
+  const percentage = Math.round(score * 100)
+
+  return (
+    <div className="flex items-center gap-2 text-xs text-gray-500">
+      <div className="w-16 h-1.5 bg-emerald-100 rounded-full overflow-hidden">
+        <div
+          className="h-full bg-emerald-500 rounded-full"
+          style={{ width: `${percentage}%` }}
+        />
+      </div>
+      <span>{percentage}%</span>
+    </div>
+  )
+}
+
+/**
+ * Single source item
+ */
+function SourceItem({ source }) {
+  const { title, url, relevance_score } = source
+
+  return (
+    <div className="flex items-start justify-between gap-2 py-2 border-b border-gray-100 last:border-b-0">
+      <div className="flex-1 min-w-0">
+        <p className="text-sm text-gray-700 truncate">{title || 'Untitled Source'}</p>
+        <RelevanceBar score={relevance_score} />
+      </div>
+      {url && (
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex-shrink-0 p-1 text-gray-400 hover:text-emerald-600 transition-colors"
+          title="Open source"
+        >
+          <LinkIcon />
+        </a>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Collapsible sources panel component
+ *
+ * Shows a summary header that expands to reveal full source list
+ */
+export function SourcesPanel({ sources }) {
+  const [isOpen, setIsOpen] = useState(false)
+
+  if (!sources || sources.length === 0) return null
+
+  return (
+    <div className="border border-emerald-200 rounded-lg overflow-hidden bg-emerald-50/30">
+      {/* Header - always visible */}
+      <button
+        onClick={() => setIsOpen(!isOpen)}
+        className="w-full flex items-center gap-2 px-3 py-2 text-sm text-emerald-700 hover:bg-emerald-50 transition-colors"
+      >
+        <ChevronIcon isOpen={isOpen} />
+        <span className="font-medium">Sources ({sources.length})</span>
+        <Tooltip
+          title="Article Sources"
+          description="Source articles used to generate this response. The bar and percentage indicate semantic relevance—how closely each source's content matches your question based on vector similarity."
+          color="emerald"
+          position="top"
+        >
+          <span className="text-gray-400 hover:text-emerald-600 transition-colors">
+            <InfoIcon />
+          </span>
+        </Tooltip>
+      </button>
+
+      {/* Expandable content */}
+      {isOpen && (
+        <div className="px-3 pb-2 border-t border-emerald-100 bg-white">
+          {sources.map((source, index) => (
+            <SourceItem key={`source-${index}`} source={source} />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/components/metadata/WebinarsGallery.jsx
+++ b/frontend/src/components/metadata/WebinarsGallery.jsx
@@ -1,0 +1,158 @@
+import { useState, useRef } from 'react'
+import { Tooltip, TooltipPortal, TooltipContent } from '../ui/Tooltip'
+
+/**
+ * Info icon for tooltip trigger
+ */
+function InfoIcon() {
+  return (
+    <svg className="w-3.5 h-3.5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M13 16h-1v-4h-1m1-4h.01M21 12a9 9 0 11-18 0 9 9 0 0118 0z"
+      />
+    </svg>
+  )
+}
+
+/**
+ * Play icon for webinar thumbnails
+ */
+function PlayIcon() {
+  return (
+    <svg className="w-6 h-6" fill="currentColor" viewBox="0 0 24 24">
+      <path d="M8 5v14l11-7z" />
+    </svg>
+  )
+}
+
+/**
+ * External link icon
+ */
+function ExternalLinkIcon() {
+  return (
+    <svg className="w-3 h-3" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+      <path
+        strokeLinecap="round"
+        strokeLinejoin="round"
+        strokeWidth={2}
+        d="M10 6H6a2 2 0 00-2 2v10a2 2 0 002 2h10a2 2 0 002-2v-4M14 4h6m0 0v6m0-6L10 14"
+      />
+    </svg>
+  )
+}
+
+/**
+ * Webinar thumbnail card component with styled tooltip
+ * Uses thumbnail_url from Neo4j, with icon placeholder fallback
+ */
+function WebinarThumbnail({ webinar }) {
+  const [showTooltip, setShowTooltip] = useState(false)
+  const thumbnailRef = useRef(null)
+  const { url, title, thumbnail_url } = webinar
+
+  const displayTitle = title || 'Webinar'
+  const description = 'Click to watch this webinar from Jama Software.'
+
+  return (
+    <>
+      <a
+        ref={thumbnailRef}
+        href={url}
+        target="_blank"
+        rel="noopener noreferrer"
+        className="group relative block w-24 h-16 rounded-lg overflow-hidden bg-gradient-to-br from-rose-50 to-rose-100 border border-rose-200 hover:border-rose-400 transition-colors"
+        onMouseEnter={() => setShowTooltip(true)}
+        onMouseLeave={() => setShowTooltip(false)}
+      >
+        {thumbnail_url ? (
+          <>
+            <img
+              src={thumbnail_url}
+              alt={title || 'Webinar thumbnail'}
+              className="w-full h-full object-cover"
+              onError={(e) => {
+                e.target.style.display = 'none'
+                e.target.nextSibling.style.display = 'flex'
+              }}
+            />
+            {/* Fallback placeholder on image load error */}
+            <div className="hidden w-full h-full items-center justify-center bg-gradient-to-br from-rose-50 to-rose-100 text-rose-400">
+              <PlayIcon />
+            </div>
+          </>
+        ) : (
+          /* Icon placeholder when no thumbnail available */
+          <div className="w-full h-full flex items-center justify-center bg-gradient-to-br from-rose-50 to-rose-100 text-rose-400">
+            <PlayIcon />
+          </div>
+        )}
+
+        {/* Play overlay on hover */}
+        <div className="absolute inset-0 flex items-center justify-center bg-black/0 group-hover:bg-black/30 transition-colors">
+          <div className="opacity-0 group-hover:opacity-100 text-white transition-opacity">
+            <PlayIcon />
+          </div>
+        </div>
+
+        {/* External link indicator */}
+        <div className="absolute top-1 right-1 opacity-0 group-hover:opacity-100 text-white transition-opacity">
+          <ExternalLinkIcon />
+        </div>
+      </a>
+
+      <TooltipPortal targetRef={thumbnailRef} show={showTooltip} position="top">
+        <TooltipContent
+          title={displayTitle}
+          description={description}
+          position="top"
+          color="rose"
+        />
+      </TooltipPortal>
+    </>
+  )
+}
+
+/**
+ * Webinars gallery component
+ *
+ * Displays webinars as thumbnail cards with "WEBINARS" section header
+ */
+export function WebinarsGallery({ resources }) {
+  if (!resources) return null
+
+  const { webinars = [] } = resources
+  const hasWebinars = webinars.length > 0
+
+  if (!hasWebinars) return null
+
+  return (
+    <div className="space-y-2">
+      {/* Section header */}
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs font-medium text-rose-600 uppercase tracking-wide">
+          Webinars
+        </span>
+        <Tooltip
+          title="Video Content"
+          description="Related video content from Jama Software. Click any thumbnail to watch the webinar."
+          color="rose"
+          position="top"
+        >
+          <span className="text-gray-400 hover:text-rose-600 transition-colors">
+            <InfoIcon />
+          </span>
+        </Tooltip>
+      </div>
+
+      {/* Webinars row */}
+      <div className="flex flex-wrap gap-2">
+        {webinars.map((webinar, index) => (
+          <WebinarThumbnail key={`webinar-${index}`} webinar={webinar} />
+        ))}
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/components/metadata/index.js
+++ b/frontend/src/components/metadata/index.js
@@ -1,0 +1,7 @@
+export { QueryIntentBadge } from './QueryIntentBadge'
+export { EntityBadges } from './EntityBadges'
+export { SourcesPanel } from './SourcesPanel'
+export { CypherDisplay } from './CypherDisplay'
+export { ResultsTable } from './ResultsTable'
+export { ResourceGallery } from './ResourceGallery'
+export { WebinarsGallery } from './WebinarsGallery'

--- a/frontend/src/components/ui/Tooltip.jsx
+++ b/frontend/src/components/ui/Tooltip.jsx
@@ -1,0 +1,187 @@
+import React, { useState, useRef, useEffect } from 'react'
+import { createPortal } from 'react-dom'
+
+/**
+ * Tooltip portal component that renders outside the DOM hierarchy
+ * to avoid clipping by overflow-hidden containers.
+ *
+ * Uses fixed positioning calculated from getBoundingClientRect().
+ * Automatically adjusts position to stay within viewport bounds.
+ */
+function TooltipPortal({ children, targetRef, show, position = 'top' }) {
+  const [coords, setCoords] = useState({ top: 0, left: 0 })
+  const [actualPosition, setActualPosition] = useState(position)
+  const tooltipRef = useRef(null)
+
+  useEffect(() => {
+    if (show && targetRef.current) {
+      const rect = targetRef.current.getBoundingClientRect()
+      const tooltipWidth = 256 // w-64 = 16rem = 256px
+      const tooltipHeight = 80 // Approximate height
+      const padding = 16 // Minimum distance from viewport edge
+
+      // Calculate horizontal position, keeping within viewport
+      let left = rect.left + rect.width / 2
+      const minLeft = tooltipWidth / 2 + padding
+      const maxLeft = window.innerWidth - tooltipWidth / 2 - padding
+      left = Math.max(minLeft, Math.min(maxLeft, left))
+
+      // Determine vertical position based on available space
+      let finalPosition = position
+      let top
+
+      if (position === 'top') {
+        // Check if there's enough space above
+        if (rect.top < tooltipHeight + padding) {
+          // Not enough space above, flip to bottom
+          finalPosition = 'bottom'
+          top = rect.bottom + 8
+        } else {
+          top = rect.top - 8
+        }
+      } else {
+        // Check if there's enough space below
+        if (rect.bottom + tooltipHeight + padding > window.innerHeight) {
+          // Not enough space below, flip to top
+          finalPosition = 'top'
+          top = rect.top - 8
+        } else {
+          top = rect.bottom + 8
+        }
+      }
+
+      setCoords({ top, left })
+      setActualPosition(finalPosition)
+    }
+  }, [show, targetRef, position])
+
+  if (!show) return null
+
+  const transformClass =
+    actualPosition === 'top'
+      ? '-translate-x-1/2 -translate-y-full'
+      : '-translate-x-1/2'
+
+  return createPortal(
+    <div
+      ref={tooltipRef}
+      className={`fixed z-[9999] ${transformClass} pointer-events-none`}
+      style={{ top: coords.top, left: coords.left }}
+    >
+      {React.cloneElement(children, { position: actualPosition })}
+    </div>,
+    document.body
+  )
+}
+
+/**
+ * Styled tooltip content with dark background and arrow
+ */
+function TooltipContent({ title, description, position = 'top', color = 'gray' }) {
+  // Color variants for the tooltip background
+  // Aligned with Neo4j node label color scheme
+  const colorStyles = {
+    gray: 'bg-gray-900',
+    blue: 'bg-blue-900',
+    emerald: 'bg-emerald-900',
+    amber: 'bg-amber-900',
+    rose: 'bg-rose-900',
+    purple: 'bg-purple-900',
+    teal: 'bg-teal-900',
+    indigo: 'bg-indigo-900',
+    green: 'bg-green-900',
+  }
+
+  const arrowColors = {
+    gray: 'border-t-gray-900',
+    blue: 'border-t-blue-900',
+    emerald: 'border-t-emerald-900',
+    amber: 'border-t-amber-900',
+    rose: 'border-t-rose-900',
+    purple: 'border-t-purple-900',
+    teal: 'border-t-teal-900',
+    indigo: 'border-t-indigo-900',
+    green: 'border-t-green-900',
+  }
+
+  const arrowColorsBottom = {
+    gray: 'border-b-gray-900',
+    blue: 'border-b-blue-900',
+    emerald: 'border-b-emerald-900',
+    amber: 'border-b-amber-900',
+    rose: 'border-b-rose-900',
+    purple: 'border-b-purple-900',
+    teal: 'border-b-teal-900',
+    indigo: 'border-b-indigo-900',
+    green: 'border-b-green-900',
+  }
+
+  const bgClass = colorStyles[color] || colorStyles.gray
+  const arrowClass = position === 'top'
+    ? (arrowColors[color] || arrowColors.gray)
+    : (arrowColorsBottom[color] || arrowColorsBottom.gray)
+
+  return (
+    <div role="tooltip" className="w-64 max-w-xs">
+      {/* Arrow pointing up (for bottom position) */}
+      {position === 'bottom' && (
+        <div className="flex justify-center">
+          <div className={`w-0 h-0 border-l-[6px] border-l-transparent border-r-[6px] border-r-transparent border-b-[6px] ${arrowClass.replace('border-t-', 'border-b-')}`} />
+        </div>
+      )}
+
+      <div className={`${bgClass} text-white text-xs rounded-lg px-3 py-2 shadow-lg`}>
+        {title && <p className="font-medium mb-1">{title}</p>}
+        <p className="text-gray-300 leading-relaxed">{description}</p>
+      </div>
+
+      {/* Arrow pointing down (for top position) */}
+      {position === 'top' && (
+        <div className="flex justify-center">
+          <div className={`w-0 h-0 border-l-[6px] border-l-transparent border-r-[6px] border-r-transparent border-t-[6px] ${arrowClass}`} />
+        </div>
+      )}
+    </div>
+  )
+}
+
+/**
+ * Tooltip trigger wrapper component
+ *
+ * Wraps any element and shows a styled tooltip on hover/focus.
+ *
+ * @param {string} title - Bold header text (optional)
+ * @param {string} description - Tooltip body text
+ * @param {string} position - 'top' or 'bottom'
+ * @param {string} color - Color theme: 'gray', 'blue', 'emerald', 'amber', 'rose', 'purple'
+ * @param {ReactNode} children - The trigger element
+ */
+export function Tooltip({ title, description, position = 'top', color = 'gray', children }) {
+  const [show, setShow] = useState(false)
+  const triggerRef = useRef(null)
+
+  return (
+    <>
+      <span
+        ref={triggerRef}
+        onMouseEnter={() => setShow(true)}
+        onMouseLeave={() => setShow(false)}
+        onClick={() => setShow(!show)}
+        className="cursor-help"
+      >
+        {children}
+      </span>
+
+      <TooltipPortal targetRef={triggerRef} show={show} position={position}>
+        <TooltipContent
+          title={title}
+          description={description}
+          position={position}
+          color={color}
+        />
+      </TooltipPortal>
+    </>
+  )
+}
+
+export { TooltipPortal, TooltipContent }

--- a/frontend/src/hooks/useSSEChat.js
+++ b/frontend/src/hooks/useSSEChat.js
@@ -1,0 +1,266 @@
+import { useState, useMemo, useCallback } from 'react'
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+
+/**
+ * Generate a unique conversation ID (UUID v4)
+ */
+function generateConversationId() {
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    const r = (Math.random() * 16) | 0
+    const v = c === 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
+}
+
+/**
+ * Generate a unique message ID
+ */
+function generateMessageId() {
+  return `msg-${Date.now()}-${Math.random().toString(36).slice(2, 9)}`
+}
+
+/**
+ * Create an initial assistant message placeholder
+ */
+function createAssistantMessage() {
+  return {
+    id: generateMessageId(),
+    role: 'assistant',
+    content: '',
+    intent: null,
+    // Explanatory metadata
+    sources: [],
+    entities: [],
+    resources: { images: [], webinars: [], videos: [] },
+    // Structured metadata
+    cypher: null,
+    results: null,
+    rowCount: null,
+    // Status
+    status: 'streaming',
+    error: null,
+    // LangSmith correlation for feedback
+    runId: null,
+  }
+}
+
+/**
+ * Custom hook for SSE chat functionality with enhanced metadata support
+ *
+ * Handles SSE events: routing, sources, token, cypher, results, done, error
+ */
+export function useSSEChat() {
+  const [messages, setMessages] = useState([])
+  const [isLoading, setIsLoading] = useState(false)
+
+  // Generate a stable conversation ID for this session
+  const conversationId = useMemo(() => generateConversationId(), [])
+
+  /**
+   * Update the last assistant message with new data
+   */
+  const updateLastMessage = useCallback((updater) => {
+    setMessages((prev) => {
+      const updated = [...prev]
+      const lastIdx = updated.length - 1
+      if (lastIdx >= 0 && updated[lastIdx].role === 'assistant') {
+        updated[lastIdx] =
+          typeof updater === 'function'
+            ? updater(updated[lastIdx])
+            : { ...updated[lastIdx], ...updater }
+      }
+      return updated
+    })
+  }, [])
+
+  /**
+   * Process an SSE event and update message state
+   */
+  const processEvent = useCallback(
+    (eventType, data) => {
+      switch (eventType) {
+        case 'routing':
+          // Set the query intent (explanatory or structured)
+          updateLastMessage({ intent: data.intent })
+          break
+
+        case 'sources':
+          // Update sources, entities, and resources
+          updateLastMessage({
+            sources: data.sources || [],
+            entities: data.entities || [],
+            resources: data.resources || { images: [], webinars: [], videos: [] },
+          })
+          break
+
+        case 'token':
+          // Append token to content
+          updateLastMessage((msg) => ({
+            ...msg,
+            content: msg.content + (data.token || ''),
+          }))
+          break
+
+        case 'cypher':
+          // Set the Cypher query for structured responses
+          updateLastMessage({ cypher: data.query })
+          break
+
+        case 'results':
+          // Set the results for structured responses
+          updateLastMessage({
+            results: data.results || [],
+            rowCount: data.row_count,
+          })
+          break
+
+        case 'done':
+          // Mark as complete, use full answer if provided, capture run_id for feedback
+          updateLastMessage((msg) => ({
+            ...msg,
+            content: data.full_answer || msg.content,
+            status: 'complete',
+            rowCount: data.row_count ?? msg.rowCount,
+            runId: data.run_id || null,
+          }))
+          break
+
+        case 'error':
+          // Set error state
+          updateLastMessage({
+            status: 'error',
+            error: data.error || 'An unknown error occurred',
+          })
+          break
+
+        default:
+          // Ignore unknown event types
+          break
+      }
+    },
+    [updateLastMessage]
+  )
+
+  /**
+   * Parse SSE line to extract event type and data
+   */
+  const parseSSELine = useCallback((line) => {
+    if (!line.startsWith('data: ')) return null
+
+    try {
+      const data = JSON.parse(line.slice(6))
+
+      // Determine event type from data shape
+      if (data.intent !== undefined) return { type: 'routing', data }
+      if (data.sources !== undefined) return { type: 'sources', data }
+      if (data.token !== undefined) return { type: 'token', data }
+      if (data.query !== undefined && data.results === undefined) return { type: 'cypher', data }
+      if (data.results !== undefined) return { type: 'results', data }
+      if (data.full_answer !== undefined || (data.row_count !== undefined && data.query !== undefined))
+        return { type: 'done', data }
+      if (data.error !== undefined) return { type: 'error', data }
+
+      return null
+    } catch {
+      return null
+    }
+  }, [])
+
+  /**
+   * Send a message and handle SSE response
+   */
+  const sendMessage = useCallback(
+    async (input) => {
+      if (!input.trim() || isLoading) return
+
+      const userMessage = { id: generateMessageId(), role: 'user', content: input }
+      setMessages((prev) => [...prev, userMessage])
+      setIsLoading(true)
+
+      // Add placeholder for streaming response
+      const assistantMessage = createAssistantMessage()
+      setMessages((prev) => [...prev, assistantMessage])
+
+      try {
+        // Build conversation history from completed messages
+        const conversationHistory = messages
+          .filter((m) => m.content && m.content.trim() && m.status !== 'streaming')
+          .map((m) => ({ role: m.role, content: m.content }))
+
+        const response = await fetch(`${API_URL}/chat`, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            message: input,
+            conversation_id: conversationId,
+            conversation_history: conversationHistory.length > 0 ? conversationHistory : null,
+          }),
+        })
+
+        if (!response.ok) {
+          throw new Error(`HTTP error: ${response.status}`)
+        }
+
+        // Handle SSE streaming response
+        const reader = response.body.getReader()
+        const decoder = new TextDecoder()
+        let buffer = ''
+
+        while (true) {
+          const { done, value } = await reader.read()
+          if (done) break
+
+          buffer += decoder.decode(value, { stream: true })
+          const lines = buffer.split('\n')
+          buffer = lines.pop() || ''
+
+          for (const line of lines) {
+            const event = parseSSELine(line)
+            if (event) {
+              processEvent(event.type, event.data)
+            }
+          }
+        }
+
+        // Process any remaining buffer
+        if (buffer.trim()) {
+          const event = parseSSELine(buffer)
+          if (event) {
+            processEvent(event.type, event.data)
+          }
+        }
+
+        // Ensure message is marked as complete
+        updateLastMessage((msg) => ({
+          ...msg,
+          status: msg.status === 'streaming' ? 'complete' : msg.status,
+        }))
+      } catch (error) {
+        updateLastMessage({
+          status: 'error',
+          error: error.message || 'Failed to get response',
+          content: 'Sorry, there was an error processing your request.',
+        })
+      } finally {
+        setIsLoading(false)
+      }
+    },
+    [messages, isLoading, conversationId, parseSSELine, processEvent, updateLastMessage]
+  )
+
+  /**
+   * Clear all messages
+   */
+  const clearMessages = useCallback(() => {
+    setMessages([])
+  }, [])
+
+  return {
+    messages,
+    isLoading,
+    conversationId,
+    sendMessage,
+    clearMessages,
+  }
+}

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,3 +1,32 @@
 @import "tailwindcss";
+@plugin "@tailwindcss/typography";
+
+/* Jama Software brand colors */
+@theme {
+  --color-jama-orange: #f78f2c;
+  --color-jama-orange-dark: #d6522b;
+  --color-jama-orange-light: #fef3e7;
+}
 
 /* Custom styles can be added below */
+
+/* Ensure Jama orange links maintain color after being visited */
+a.text-jama-orange:visited {
+  color: var(--color-jama-orange);
+}
+
+/* Fade-in animation for feedback thank you message */
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-4px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-in {
+  animation: fade-in 0.2s ease-out;
+}


### PR DESCRIPTION
## Summary

Implements Issue #46 - Complete frontend overhaul to display rich contextual data from SSE events.

## Changes

### Frontend Architecture
- Componentized structure with `/components/chat`, `/metadata`, `/feedback`, `/ui`
- Custom `useSSEChat` hook for SSE event handling
- React Portal-based tooltips to avoid overflow clipping

### New Features
- **Sources panel**: Collapsible list with emerald relevance indicators
- **Concepts section**: Node label color-coding (purple=Concept, blue=Definition, teal=Entity)
- **Images gallery**: Expandable rows with amber-themed styled tooltips
- **Webinars gallery**: Rose-themed thumbnails from Neo4j `thumbnail_url`
- **Clickable citations**: `[Source 1, Source 2]` become linked badges
- **Intent badges**: GraphRAG/Cypher indicators
- **Results table**: Structured query results (50 row limit)
- **Feedback system**: Thumbs up/down with modal for detailed feedback

### UI Enhancements
- Jama Software brand orange (`#f78f2c`) via CSS variables
- Markdown rendering with `@tailwindcss/typography`
- Consistent dark tooltip styling with viewport-aware positioning
- Persistent link colors (no visited state change)

### Backend Changes
- Node labels added to entity extraction for color-coding
- `thumbnail_url` field added to webinar data flow
- `/feedback` endpoint for user ratings

## Test Plan

- [x] Ask explanatory question → verify sources, concepts, images, webinars display
- [x] Ask structured question → verify Cypher query and results table
- [x] Hover over section headers → verify styled tooltips appear correctly
- [x] Hover over concept badges → verify definition tooltips with node labels
- [x] Click source citations in response → verify links open correct articles
- [x] Test feedback buttons (copy, thumbs up/down)
- [x] Verify Jama orange branding on user messages and Send button

Closes #46

🤖 Generated with [Claude Code](https://claude.com/claude-code)