### PR TITLE
fix: filter webinar thumbnails from IMAGES gallery

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -54,6 +54,9 @@ htmlcov/
 # ruff
 .ruff_cache/
 
+# Playwright MCP
+.playwright-mcp/
+
 # OS
 .DS_Store
 Thumbs.db

--- a/backend/src/requirements_graphrag_api/core/generation.py
+++ b/backend/src/requirements_graphrag_api/core/generation.py
@@ -261,6 +261,14 @@ def _build_context_from_results(
     all_webinars: list[Resource] = []
     all_videos: list[Resource] = []
 
+    # Pre-collect webinar thumbnail URLs to exclude from images (Issue #54)
+    webinar_thumbnail_urls: set[str] = set()
+    for r in search_results:
+        for w in r.get("media", {}).get("webinars", []):
+            thumb = w.get("thumbnail_url")
+            if thumb:
+                webinar_thumbnail_urls.add(thumb)
+
     # Add definitions to context first (if any found)
     if definitions:
         for defn in definitions:
@@ -345,7 +353,7 @@ def _build_context_from_results(
             source_image_count = 0
             for img in media.get("images", []):
                 img_url = img.get("url")
-                if not img_url or img_url in seen_urls:
+                if not img_url or img_url in seen_urls or img_url in webinar_thumbnail_urls:
                     continue
                 if source_image_count >= max_resources_per_type:
                     break


### PR DESCRIPTION
## Summary

Closes #54

- Add a pre-pass in `_build_context_from_results()` to collect all webinar `thumbnail_url` values into a set before the main extraction loop
- Exclude matching URLs during image extraction, preventing webinar thumbnails from appearing in both the IMAGES and WEBINARS galleries
- Add `.playwright-mcp/` to `.gitignore`

## How it works

Webinar thumbnail images (YouTube/Vimeo preview images) were appearing in both galleries because some `Image` nodes in Neo4j have URLs that match a `Webinar` node's `thumbnail_url`. The fix uses actual data cross-referencing (not brittle URL pattern matching) and handles cross-article cases where the webinar and matching image come from different search results.

## Test plan

- [x] `test_filters_webinar_thumbnails_from_images` — image URL matches webinar `thumbnail_url` in same result; asserts image excluded, webinar preserved
- [x] `test_filters_cross_article_webinar_thumbnails` — webinar in result A, matching image in result B; asserts cross-article filtering works
- [x] `test_preserves_images_when_no_webinar_thumbnails` — webinars without `thumbnail_url`; asserts all images preserved (regression guard)
- [x] Full test suite passes (190/190)

🤖 Generated with [Claude Code](https://claude.com/claude-code)