### PR TITLE
fix: deduplicate media rows in Text2Cypher queries

### DIFF
--- a/backend/src/requirements_graphrag_api/prompts/definitions.py
+++ b/backend/src/requirements_graphrag_api/prompts/definitions.py
@@ -430,6 +430,8 @@ Guidelines:
 4. Return meaningful property values, not just node counts
 5. Limit results to 25 unless aggregating
 6. For media queries (webinars, videos, images), traverse from Article
+7. For media listing queries, use COLLECT(DISTINCT ...) to aggregate
+   source articles and avoid duplicate rows
 
 Generate only the Cypher query, no explanation."""
 
@@ -509,21 +511,24 @@ LIMIT 5
 Example 8:
 Question: List all webinars
 Cypher: MATCH (a:Article)-[:HAS_WEBINAR]->(w:Webinar)
-RETURN w.title AS webinar_title, w.url AS webinar_url, a.article_title AS source_article
+RETURN w.title AS webinar_title, w.url AS webinar_url,
+       COLLECT(DISTINCT a.article_title) AS source_articles
 ORDER BY w.title
 
 Example 9:
 Question: Show me all videos in the knowledge base
 Cypher: MATCH (a:Article)-[:HAS_VIDEO]->(v:Video)
-RETURN v.title AS video_title, v.url AS video_url, a.article_title AS source_article
+RETURN v.title AS video_title, v.url AS video_url,
+       COLLECT(DISTINCT a.article_title) AS source_articles
 ORDER BY v.title
 
 Example 10:
 Question: What images are available about traceability?
-Cypher: MATCH (e)-[:MENTIONED_IN]->(c:Chunk)-[:FROM_ARTICLE]->(a:Article)-[:HAS_IMAGE]->(img:Image)
-WHERE toLower(e.name) CONTAINS 'traceability'
-   OR toLower(img.alt_text) CONTAINS 'traceability'
-RETURN DISTINCT img.alt_text AS description, img.url AS image_url, a.article_title AS source
+Cypher: MATCH (a:Article)-[:HAS_IMAGE]->(img:Image)
+WHERE toLower(img.alt_text) CONTAINS 'traceability'
+RETURN img.alt_text AS description, img.url AS image_url,
+       COLLECT(DISTINCT a.article_title) AS source_articles
+ORDER BY description
 LIMIT 10
 
 Example 11:

--- a/frontend/src/components/metadata/ResultsTable.jsx
+++ b/frontend/src/components/metadata/ResultsTable.jsx
@@ -7,6 +7,9 @@ function formatCellValue(value) {
   if (value === null || value === undefined) {
     return <span className="text-charcoal-muted italic">null</span>
   }
+  if (Array.isArray(value)) {
+    return value.join(', ')
+  }
   if (typeof value === 'object') {
     return JSON.stringify(value)
   }


### PR DESCRIPTION
## Summary

- Use `COLLECT(DISTINCT ...)` in Text2Cypher few-shot examples 8–10 to aggregate source articles per media item, eliminating duplicate webinar/video/image rows
- Add guideline 7 to the `TEXT2CYPHER_SYSTEM` prompt reinforcing the deduplication pattern for media queries
- Render array cell values as comma-separated text in the frontend `ResultsTable` instead of raw `JSON.stringify` output

Closes #68

## Test plan

- [x] `uv run ruff check` — all checks passed
- [x] `uv run pytest` — 195 tests passed
- [ ] After Railway redeploys, ask "List all webinars about traceability" and verify distinct webinar rows with aggregated `source_articles` arrays
- [ ] Verify `ResultsTable` renders array columns (e.g., `source_articles`) as readable comma-separated text

🤖 Generated with [Claude Code](https://claude.com/claude-code)