### PR TITLE
fix: capture run_id inside text2cypher_query for feedback correlation

### DIFF
--- a/backend/src/requirements_graphrag_api/core/text2cypher.py
+++ b/backend/src/requirements_graphrag_api/core/text2cypher.py
@@ -20,6 +20,7 @@ from typing import TYPE_CHECKING, Any, Final
 
 from langchain_core.output_parsers import StrOutputParser
 from langchain_openai import ChatOpenAI
+from langsmith import get_current_run_tree
 
 from requirements_graphrag_api.observability import traceable_safe
 from requirements_graphrag_api.prompts import PromptName, get_prompt_sync
@@ -176,6 +177,14 @@ async def text2cypher_query(
                 response["error"] = str(e)
                 response["results"] = []
                 response["row_count"] = 0
+
+    # Capture run_id for feedback correlation (must be inside @traceable function)
+    try:
+        run_tree = get_current_run_tree()
+        if run_tree:
+            response["run_id"] = str(run_tree.id)
+    except Exception:
+        logger.debug("Could not get run_id - tracing may be disabled")
 
     return response
 

--- a/backend/src/requirements_graphrag_api/routes/chat.py
+++ b/backend/src/requirements_graphrag_api/routes/chat.py
@@ -22,7 +22,6 @@ from typing import TYPE_CHECKING
 
 from fastapi import APIRouter, Request
 from fastapi.responses import StreamingResponse
-from langsmith import get_current_run_tree
 from pydantic import BaseModel, Field
 
 from requirements_graphrag_api.core import (
@@ -246,14 +245,8 @@ async def _generate_structured_events(
         }
         yield f"data: {json.dumps(results_data)}\n\n"
 
-        # Get run_id for feedback correlation
-        run_id = None
-        try:
-            run_tree = get_current_run_tree()
-            if run_tree:
-                run_id = str(run_tree.id)
-        except Exception:
-            logger.debug("Could not get run_id - tracing may be disabled")
+        # Get run_id from result (captured inside text2cypher_query for correct context)
+        run_id = result.get("run_id")
 
         # Emit done event
         if "error" in result:


### PR DESCRIPTION
## Summary

- Fix structured query feedback not appearing in LangSmith dashboards
- Move `run_id` capture inside `text2cypher_query()` where trace context is active
- Remove redundant `get_current_run_tree()` call from `_generate_structured_events`

## Root Cause

The `run_id` for structured queries was being captured **OUTSIDE** the `@traceable` decorated function, after the trace context had already closed:

```python
# BEFORE (broken)
result = await text2cypher_query(...)  # Trace context ends here
run_tree = get_current_run_tree()      # Returns None - context closed!
```

This is why explanatory queries worked (capture inside `stream_chat()`) but structured queries didn't.

## Solution

```python
# AFTER (fixed)
# Inside text2cypher_query():
run_tree = get_current_run_tree()  # Captured while context active
response["run_id"] = str(run_tree.id)
return response

# In _generate_structured_events:
run_id = result.get("run_id")  # Use pre-captured value
```

## Test Plan

- [x] All 235 existing tests pass
- [x] Linting passes
- [ ] Manual test: Submit feedback for structured query, verify in LangSmith

Fixes #85

🤖 Generated with [Claude Code](https://claude.ai/code)