### PR TITLE
feat(frontend): update branding to Norfolk AI | BI with red accent

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -12,6 +12,14 @@ function SidebarToggleIcon() {
   )
 }
 
+function GitHubIcon() {
+  return (
+    <svg className="w-4 h-4" viewBox="0 0 16 16" fill="currentColor">
+      <path d="M8 0C3.58 0 0 3.58 0 8c0 3.54 2.29 6.53 5.47 7.59.4.07.55-.17.55-.38 0-.19-.01-.82-.01-1.49-2.01.37-2.53-.49-2.69-.94-.09-.23-.48-.94-.82-1.13-.28-.15-.68-.52-.01-.53.63-.01 1.08.58 1.23.82.72 1.21 1.87.87 2.33.66.07-.52.28-.87.51-1.07-1.78-.2-3.64-.89-3.64-3.95 0-.87.31-1.59.82-2.15-.08-.2-.36-1.02.08-2.12 0 0 .67-.21 2.2.82.64-.18 1.32-.27 2-.27.68 0 1.36.09 2 .27 1.53-1.04 2.2-.82 2.2-.82.44 1.1.16 1.92.08 2.12.51.56.82 1.27.82 2.15 0 3.07-1.87 3.75-3.65 3.95.29.25.54.73.54 1.48 0 1.07-.01 1.93-.01 2.2 0 .21.15.46.55.38A8.013 8.013 0 0016 8c0-4.42-3.58-8-8-8z" />
+    </svg>
+  )
+}
+
 function App() {
   const { messages, isLoading, sendMessage } = useSSEChat()
   const [sidebarOpen, setSidebarOpen] = useState(true)
@@ -34,7 +42,7 @@ function App() {
               <SidebarToggleIcon />
             </button>
             <span className="font-heading text-2xl text-charcoal">
-              Norfolk <span className="text-terracotta">AI/BI</span>
+              Norfolk <span className="text-norfolk-red">AI | BI</span>
             </span>
           </div>
           <nav className="flex items-center gap-4 text-xs text-charcoal-muted">
@@ -44,7 +52,7 @@ function App() {
               rel="noopener noreferrer"
               className="hover:text-charcoal transition-colors"
             >
-              GitHub
+              <GitHubIcon />
             </a>
             <a
               href="https://norfolkaibi.com"
@@ -52,7 +60,7 @@ function App() {
               rel="noopener noreferrer"
               className="hover:text-charcoal transition-colors"
             >
-              &larr; Norfolk AI/BI
+              &larr; Norfolk <span className="text-norfolk-red">AI | BI</span>
             </a>
           </nav>
         </div>
@@ -106,7 +114,7 @@ function App() {
 
           {/* Footer */}
           <footer className="bg-ivory-light border-t border-black/10 px-6 py-2 text-center text-xs text-charcoal-muted">
-            &copy; 2026 Norfolk AI/BI &middot; GraphRAG &middot; Neo4j &middot; LangChain &middot; LangSmith
+            &copy; 2026 Norfolk <span className="text-norfolk-red">AI | BI</span> &middot; GraphRAG &middot; Neo4j &middot; LangChain &middot; LangSmith
           </footer>
         </div>
       </div>

--- a/frontend/src/components/sidebar/Sidebar.jsx
+++ b/frontend/src/components/sidebar/Sidebar.jsx
@@ -147,7 +147,7 @@ export function Sidebar({ isOpen, onClose, onQuickStart }) {
 
       {/* Footer */}
       <div className="border-t border-black/10 px-4 py-2.5 text-[10px] text-charcoal-muted text-center">
-        Norfolk AI/BI &middot; GraphRAG
+        Norfolk <span className="text-norfolk-red">AI | BI</span> &middot; GraphRAG
       </div>
     </aside>
   )

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
 @plugin "@tailwindcss/typography";
 
-/* Norfolk AI/BI + Jama brand design tokens */
+/* Norfolk AI | BI + Jama brand design tokens */
 @theme {
   --color-ivory: #FAF9F0;
   --color-ivory-light: #FDFCF7;
@@ -13,6 +13,7 @@
   --color-terracotta: #CC785C;
   --color-terracotta-light: #D89478;
   --color-terracotta-dark: #B56A50;
+  --color-norfolk-red: #B50101;
   --color-terminal-bg: #1E1E1E;
   --color-terminal-text: #E0E0E0;
   --color-terminal-green: #7EC699;


### PR DESCRIPTION
## Summary

Closes #58

- Replace all "Norfolk AI/BI" instances with "Norfolk AI | BI" across header branding, header nav link, sidebar footer, and main footer
- Style "AI | BI" with brand color `#B50101` via new `--color-norfolk-red` design token
- Replace header "GitHub" text link with inline SVG GitHub icon (Invertocat mark), consistent with existing `SidebarToggleIcon` pattern

## Files changed

| File | Change |
|------|--------|
| `frontend/src/index.css` | Add `--color-norfolk-red: #B50101` to `@theme` block |
| `frontend/src/App.jsx` | Add `GitHubIcon` component; update branding in header, nav, and footer |
| `frontend/src/components/sidebar/Sidebar.jsx` | Update branding in sidebar footer |

## Test plan

- [x] `npm run build` passes (212 modules, no warnings)
- [x] Zero remaining "AI/BI" occurrences in `frontend/src/`
- [ ] Visual verification: header left shows "Norfolk **AI | BI**" in `#B50101`
- [ ] Visual verification: header right shows GitHub icon (not text) linking to repo
- [ ] Visual verification: header right shows "← Norfolk **AI | BI**" in `#B50101`
- [ ] Visual verification: sidebar footer shows "Norfolk **AI | BI**" in `#B50101`
- [ ] Visual verification: main footer shows "Norfolk **AI | BI**" in `#B50101`

🤖 Generated with [Claude Code](https://claude.com/claude-code)