### PR TITLE
docs: update LangSmith project references to graphrag-api-* naming

### DIFF
--- a/docs/FEEDBACK_WORKFLOW.md
+++ b/docs/FEEDBACK_WORKFLOW.md
@@ -53,7 +53,7 @@ The feedback loop enables systematic improvement of RAG quality through:
 ```bash
 # Export runs with confidence below 0.7 from the last 7 days
 python scripts/export_for_annotation.py \
-    --project jama-mcp-graphrag \
+    --project graphrag-api-dev \
     --threshold 0.7 \
     --days 7 \
     --output data/annotations/pending.json
@@ -115,7 +115,7 @@ Exports low-confidence evaluation runs for human review.
 | Flag | Default | Description |
 |------|---------|-------------|
 | `--output`, `-o` | `data/annotations/pending.json` | Output file path |
-| `--project`, `-p` | `jama-mcp-graphrag` | LangSmith project name |
+| `--project`, `-p` | `graphrag-api-dev` | LangSmith project name |
 | `--threshold`, `-t` | `0.7` | Confidence threshold |
 | `--max-runs`, `-m` | `100` | Maximum runs to export |
 | `--days`, `-d` | `7` | Days to look back |
@@ -137,7 +137,7 @@ Imports annotated feedback and generates evaluation examples.
 |------|---------|-------------|
 | `--input`, `-i` | Required | Input JSON file |
 | `--from-langsmith` | `false` | Import from LangSmith instead |
-| `--project`, `-p` | `jama-mcp-graphrag` | LangSmith project |
+| `--project`, `-p` | `graphrag-api-dev` | LangSmith project |
 | `--output`, `-o` | `data/feedback/new_examples.json` | Output file |
 | `--generate-examples` | `true` | Generate evaluation examples |
 | `--validate-only` | `false` | Only validate, don't import |
@@ -238,7 +238,7 @@ When marking as incorrect, provide:
 # Import feedback directly from LangSmith
 python scripts/import_feedback.py \
     --from-langsmith \
-    --project jama-mcp-graphrag \
+    --project graphrag-api-dev \
     --days 14
 ```
 
@@ -288,7 +288,7 @@ Track these metrics over feedback cycles:
 ### No Runs Exported
 
 - Verify LangSmith API key is set: `echo $LANGSMITH_API_KEY`
-- Check project name matches: `--project jama-mcp-graphrag`
+- Check project name matches: `--project graphrag-api-dev`
 - Lower threshold: `--threshold 0.5`
 - Extend date range: `--days 30`
 

--- a/docs/PLATFORM_COMPARISON.md
+++ b/docs/PLATFORM_COMPARISON.md
@@ -18,7 +18,7 @@ This document provides a comprehensive comparison of LangSmith and MLflow for LL
 ```bash
 # Total setup: ~5 minutes
 export LANGSMITH_API_KEY=<your-key>
-export LANGSMITH_PROJECT=requirements-graphrag
+export LANGSMITH_PROJECT=graphrag-api-dev
 export LANGSMITH_TRACING=true
 # Done! LangChain auto-traces everything.
 ```
@@ -39,7 +39,7 @@ export LANGSMITH_TRACING=true
 pip install mlflow
 mlflow server --host 0.0.0.0 --port 5000
 export MLFLOW_TRACKING_URI=http://localhost:5000
-mlflow experiments create -n requirements-graphrag
+mlflow experiments create -n graphrag-api
 # Then: manual instrumentation in code
 ```
 

--- a/docs/PRODUCTION_MONITORING.md
+++ b/docs/PRODUCTION_MONITORING.md
@@ -19,16 +19,15 @@ Create distinct projects for each environment:
 
 | Project | Purpose | Environment Variable |
 |---------|---------|---------------------|
-| `requirements-graphrag-dev` | Development testing | `LANGSMITH_PROJECT=requirements-graphrag-dev` |
-| `requirements-graphrag-staging` | Pre-production | `LANGSMITH_PROJECT=requirements-graphrag-staging` |
-| `requirements-graphrag-prod` | Production | `LANGSMITH_PROJECT=requirements-graphrag-prod` |
+| `graphrag-api-dev` | Development testing | `LANGSMITH_PROJECT=graphrag-api-dev` |
+| `graphrag-api-prod` | Production | `LANGSMITH_PROJECT=graphrag-api-prod` |
 
 ### Environment Configuration
 
 ```bash
 # Production .env
 LANGSMITH_TRACING=true
-LANGSMITH_PROJECT=requirements-graphrag-prod
+LANGSMITH_PROJECT=graphrag-api-prod
 LANGSMITH_API_KEY=<org-scoped-key>
 LANGSMITH_WORKSPACE_ID=33c08fbf-3b88-4b49-ae32-9677043ebed2
 PROMPT_ENVIRONMENT=production
@@ -53,7 +52,7 @@ PROMPT_ENVIRONMENT=production
 ### Creating an Alert (UI)
 
 1. Click **"Create Alert"**
-2. Select project: `requirements-graphrag-prod`
+2. Select project: `graphrag-api-prod`
 3. Configure condition:
    - Metric: `latency_p95`
    - Operator: `greater_than`
@@ -107,7 +106,7 @@ Annotation queues enable human review of LLM outputs.
 2. Click **"Create Queue"**
 3. Configure:
    - Name: `low-confidence-review`
-   - Project: `requirements-graphrag-prod`
+   - Project: `graphrag-api-prod`
    - Filter: `metadata.confidence < 0.5`
 4. Assign reviewers
 5. Save
@@ -137,7 +136,7 @@ client = Client()
 
 # Get successful production runs
 runs = client.list_runs(
-    project_name="requirements-graphrag-prod",
+    project_name="graphrag-api-prod",
     filter='eq(status, "success")',
     limit=100,
 )
@@ -178,7 +177,7 @@ uv run python scripts/run_prompt_comparison.py router \
 # Required for production
 LANGSMITH_TRACING=true
 LANGSMITH_API_KEY=<your-org-api-key>
-LANGSMITH_PROJECT=requirements-graphrag-prod
+LANGSMITH_PROJECT=graphrag-api-prod
 LANGSMITH_WORKSPACE_ID=33c08fbf-3b88-4b49-ae32-9677043ebed2
 PROMPT_ENVIRONMENT=production
 ```


### PR DESCRIPTION
## Summary

Updates all documentation files in `docs/` to use the new LangSmith project naming convention following PR #74.

## Changes

| File | Updates |
|------|---------|
| `FEEDBACK_WORKFLOW.md` | `jama-mcp-graphrag` → `graphrag-api-dev` (5 occurrences) |
| `PLATFORM_COMPARISON.md` | `requirements-graphrag` → `graphrag-api-dev` (2 occurrences) |
| `PRODUCTION_MONITORING.md` | `requirements-graphrag-*` → `graphrag-api-*`, removed staging reference |

## New Naming Convention

| Environment | LangSmith Project |
|-------------|-------------------|
| Development | `graphrag-api-dev` |
| Production | `graphrag-api-prod` |

**Note:** Staging project was removed as it doesn't exist in the current LangSmith workspace.

## Test plan

- [x] Verified no old project names remain in docs/
- [x] Pre-commit hooks pass

Closes #75

🤖 Generated with [Claude Code](https://claude.com/claude-code)