### PR TITLE
fix: rename API title from Jama to Requirements GraphRAG API

### DIFF
--- a/backend/src/requirements_graphrag_api/__init__.py
+++ b/backend/src/requirements_graphrag_api/__init__.py
@@ -1,6 +1,6 @@
-"""Jama GraphRAG API - FastAPI REST API for Requirements Management Knowledge Graph.
+"""Requirements GraphRAG API - FastAPI REST API for Requirements Management Knowledge Graph.
 
-This package provides the REST API backend for the Jama GraphRAG system,
+This package provides the REST API backend for the Requirements GraphRAG system,
 deployable to Vercel serverless functions.
 """
 

--- a/backend/src/requirements_graphrag_api/api.py
+++ b/backend/src/requirements_graphrag_api/api.py
@@ -123,7 +123,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
 
 # Create FastAPI app
 app = FastAPI(
-    title="Jama GraphRAG API",
+    title="Requirements GraphRAG API",
     description=(
         "GraphRAG REST API for Requirements Management Knowledge Graph. "
         "Provides RAG-powered Q&A, semantic search, and knowledge graph exploration."
@@ -165,7 +165,7 @@ app.include_router(schema_router, tags=["Schema"])
 async def root() -> dict[str, str]:
     """Root endpoint with API information."""
     return {
-        "name": "Jama GraphRAG API",
+        "name": "Requirements GraphRAG API",
         "version": "1.0.0",
         "docs": "/docs",
         "health": "/health",


### PR DESCRIPTION
## Summary

- Rename "Jama GraphRAG API" → "Requirements GraphRAG API" in three locations:
  - FastAPI `title` parameter (controls Swagger `/docs` page header)
  - Root `GET /` endpoint JSON response
  - Package docstring in `__init__.py`
- Limits Jama branding to the permitted guide citation only

## Test plan

- [ ] Swagger docs at `/docs` shows "Requirements GraphRAG API" as the page title
- [ ] `GET /` returns `{"name": "Requirements GraphRAG API", ...}`
- [ ] CI passes (lint + tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)