### PR TITLE
chore: rename LangSmith projects to graphrag-api-* convention

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -29,7 +29,7 @@ LOG_LEVEL=INFO
 # LangSmith Observability (Optional)
 LANGSMITH_TRACING=false
 LANGSMITH_API_KEY=
-LANGSMITH_PROJECT=requirements-graphrag
+LANGSMITH_PROJECT=graphrag-api-dev
 # LANGCHAIN_PROJECT=requirements-graphrag  # Legacy alternative
 
 # CORS (for frontend access)

--- a/.github/workflows/evaluation.yml
+++ b/.github/workflows/evaluation.yml
@@ -66,7 +66,7 @@ jobs:
           NEO4J_DATABASE: ${{ secrets.NEO4J_DATABASE }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
-          LANGSMITH_PROJECT: requirements-graphrag-release
+          LANGSMITH_PROJECT: graphrag-api-release
           LANGSMITH_TRACING: "true"
 
       - name: Upload Tier 3 results
@@ -135,7 +135,7 @@ jobs:
           NEO4J_DATABASE: ${{ secrets.NEO4J_DATABASE }}
           OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
-          LANGSMITH_PROJECT: requirements-graphrag-nightly
+          LANGSMITH_PROJECT: graphrag-api-nightly
           LANGSMITH_TRACING: "true"
 
       - name: Upload Tier 4 results

--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ See [`backend/.env.example`](backend/.env.example) for the full template with in
 | `NEO4J_CONNECTION_TIMEOUT` | No | `30.0` | Connection timeout in seconds |
 | `LANGSMITH_TRACING` | No | `false` | Enable LangSmith tracing |
 | `LANGSMITH_API_KEY` | No | — | LangSmith API key |
-| `LANGSMITH_PROJECT` | No | `requirements-graphrag` | LangSmith project name |
+| `LANGSMITH_PROJECT` | No | `graphrag-api-dev` | LangSmith project name |
 | `CORS_ORIGINS` | No | `localhost:3000,5173` | Allowed CORS origins (comma-separated) |
 | `VITE_API_URL` | Yes (frontend) | — | Backend API URL for the frontend |
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -48,7 +48,7 @@ LANGSMITH_API_KEY=
 # LANGCHAIN_API_KEY=  # Legacy alternative
 
 # Project name in LangSmith dashboard
-LANGSMITH_PROJECT=requirements-graphrag
+LANGSMITH_PROJECT=graphrag-api-dev
 # LANGCHAIN_PROJECT=requirements-graphrag  # Legacy alternative
 
 # Organization/workspace handle for LangSmith Hub prompts

--- a/backend/src/requirements_graphrag_api/config.py
+++ b/backend/src/requirements_graphrag_api/config.py
@@ -86,7 +86,7 @@ class AppConfig:
     neo4j_max_connection_lifetime: int = 300  # Max seconds a connection can live (5 min)
     # LangSmith observability settings
     langsmith_api_key: str = ""
-    langsmith_project: str = "requirements-graphrag"
+    langsmith_project: str = "graphrag-api-dev"
     langsmith_tracing_enabled: bool = False
     langsmith_workspace_id: str = ""  # Required for org-scoped API keys
     # Prompt catalog settings

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
       - LOG_LEVEL=${LOG_LEVEL:-INFO}
       - LANGSMITH_API_KEY=${LANGSMITH_API_KEY:-}
       - LANGSMITH_TRACING=${LANGSMITH_TRACING:-false}
-      - LANGSMITH_PROJECT=${LANGSMITH_PROJECT:-requirements-graphrag}
+      - LANGSMITH_PROJECT=${LANGSMITH_PROJECT:-graphrag-api-dev}
       - CORS_ORIGINS=${CORS_ORIGINS:-http://localhost:3000,http://localhost:5173}
     env_file:
       - .env


### PR DESCRIPTION
## Summary

- Updates all LangSmith project references from legacy `requirements-graphrag-*` naming to standardized `graphrag-api-*` convention
- Aligns codebase with renamed LangSmith workspace and projects

## Changes

| File | Update |
|------|--------|
| `.env.example` | `requirements-graphrag` → `graphrag-api-dev` |
| `backend/.env.example` | `requirements-graphrag` → `graphrag-api-dev` |
| `docker-compose.yml` | Default fallback → `graphrag-api-dev` |
| `config.py` | Code default → `graphrag-api-dev` |
| `README.md` | Documentation → `graphrag-api-dev` |
| `evaluation.yml` | CI projects → `graphrag-api-release`, `graphrag-api-nightly` |

## New Naming Convention

| Environment | LangSmith Project |
|-------------|-------------------|
| Development | `graphrag-api-dev` |
| Production | `graphrag-api-prod` |
| Release CI | `graphrag-api-release` |
| Nightly CI | `graphrag-api-nightly` |

## Test plan

- [x] All 195 tests pass
- [x] Ruff linting passes
- [x] Pre-commit hooks pass
- [ ] Verify LangSmith traces appear in correct projects after merge

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)