### PR TITLE
chore: update Neo4j instance reference to graphrag-api-db

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,7 +21,7 @@ NEO4J_CONNECTION_TIMEOUT=30.0
 OPENAI_API_KEY=sk-your-api-key-here
 OPENAI_MODEL=gpt-4o
 # CRITICAL: Must match the model used to create embeddings in Neo4j!
-# The jama-guide-to-rm database uses text-embedding-3-small
+# The graphrag-api-db database uses text-embedding-3-small
 EMBEDDING_MODEL=text-embedding-3-small
 
 # =============================================================================


### PR DESCRIPTION
## Summary

Updates the Neo4j instance name reference in `backend/.env.example` to match the renamed Aura instance.

## Change

```diff
- # The jama-guide-to-rm database uses text-embedding-3-small
+ # The graphrag-api-db database uses text-embedding-3-small
```

## Context

| Property | Old | New |
|----------|-----|-----|
| Instance Name | `jama-guide-to-rm` | `graphrag-api-db` |
| Instance ID | `234ea307` | `78734491` |

This aligns the Neo4j instance naming with the project's `graphrag-api-*` convention used for LangSmith projects.

## Test plan

- [x] Pre-commit hooks pass
- [x] Comment-only change, no functional impact

Closes #77

🤖 Generated with [Claude Code](https://claude.com/claude-code)