### PR TITLE
feat: auto-load .env file for local backend development

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,4 +1,21 @@
 # =============================================================================
+# Backend Environment Configuration
+# =============================================================================
+# USAGE: Copy this file to .env and fill in your values:
+#   cp .env.example .env
+#
+# This file is auto-loaded by the backend when running locally:
+#   uv run uvicorn requirements_graphrag_api.api:app --reload
+#
+# Load order (first found wins, existing env vars are NOT overridden):
+#   1. backend/.env (this directory)
+#   2. root/.env (project root, used by docker-compose)
+#
+# For Docker: docker-compose uses root/.env via env_file directive
+# For Railway: Configure env vars in Railway dashboard
+# =============================================================================
+
+# =============================================================================
 # Neo4j Connection
 # =============================================================================
 # Use neo4j+s:// for production (Aura, clusters) - enables TLS and routing

--- a/backend/src/requirements_graphrag_api/config.py
+++ b/backend/src/requirements_graphrag_api/config.py
@@ -14,7 +14,24 @@ from __future__ import annotations
 import logging
 import os
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Final
+
+from dotenv import load_dotenv
+
+# Load .env file for local development
+# Checks backend/.env first, then falls back to root .env
+# Does not override existing environment variables (deployment configs take precedence)
+# Path from config.py: backend/src/requirements_graphrag_api/config.py
+#   -> 3 parents up = backend/
+#   -> 4 parents up = project root
+_backend_env = Path(__file__).parent.parent.parent / ".env"
+_root_env = Path(__file__).parent.parent.parent.parent / ".env"
+
+if _backend_env.exists():
+    load_dotenv(_backend_env, override=False)
+elif _root_env.exists():
+    load_dotenv(_root_env, override=False)
 
 logger = logging.getLogger(__name__)
 


### PR DESCRIPTION
## Summary

- Use `python-dotenv` (already a dependency) to auto-load environment variables from `.env` files
- Check `backend/.env` first, then fall back to root `.env`
- Does not override existing env vars (deployment configs take precedence)
- Update `.env.example` with usage documentation

## Problem

The backend had `python-dotenv` as a dependency but never used it. Running `uv run uvicorn ...` locally required manually exporting environment variables, while the `backend/.env.example` file existed but served no functional purpose.

## Solution

Now developers can simply:
```bash
cd backend
cp .env.example .env
# Edit .env with credentials
uv run uvicorn requirements_graphrag_api.api:app --reload
```

## Test plan

- [x] All 195 existing tests pass
- [x] Ruff linting passes
- [x] Verified path calculations resolve correctly
- [x] Manual test: Run backend locally with root `.env` fallback
- [x] Manual test: Verified LangSmith traces logged to correct project (`graphrag-api-dev`)

Closes #79

🤖 Generated with [Claude Code](https://claude.com/claude-code)