### PR TITLE
feat(guardrails): implement Phase 2 content safety guardrails

### DIFF
--- a/backend/src/requirements_graphrag_api/guardrails/__init__.py
+++ b/backend/src/requirements_graphrag_api/guardrails/__init__.py
@@ -1,14 +1,23 @@
 """Guardrails module for input/output safety checks.
 
 This module provides security guardrails for the GraphRAG API:
-- Prompt injection detection and blocking
-- PII detection and redaction
+- Prompt injection detection and blocking (Phase 1)
+- PII detection and redaction (Phase 1)
+- Toxicity detection (Phase 2)
+- Topic boundary enforcement (Phase 2)
+- Output content filtering (Phase 2)
 - Structured event logging for security monitoring
 
 Usage:
     from requirements_graphrag_api.guardrails import (
+        # Phase 1 - Critical Security
         check_prompt_injection,
         detect_and_redact_pii,
+        # Phase 2 - Content Safety
+        check_toxicity,
+        check_topic_relevance,
+        filter_output,
+        # Events
         log_guardrail_event,
     )
 """
@@ -16,9 +25,18 @@ Usage:
 from __future__ import annotations
 
 from requirements_graphrag_api.guardrails.events import (
+    ActionTaken,
     GuardrailEvent,
     GuardrailEventType,
+    create_output_filter_event,
+    create_topic_event,
+    create_toxicity_event,
     log_guardrail_event,
+)
+from requirements_graphrag_api.guardrails.output_filter import (
+    OutputFilterConfig,
+    OutputFilterResult,
+    filter_output,
 )
 from requirements_graphrag_api.guardrails.pii_detection import (
     PIICheckResult,
@@ -29,14 +47,41 @@ from requirements_graphrag_api.guardrails.prompt_injection import (
     InjectionRisk,
     check_prompt_injection,
 )
+from requirements_graphrag_api.guardrails.topic_guard import (
+    TopicCheckResult,
+    TopicClassification,
+    TopicGuardConfig,
+    check_topic_relevance,
+)
+from requirements_graphrag_api.guardrails.toxicity import (
+    ToxicityCategory,
+    ToxicityConfig,
+    ToxicityResult,
+    check_toxicity,
+)
 
 __all__ = [
+    "ActionTaken",
     "GuardrailEvent",
     "GuardrailEventType",
     "InjectionCheckResult",
     "InjectionRisk",
+    "OutputFilterConfig",
+    "OutputFilterResult",
     "PIICheckResult",
+    "TopicCheckResult",
+    "TopicClassification",
+    "TopicGuardConfig",
+    "ToxicityCategory",
+    "ToxicityConfig",
+    "ToxicityResult",
     "check_prompt_injection",
+    "check_topic_relevance",
+    "check_toxicity",
+    "create_output_filter_event",
+    "create_topic_event",
+    "create_toxicity_event",
     "detect_and_redact_pii",
+    "filter_output",
     "log_guardrail_event",
 ]

--- a/backend/src/requirements_graphrag_api/guardrails/output_filter.py
+++ b/backend/src/requirements_graphrag_api/guardrails/output_filter.py
@@ -1,0 +1,322 @@
+"""Output content filtering for LLM responses.
+
+This module filters LLM outputs for safety, accuracy, and appropriateness
+before returning them to users.
+
+Checks Performed:
+    1. Toxicity check: Same as input (using OpenAI Moderation)
+    2. Confidence scoring: Estimate answer reliability
+    3. Disclaimer injection: Add warnings for uncertain answers
+
+The filter can:
+    - Block toxic or harmful responses
+    - Add disclaimers to low-confidence answers
+    - Track modifications made for logging
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import TYPE_CHECKING, Any
+
+from requirements_graphrag_api.guardrails.toxicity import (
+    ToxicityConfig,
+    check_toxicity,
+)
+
+if TYPE_CHECKING:
+    from openai import AsyncOpenAI
+
+logger = logging.getLogger(__name__)
+
+
+# Default blocked response message
+BLOCKED_RESPONSE = """I apologize, but I'm unable to provide that response.
+
+If you have questions about requirements management, traceability, or systems \
+engineering, I'd be happy to help with those topics.
+
+If you believe this is an error, please contact support."""
+
+
+# Disclaimer for low-confidence answers
+LOW_CONFIDENCE_DISCLAIMER = (
+    "\n\n_Note: This answer may not fully address your question. "
+    "Please verify with authoritative sources._"
+)
+
+
+@dataclass(frozen=True, slots=True)
+class OutputFilterConfig:
+    """Configuration for output filtering.
+
+    Attributes:
+        enabled: Whether output filtering is enabled.
+        toxicity_enabled: Whether to check output for toxicity.
+        add_disclaimers: Whether to add disclaimers to low-confidence answers.
+        confidence_threshold: Threshold below which disclaimers are added.
+        blocked_response_message: Message to return when output is blocked.
+        disclaimer_message: Message to append to low-confidence answers.
+    """
+
+    enabled: bool = True
+    toxicity_enabled: bool = True
+    add_disclaimers: bool = True
+    confidence_threshold: float = 0.6
+    blocked_response_message: str = BLOCKED_RESPONSE
+    disclaimer_message: str = LOW_CONFIDENCE_DISCLAIMER
+
+
+@dataclass(frozen=True, slots=True)
+class OutputFilterResult:
+    """Result of output filtering.
+
+    Attributes:
+        is_safe: Whether the output passed all safety checks.
+        filtered_content: The filtered/modified output content.
+        original_content: The original unmodified output.
+        warnings: List of warning messages about the output.
+        modifications: List of modifications made to the output.
+        confidence_score: Estimated confidence in the answer (0-1).
+        should_add_disclaimer: Whether a disclaimer should be added.
+        blocked_reason: Reason if the output was blocked.
+    """
+
+    is_safe: bool
+    filtered_content: str
+    original_content: str
+    warnings: tuple[str, ...]
+    modifications: tuple[str, ...]
+    confidence_score: float
+    should_add_disclaimer: bool
+    blocked_reason: str | None = None
+
+
+# Indicators that suggest uncertainty or lack of grounding
+HALLUCINATION_INDICATORS: tuple[str, ...] = (
+    "i don't have information about",
+    "i cannot find",
+    "i don't have access to",
+    "based on my knowledge",
+    "based on my training",
+    "i believe",
+    "i think",
+    "i'm not sure",
+    "i'm not certain",
+    "i cannot verify",
+    "i don't know",
+    "as far as i know",
+    "to my knowledge",
+    "i assume",
+    "i speculate",
+    "it's possible that",
+    "it might be",
+    "perhaps",
+    "maybe",
+    "i would guess",
+)
+
+# Indicators of confident, grounded responses
+CONFIDENCE_INDICATORS: tuple[str, ...] = (
+    "according to",
+    "the document states",
+    "as stated in",
+    "the guide mentions",
+    "the source indicates",
+    "based on the retrieved",
+    "from the knowledge base",
+)
+
+
+# Default configuration
+DEFAULT_CONFIG = OutputFilterConfig()
+DEFAULT_TOXICITY_CONFIG = ToxicityConfig()
+
+
+def _calculate_confidence(
+    output: str,
+    retrieved_sources: list[dict[str, Any]],
+) -> tuple[float, list[str]]:
+    """Calculate confidence score and collect warnings.
+
+    Args:
+        output: The LLM output to analyze.
+        retrieved_sources: Sources retrieved for the query.
+
+    Returns:
+        Tuple of (confidence_score, warnings_list).
+    """
+    confidence = 1.0
+    warnings: list[str] = []
+    output_lower = output.lower()
+
+    # Check for hallucination indicators (reduce confidence)
+    for indicator in HALLUCINATION_INDICATORS:
+        if indicator in output_lower:
+            confidence -= 0.15
+            warnings.append(f"Potential uncertainty: '{indicator}'")
+            # Cap the reduction from indicators
+            if confidence < 0.3:
+                confidence = 0.3
+                break
+
+    # Check for confidence indicators (boost confidence)
+    for indicator in CONFIDENCE_INDICATORS:
+        if indicator in output_lower:
+            confidence = min(1.0, confidence + 0.1)
+            break
+
+    # Check source grounding
+    if not retrieved_sources:
+        confidence -= 0.3
+        warnings.append("No sources retrieved for grounding")
+    elif len(retrieved_sources) < 2:
+        confidence -= 0.1
+        warnings.append("Limited sources retrieved")
+
+    # Check response length (very short responses may be incomplete)
+    word_count = len(output.split())
+    if word_count < 10:
+        confidence -= 0.2
+        warnings.append("Response is very short")
+    elif word_count < 25:
+        confidence -= 0.1
+        warnings.append("Response may be incomplete")
+
+    # Ensure confidence stays in valid range
+    confidence = max(0.0, min(1.0, confidence))
+
+    return confidence, warnings
+
+
+async def filter_output(
+    output: str,
+    original_query: str,
+    retrieved_sources: list[dict[str, Any]] | None = None,
+    config: OutputFilterConfig = DEFAULT_CONFIG,
+    toxicity_config: ToxicityConfig = DEFAULT_TOXICITY_CONFIG,
+    openai_client: AsyncOpenAI | None = None,
+) -> OutputFilterResult:
+    """Filter LLM output for safety and quality.
+
+    Performs toxicity checking and confidence scoring on LLM output.
+    Can block harmful content and add disclaimers to uncertain answers.
+
+    Args:
+        output: The LLM output to filter.
+        original_query: The original user query (for context).
+        retrieved_sources: Sources retrieved for the query.
+        config: Output filter configuration.
+        toxicity_config: Toxicity detection configuration.
+        openai_client: Async OpenAI client for toxicity checking.
+
+    Returns:
+        OutputFilterResult with filtering results.
+
+    Example:
+        >>> result = await filter_output(
+        ...     output="Requirements traceability is...",
+        ...     original_query="What is traceability?",
+        ...     retrieved_sources=[{"content": "..."}],
+        ... )
+        >>> result.is_safe
+        True
+    """
+    if not config.enabled:
+        return OutputFilterResult(
+            is_safe=True,
+            filtered_content=output,
+            original_content=output,
+            warnings=(),
+            modifications=(),
+            confidence_score=1.0,
+            should_add_disclaimer=False,
+        )
+
+    warnings: list[str] = []
+    modifications: list[str] = []
+    filtered = output
+    sources = retrieved_sources or []
+
+    # 1. Toxicity check on output
+    if config.toxicity_enabled:
+        toxicity = await check_toxicity(
+            output,
+            openai_client=openai_client,
+            config=toxicity_config,
+        )
+
+        if toxicity.should_block:
+            logger.warning(
+                "Output blocked due to toxicity",
+                extra={
+                    "categories": [c.value for c in toxicity.categories],
+                    "confidence": toxicity.confidence,
+                },
+            )
+            return OutputFilterResult(
+                is_safe=False,
+                filtered_content=config.blocked_response_message,
+                original_content=output,
+                warnings=("Output contained harmful content",),
+                modifications=("Replaced with safe response",),
+                confidence_score=0.0,
+                should_add_disclaimer=False,
+                blocked_reason="toxicity",
+            )
+
+        if toxicity.should_warn:
+            warnings.append(f"Toxicity warning: {', '.join(c.value for c in toxicity.categories)}")
+
+    # 2. Calculate confidence score
+    confidence, confidence_warnings = _calculate_confidence(output, sources)
+    warnings.extend(confidence_warnings)
+
+    # 3. Determine if disclaimer should be added
+    should_add_disclaimer = config.add_disclaimers and confidence < config.confidence_threshold
+
+    # 4. Add disclaimer if needed
+    if should_add_disclaimer:
+        filtered = output + config.disclaimer_message
+        modifications.append("Added low-confidence disclaimer")
+
+    return OutputFilterResult(
+        is_safe=True,
+        filtered_content=filtered,
+        original_content=output,
+        warnings=tuple(warnings),
+        modifications=tuple(modifications),
+        confidence_score=confidence,
+        should_add_disclaimer=should_add_disclaimer,
+    )
+
+
+async def filter_streaming_output(
+    output_chunk: str,
+    accumulated_output: str,
+    config: OutputFilterConfig = DEFAULT_CONFIG,
+) -> tuple[str, bool]:
+    """Filter streaming output chunk (lightweight check).
+
+    For streaming responses, we can't do full toxicity checking on each chunk.
+    This performs lightweight checks that can be done incrementally.
+
+    Args:
+        output_chunk: The current output chunk.
+        accumulated_output: The accumulated output so far.
+        config: Output filter configuration.
+
+    Returns:
+        Tuple of (filtered_chunk, should_continue).
+
+    Note:
+        Full toxicity check should be done on the complete output
+        using filter_output() after streaming completes.
+    """
+    if not config.enabled:
+        return output_chunk, True
+
+    # For streaming, we do minimal checks
+    # Full toxicity check happens post-stream
+    return output_chunk, True

--- a/backend/src/requirements_graphrag_api/guardrails/topic_guard.py
+++ b/backend/src/requirements_graphrag_api/guardrails/topic_guard.py
@@ -1,0 +1,396 @@
+"""Topic boundary enforcement for query relevance.
+
+This module ensures queries and responses stay within the intended domain
+(requirements management). It uses two methods:
+1. Fast keyword matching for obvious out-of-scope queries
+2. LLM classification for ambiguous cases
+
+In-Scope Topics:
+    - Requirements management and traceability
+    - Systems engineering and product development
+    - Compliance standards (ISO, IEC, FDA, etc.)
+    - Jama Software products and features
+    - Related technical documentation practices
+
+Out-of-Scope Topics:
+    - Politics, religion, personal relationships
+    - Medical diagnosis/treatment, legal advice
+    - Financial investment advice
+    - Entertainment, sports, current events
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from langchain_openai import ChatOpenAI
+
+logger = logging.getLogger(__name__)
+
+
+class TopicClassification(StrEnum):
+    """Classification result for topic relevance."""
+
+    IN_SCOPE = "in_scope"
+    OUT_OF_SCOPE = "out_of_scope"
+    BORDERLINE = "borderline"
+
+
+@dataclass(frozen=True, slots=True)
+class TopicGuardConfig:
+    """Configuration for topic boundary enforcement.
+
+    Attributes:
+        enabled: Whether topic guard is enabled.
+        use_llm_classification: Whether to use LLM for ambiguous cases.
+        allow_borderline: Whether to allow borderline queries.
+        out_of_scope_response: Default response for out-of-scope queries.
+    """
+
+    enabled: bool = True
+    use_llm_classification: bool = True
+    allow_borderline: bool = True
+    out_of_scope_response: str = """I'm a specialized assistant for Requirements Management topics.
+
+I can help you with:
+- Requirements traceability and management
+- Systems engineering best practices
+- Compliance with standards (ISO, IEC, FDA)
+- Jama Software features and workflows
+
+Would you like to ask about any of these topics instead?"""
+
+
+@dataclass(frozen=True, slots=True)
+class TopicCheckResult:
+    """Result of topic relevance check.
+
+    Attributes:
+        classification: The topic classification result.
+        confidence: Confidence score (0-1) for the classification.
+        suggested_response: For out-of-scope, a polite redirect message.
+        reasoning: Explanation for the classification.
+        check_type: Type of check performed ("keyword" or "llm").
+    """
+
+    classification: TopicClassification
+    confidence: float
+    suggested_response: str | None
+    reasoning: str | None
+    check_type: str
+
+
+# Topics that are clearly in scope for requirements management
+IN_SCOPE_TOPICS: tuple[str, ...] = (
+    "requirements management",
+    "requirements traceability",
+    "traceability matrix",
+    "systems engineering",
+    "product development",
+    "software requirements",
+    "hardware requirements",
+    "compliance",
+    "regulatory",
+    "iso ",
+    "iec ",
+    "fda ",
+    "verification and validation",
+    "v&v",
+    "change management",
+    "configuration management",
+    "risk management",
+    "jama software",
+    "jama connect",
+    "requirements documentation",
+    "specification writing",
+    "test case",
+    "test management",
+    "srs ",
+    "software requirement specification",
+    "system requirement specification",
+    "functional requirement",
+    "non-functional requirement",
+    "nfr",
+    "use case",
+    "user story",
+    "acceptance criteria",
+    "requirement elicitation",
+    "stakeholder",
+    "trace link",
+    "impact analysis",
+    "baseline",
+    "requirement attribute",
+    "requirement type",
+    "derived requirement",
+    "parent requirement",
+    "child requirement",
+)
+
+# Topics that are clearly out of scope
+OUT_OF_SCOPE_TOPICS: tuple[str, ...] = (
+    "politics",
+    "political",
+    "election",
+    "vote",
+    "republican",
+    "democrat",
+    "religion",
+    "religious",
+    "church",
+    "prayer",
+    "personal relationship",
+    "dating",
+    "boyfriend",
+    "girlfriend",
+    "medical diagnosis",
+    "medical treatment",
+    "medication",
+    "prescription",
+    "legal advice",
+    "lawsuit",
+    "attorney",
+    "lawyer",
+    "financial advice",
+    "stock",
+    "investment",
+    "cryptocurrency",
+    "crypto",
+    "bitcoin",
+    "competitor product",
+    "current events",
+    "news",
+    "entertainment",
+    "movie",
+    "music",
+    "celebrity",
+    "pop culture",
+    "cooking",
+    "recipe",
+    "sports",
+    "football",
+    "basketball",
+    "soccer",
+    "weather",
+    "horoscope",
+    "joke",
+)
+
+
+# LLM prompt for topic classification
+TOPIC_CLASSIFIER_PROMPT = """You are a topic classifier for a Requirements Management \
+knowledge base chatbot.
+
+The chatbot should ONLY answer questions about:
+- Requirements management and traceability
+- Systems engineering and product development
+- Compliance standards (ISO, IEC, FDA, etc.)
+- Jama Software products and features
+- Related technical documentation practices
+
+Classify the following user query as one of:
+- IN_SCOPE: Related to the topics above
+- OUT_OF_SCOPE: Unrelated to requirements management
+- BORDERLINE: Could be related depending on context
+
+User Query: {query}
+
+Classification (respond with only IN_SCOPE, OUT_OF_SCOPE, or BORDERLINE):"""
+
+
+# Default configuration
+DEFAULT_CONFIG = TopicGuardConfig()
+
+
+def _get_redirect_response(detected_topic: str | None = None) -> str:
+    """Get a polite redirect response for out-of-scope queries.
+
+    Args:
+        detected_topic: The detected out-of-scope topic (optional).
+
+    Returns:
+        A polite message redirecting to in-scope topics.
+    """
+    base_response = """I'm a specialized assistant for Requirements Management topics.
+
+I can help you with:
+- Requirements traceability and management
+- Systems engineering best practices
+- Compliance with standards (ISO, IEC, FDA)
+- Jama Software features and workflows
+
+Would you like to ask about any of these topics instead?"""
+
+    return base_response
+
+
+def _check_keywords(text: str) -> tuple[TopicClassification, str | None, float]:
+    """Fast keyword-based topic check.
+
+    Args:
+        text: The text to check.
+
+    Returns:
+        Tuple of (classification, detected_topic, confidence).
+    """
+    text_lower = text.lower()
+
+    # Check for out-of-scope topics first
+    for topic in OUT_OF_SCOPE_TOPICS:
+        if topic.lower() in text_lower:
+            return (TopicClassification.OUT_OF_SCOPE, topic, 0.9)
+
+    # Check for in-scope topics
+    for topic in IN_SCOPE_TOPICS:
+        if topic.lower() in text_lower:
+            return (TopicClassification.IN_SCOPE, topic, 0.9)
+
+    # No keyword matches - uncertain
+    return (TopicClassification.BORDERLINE, None, 0.5)
+
+
+def _parse_classification(response_text: str) -> TopicClassification:
+    """Parse LLM classification response.
+
+    Args:
+        response_text: The raw LLM response.
+
+    Returns:
+        Parsed TopicClassification.
+    """
+    text = response_text.strip().upper()
+
+    if "OUT_OF_SCOPE" in text or "OUT OF SCOPE" in text:
+        return TopicClassification.OUT_OF_SCOPE
+    elif "IN_SCOPE" in text or "IN SCOPE" in text:
+        return TopicClassification.IN_SCOPE
+    else:
+        return TopicClassification.BORDERLINE
+
+
+async def check_topic_relevance_fast(
+    query: str,
+    config: TopicGuardConfig = DEFAULT_CONFIG,
+) -> TopicCheckResult:
+    """Fast keyword-based topic relevance check.
+
+    Args:
+        query: The user query to check.
+        config: Topic guard configuration.
+
+    Returns:
+        TopicCheckResult with keyword-based classification.
+
+    Example:
+        >>> result = await check_topic_relevance_fast("What is requirements traceability?")
+        >>> result.classification
+        <TopicClassification.IN_SCOPE: 'in_scope'>
+    """
+    if not query or not query.strip():
+        return TopicCheckResult(
+            classification=TopicClassification.IN_SCOPE,
+            confidence=0.5,
+            suggested_response=None,
+            reasoning="Empty query",
+            check_type="keyword",
+        )
+
+    classification, detected_topic, confidence = _check_keywords(query)
+
+    suggested_response = None
+    if classification == TopicClassification.OUT_OF_SCOPE:
+        suggested_response = _get_redirect_response(detected_topic)
+
+    reasoning = None
+    if detected_topic:
+        if classification == TopicClassification.OUT_OF_SCOPE:
+            reasoning = f"Query contains out-of-scope topic: {detected_topic}"
+        else:
+            reasoning = f"Query contains in-scope topic: {detected_topic}"
+    else:
+        reasoning = "No keyword matches found"
+
+    return TopicCheckResult(
+        classification=classification,
+        confidence=confidence,
+        suggested_response=suggested_response,
+        reasoning=reasoning,
+        check_type="keyword",
+    )
+
+
+async def check_topic_relevance(
+    query: str,
+    llm: ChatOpenAI | None = None,
+    config: TopicGuardConfig = DEFAULT_CONFIG,
+) -> TopicCheckResult:
+    """Check if query is within the chatbot's intended scope.
+
+    Performs keyword-based check first, then uses LLM classification
+    for ambiguous cases if configured.
+
+    Args:
+        query: The user query to check.
+        llm: LangChain ChatOpenAI instance for LLM classification.
+        config: Topic guard configuration.
+
+    Returns:
+        TopicCheckResult with classification and suggested response.
+
+    Example:
+        >>> result = await check_topic_relevance("What is requirements traceability?")
+        >>> result.classification
+        <TopicClassification.IN_SCOPE: 'in_scope'>
+
+        >>> result = await check_topic_relevance("What's your favorite movie?")
+        >>> result.classification
+        <TopicClassification.OUT_OF_SCOPE: 'out_of_scope'>
+    """
+    if not config.enabled:
+        return TopicCheckResult(
+            classification=TopicClassification.IN_SCOPE,
+            confidence=1.0,
+            suggested_response=None,
+            reasoning="Topic guard disabled",
+            check_type="disabled",
+        )
+
+    # Fast keyword check first
+    fast_result = await check_topic_relevance_fast(query, config)
+
+    # If keyword check gives high confidence result, use it
+    if fast_result.confidence >= 0.9:
+        return fast_result
+
+    # If keyword check is uncertain and LLM is available, use LLM classification
+    if config.use_llm_classification and llm is not None:
+        try:
+            response = await llm.ainvoke(TOPIC_CLASSIFIER_PROMPT.format(query=query))
+            classification = _parse_classification(str(response.content))
+
+            suggested_response = None
+            is_out_of_scope = classification == TopicClassification.OUT_OF_SCOPE
+            is_blocked_borderline = (
+                classification == TopicClassification.BORDERLINE and not config.allow_borderline
+            )
+            if is_out_of_scope or is_blocked_borderline:
+                suggested_response = _get_redirect_response()
+
+            return TopicCheckResult(
+                classification=classification,
+                confidence=0.85,
+                suggested_response=suggested_response,
+                reasoning=f"LLM classified as: {classification.value}",
+                check_type="llm",
+            )
+
+        except Exception:
+            logger.exception("Error during LLM topic classification")
+            # Fall back to keyword result on error
+            return fast_result
+
+    # Return keyword result if no LLM check
+    return fast_result

--- a/backend/src/requirements_graphrag_api/guardrails/toxicity.py
+++ b/backend/src/requirements_graphrag_api/guardrails/toxicity.py
@@ -1,0 +1,381 @@
+"""Toxicity detection for user inputs and LLM outputs.
+
+This module provides dual-layer toxicity detection:
+1. Fast layer: Word-list based profanity check using better-profanity (~1ms)
+2. Accurate layer: OpenAI Moderation API (~500ms) for comprehensive detection
+
+Toxicity Categories (aligned with OpenAI Moderation):
+    - HATE: Hateful content targeting protected characteristics
+    - HATE_THREATENING: Hateful content with threats
+    - HARASSMENT: Harassing content
+    - HARASSMENT_THREATENING: Harassing content with threats
+    - SELF_HARM: Content about self-harm
+    - SELF_HARM_INTENT: Content expressing intent to self-harm
+    - SELF_HARM_INSTRUCTIONS: Instructions for self-harm
+    - SEXUAL: Sexual content
+    - SEXUAL_MINORS: Sexual content involving minors
+    - VIOLENCE: Violent content
+    - VIOLENCE_GRAPHIC: Graphic violent content
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from enum import StrEnum
+from functools import lru_cache
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from openai import AsyncOpenAI
+
+logger = logging.getLogger(__name__)
+
+
+class ToxicityCategory(StrEnum):
+    """Toxicity categories aligned with OpenAI Moderation API."""
+
+    HATE = "hate"
+    HATE_THREATENING = "hate/threatening"
+    HARASSMENT = "harassment"
+    HARASSMENT_THREATENING = "harassment/threatening"
+    SELF_HARM = "self-harm"
+    SELF_HARM_INTENT = "self-harm/intent"
+    SELF_HARM_INSTRUCTIONS = "self-harm/instructions"
+    SEXUAL = "sexual"
+    SEXUAL_MINORS = "sexual/minors"
+    VIOLENCE = "violence"
+    VIOLENCE_GRAPHIC = "violence/graphic"
+
+
+@dataclass(frozen=True, slots=True)
+class ToxicityConfig:
+    """Configuration for toxicity detection.
+
+    Attributes:
+        enabled: Whether toxicity detection is enabled.
+        use_full_check: Whether to use OpenAI Moderation API (slower but accurate).
+        block_threshold: Confidence threshold for blocking content.
+        categories_to_block: Categories that should trigger blocking.
+        categories_to_warn: Categories that should trigger warnings.
+    """
+
+    enabled: bool = True
+    use_full_check: bool = True
+    block_threshold: float = 0.7
+    categories_to_block: tuple[str, ...] = (
+        "hate",
+        "hate/threatening",
+        "harassment",
+        "harassment/threatening",
+        "self-harm",
+        "self-harm/intent",
+        "self-harm/instructions",
+        "sexual/minors",
+        "violence/graphic",
+    )
+    categories_to_warn: tuple[str, ...] = (
+        "sexual",
+        "violence",
+    )
+
+
+@dataclass(frozen=True, slots=True)
+class ToxicityResult:
+    """Result of toxicity check.
+
+    Attributes:
+        is_toxic: Whether any toxicity was detected.
+        categories: List of detected toxicity categories.
+        category_scores: Score (0-1) for each category checked.
+        confidence: Overall confidence score (max of detected scores).
+        should_block: Whether the content should be blocked.
+        should_warn: Whether a warning should be logged.
+        check_type: Type of check performed ("fast" or "full").
+    """
+
+    is_toxic: bool
+    categories: tuple[ToxicityCategory, ...]
+    category_scores: dict[str, float]
+    confidence: float
+    should_block: bool
+    should_warn: bool
+    check_type: str
+
+
+# Default configuration
+DEFAULT_CONFIG = ToxicityConfig()
+
+
+@lru_cache(maxsize=1)
+def _get_profanity_filter() -> object:
+    """Get initialized profanity filter (singleton).
+
+    Returns:
+        Configured profanity filter instance.
+
+    Note:
+        Uses lru_cache to avoid reinitializing on each call.
+    """
+    from better_profanity import profanity
+
+    profanity.load_censor_words()
+    return profanity
+
+
+async def check_toxicity_fast(text: str) -> ToxicityResult:
+    """Fast profanity check using word lists (~1ms).
+
+    This is a quick first-pass check that catches obvious profanity.
+    For comprehensive toxicity detection, use check_toxicity_full.
+
+    Args:
+        text: The text to check for profanity.
+
+    Returns:
+        ToxicityResult with fast check results.
+
+    Example:
+        >>> result = await check_toxicity_fast("Hello world")
+        >>> result.is_toxic
+        False
+    """
+    if not text or not text.strip():
+        return ToxicityResult(
+            is_toxic=False,
+            categories=(),
+            category_scores={},
+            confidence=0.0,
+            should_block=False,
+            should_warn=False,
+            check_type="fast",
+        )
+
+    try:
+        profanity = _get_profanity_filter()
+        contains_profanity = profanity.contains_profanity(text)
+
+        return ToxicityResult(
+            is_toxic=contains_profanity,
+            categories=(ToxicityCategory.HARASSMENT,) if contains_profanity else (),
+            category_scores={"harassment": 0.8 if contains_profanity else 0.0},
+            confidence=0.8 if contains_profanity else 0.0,
+            should_block=contains_profanity,
+            should_warn=contains_profanity,
+            check_type="fast",
+        )
+    except ImportError:
+        logger.warning(
+            "better-profanity not installed. Fast toxicity check disabled. "
+            "Install with: pip install better-profanity"
+        )
+        return ToxicityResult(
+            is_toxic=False,
+            categories=(),
+            category_scores={},
+            confidence=0.0,
+            should_block=False,
+            should_warn=False,
+            check_type="fast",
+        )
+    except Exception:
+        logger.exception("Error during fast toxicity check")
+        return ToxicityResult(
+            is_toxic=False,
+            categories=(),
+            category_scores={},
+            confidence=0.0,
+            should_block=False,
+            should_warn=False,
+            check_type="fast",
+        )
+
+
+def _openai_category_to_enum(category_name: str) -> ToxicityCategory | None:
+    """Convert OpenAI category name to ToxicityCategory enum.
+
+    Args:
+        category_name: OpenAI category name (uses underscores).
+
+    Returns:
+        Corresponding ToxicityCategory or None if not mapped.
+    """
+    # OpenAI uses underscores, our enum uses hyphens
+    normalized = category_name.replace("_", "-").replace("/", "/")
+
+    # Handle the slash variants
+    category_map = {
+        "hate": ToxicityCategory.HATE,
+        "hate-threatening": ToxicityCategory.HATE_THREATENING,
+        "harassment": ToxicityCategory.HARASSMENT,
+        "harassment-threatening": ToxicityCategory.HARASSMENT_THREATENING,
+        "self-harm": ToxicityCategory.SELF_HARM,
+        "self-harm-intent": ToxicityCategory.SELF_HARM_INTENT,
+        "self-harm-instructions": ToxicityCategory.SELF_HARM_INSTRUCTIONS,
+        "sexual": ToxicityCategory.SEXUAL,
+        "sexual-minors": ToxicityCategory.SEXUAL_MINORS,
+        "violence": ToxicityCategory.VIOLENCE,
+        "violence-graphic": ToxicityCategory.VIOLENCE_GRAPHIC,
+    }
+
+    return category_map.get(normalized)
+
+
+async def check_toxicity_full(
+    text: str,
+    openai_client: AsyncOpenAI,
+    config: ToxicityConfig = DEFAULT_CONFIG,
+) -> ToxicityResult:
+    """Full toxicity check using OpenAI Moderation API.
+
+    Provides comprehensive toxicity detection across multiple categories
+    with confidence scores.
+
+    Args:
+        text: The text to check for toxicity.
+        openai_client: Async OpenAI client for API calls.
+        config: Toxicity configuration.
+
+    Returns:
+        ToxicityResult with full moderation results.
+
+    Example:
+        >>> from openai import AsyncOpenAI
+        >>> client = AsyncOpenAI()
+        >>> result = await check_toxicity_full("Hello world", client)
+        >>> result.is_toxic
+        False
+    """
+    if not text or not text.strip():
+        return ToxicityResult(
+            is_toxic=False,
+            categories=(),
+            category_scores={},
+            confidence=0.0,
+            should_block=False,
+            should_warn=False,
+            check_type="full",
+        )
+
+    try:
+        response = await openai_client.moderations.create(input=text)
+        result = response.results[0]
+
+        categories: list[ToxicityCategory] = []
+        scores: dict[str, float] = {}
+        should_block = False
+        should_warn = False
+
+        # Process each category from the moderation response
+        categories_dict = result.categories.model_dump()
+        scores_dict = result.category_scores.model_dump()
+
+        for category_name, flagged in categories_dict.items():
+            score = scores_dict.get(category_name, 0.0)
+            # Normalize category name for storage
+            normalized_name = category_name.replace("_", "/")
+            scores[normalized_name] = score
+
+            if flagged:
+                toxicity_category = _openai_category_to_enum(category_name)
+                if toxicity_category:
+                    categories.append(toxicity_category)
+
+                    # Check if this category should block
+                    if normalized_name in config.categories_to_block:
+                        should_block = True
+                    elif normalized_name in config.categories_to_warn:
+                        should_warn = True
+
+        # Calculate confidence as max score of flagged categories
+        confidence = max(scores.values()) if scores else 0.0
+
+        # Apply threshold for blocking
+        if result.flagged and confidence >= config.block_threshold:
+            # Check if any flagged category is in the block list
+            for cat in categories:
+                if cat.value in config.categories_to_block:
+                    should_block = True
+                    break
+
+        return ToxicityResult(
+            is_toxic=result.flagged,
+            categories=tuple(categories),
+            category_scores=scores,
+            confidence=confidence,
+            should_block=should_block,
+            should_warn=should_warn or result.flagged,
+            check_type="full",
+        )
+
+    except Exception:
+        logger.exception("Error during OpenAI moderation API call")
+        # On error, return safe result (fail open for availability)
+        return ToxicityResult(
+            is_toxic=False,
+            categories=(),
+            category_scores={},
+            confidence=0.0,
+            should_block=False,
+            should_warn=False,
+            check_type="full",
+        )
+
+
+async def check_toxicity(
+    text: str,
+    openai_client: AsyncOpenAI | None = None,
+    use_full_check: bool = True,
+    config: ToxicityConfig = DEFAULT_CONFIG,
+) -> ToxicityResult:
+    """Check text for toxicity with configurable depth.
+
+    Performs a fast profanity check first, then optionally uses the
+    OpenAI Moderation API for comprehensive detection.
+
+    Args:
+        text: The text to check for toxicity.
+        openai_client: Async OpenAI client (required for full check).
+        use_full_check: Whether to use OpenAI Moderation API if fast check passes.
+        config: Toxicity configuration.
+
+    Returns:
+        ToxicityResult with combined check results.
+
+    Example:
+        >>> result = await check_toxicity("What is requirements traceability?")
+        >>> result.is_toxic
+        False
+        >>> result.should_block
+        False
+
+        >>> result = await check_toxicity("some inappropriate text", openai_client)
+        >>> result.check_type
+        'fast'  # or 'full' if fast check passed
+    """
+    if not config.enabled:
+        return ToxicityResult(
+            is_toxic=False,
+            categories=(),
+            category_scores={},
+            confidence=0.0,
+            should_block=False,
+            should_warn=False,
+            check_type="disabled",
+        )
+
+    # Always do fast check first
+    fast_result = await check_toxicity_fast(text)
+
+    # If fast check detects toxicity, return immediately
+    if fast_result.is_toxic:
+        logger.debug("Fast toxicity check flagged content")
+        return fast_result
+
+    # If fast check passes and full check requested, do OpenAI moderation
+    if use_full_check and openai_client is not None:
+        full_result = await check_toxicity_full(text, openai_client, config)
+        return full_result
+
+    # Return fast result if no full check
+    return fast_result

--- a/backend/tests/test_guardrails/test_output_filter.py
+++ b/backend/tests/test_guardrails/test_output_filter.py
@@ -1,0 +1,365 @@
+"""Tests for output content filtering."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from requirements_graphrag_api.guardrails.output_filter import (
+    BLOCKED_RESPONSE,
+    LOW_CONFIDENCE_DISCLAIMER,
+    OutputFilterConfig,
+    OutputFilterResult,
+    filter_output,
+)
+from requirements_graphrag_api.guardrails.toxicity import ToxicityConfig
+
+
+class TestOutputFilterConfig:
+    """Test OutputFilterConfig dataclass."""
+
+    def test_default_config(self):
+        config = OutputFilterConfig()
+        assert config.enabled is True
+        assert config.toxicity_enabled is True
+        assert config.add_disclaimers is True
+        assert config.confidence_threshold == 0.6
+
+    def test_custom_config(self):
+        config = OutputFilterConfig(
+            enabled=False,
+            confidence_threshold=0.8,
+        )
+        assert config.enabled is False
+        assert config.confidence_threshold == 0.8
+
+    def test_config_is_frozen(self):
+        config = OutputFilterConfig()
+        with pytest.raises(AttributeError):
+            config.enabled = False  # type: ignore[misc]
+
+
+class TestOutputFilterResult:
+    """Test OutputFilterResult dataclass."""
+
+    def test_result_creation(self):
+        result = OutputFilterResult(
+            is_safe=True,
+            filtered_content="Test output",
+            original_content="Test output",
+            warnings=(),
+            modifications=(),
+            confidence_score=0.9,
+            should_add_disclaimer=False,
+        )
+        assert result.is_safe is True
+        assert result.confidence_score == 0.9
+
+    def test_result_is_frozen(self):
+        result = OutputFilterResult(
+            is_safe=True,
+            filtered_content="Test",
+            original_content="Test",
+            warnings=(),
+            modifications=(),
+            confidence_score=0.9,
+            should_add_disclaimer=False,
+        )
+        with pytest.raises(AttributeError):
+            result.is_safe = False  # type: ignore[misc]
+
+
+class TestFilterOutput:
+    """Test output filtering functionality."""
+
+    @pytest.fixture
+    def mock_openai_client(self):
+        """Create a mock OpenAI client that returns clean results."""
+        client = AsyncMock()
+
+        mock_result = MagicMock()
+        mock_result.flagged = False
+        mock_result.categories = MagicMock()
+        mock_result.categories.model_dump.return_value = {
+            "hate": False,
+            "harassment": False,
+            "self_harm": False,
+            "sexual": False,
+            "violence": False,
+        }
+        mock_result.category_scores = MagicMock()
+        mock_result.category_scores.model_dump.return_value = {
+            "hate": 0.01,
+            "harassment": 0.01,
+            "self_harm": 0.01,
+            "sexual": 0.01,
+            "violence": 0.01,
+        }
+
+        mock_response = MagicMock()
+        mock_response.results = [mock_result]
+
+        client.moderations.create = AsyncMock(return_value=mock_response)
+        return client
+
+    @pytest.fixture
+    def mock_toxic_client(self):
+        """Create a mock client that returns toxic content."""
+        client = AsyncMock()
+
+        mock_result = MagicMock()
+        mock_result.flagged = True
+        mock_result.categories = MagicMock()
+        mock_result.categories.model_dump.return_value = {
+            "hate": True,
+            "harassment": True,
+            "self_harm": False,
+            "sexual": False,
+            "violence": False,
+        }
+        mock_result.category_scores = MagicMock()
+        mock_result.category_scores.model_dump.return_value = {
+            "hate": 0.9,
+            "harassment": 0.8,
+            "self_harm": 0.01,
+            "sexual": 0.01,
+            "violence": 0.01,
+        }
+
+        mock_response = MagicMock()
+        mock_response.results = [mock_result]
+
+        client.moderations.create = AsyncMock(return_value=mock_response)
+        return client
+
+    @pytest.mark.asyncio
+    async def test_clean_output_passes(self, mock_openai_client):
+        result = await filter_output(
+            output=(
+                "Requirements traceability is the ability to trace requirements "
+                "throughout the development lifecycle."
+            ),
+            original_query="What is requirements traceability?",
+            retrieved_sources=[{"content": "traceability definition"}],
+            openai_client=mock_openai_client,
+        )
+        assert result.is_safe is True
+        assert result.confidence_score > 0.5
+        assert result.filtered_content == result.original_content
+
+    @pytest.mark.asyncio
+    async def test_toxic_output_blocked(self, mock_toxic_client):
+        config = OutputFilterConfig()
+        toxicity_config = ToxicityConfig(use_full_check=True)
+
+        result = await filter_output(
+            output="Some hateful content here",
+            original_query="What is traceability?",
+            retrieved_sources=[{"content": "test"}],
+            config=config,
+            toxicity_config=toxicity_config,
+            openai_client=mock_toxic_client,
+        )
+        assert result.is_safe is False
+        assert result.blocked_reason == "toxicity"
+        assert result.filtered_content == config.blocked_response_message
+
+    @pytest.mark.asyncio
+    async def test_disabled_filter_passes_everything(self):
+        config = OutputFilterConfig(enabled=False)
+        result = await filter_output(
+            output="Any content",
+            original_query="Any query",
+            config=config,
+        )
+        assert result.is_safe is True
+        assert result.confidence_score == 1.0
+
+    @pytest.mark.asyncio
+    async def test_no_sources_reduces_confidence(self, mock_openai_client):
+        result = await filter_output(
+            output="A detailed answer about requirements.",
+            original_query="What is traceability?",
+            retrieved_sources=[],  # No sources
+            openai_client=mock_openai_client,
+        )
+        assert result.confidence_score < 1.0
+        assert any("No sources" in w for w in result.warnings)
+
+
+class TestConfidenceScoring:
+    """Test confidence score calculation."""
+
+    @pytest.mark.asyncio
+    async def test_hallucination_indicators_reduce_confidence(self):
+        config = OutputFilterConfig(toxicity_enabled=False)
+        result = await filter_output(
+            output="I think this might be related to requirements. I'm not sure though.",
+            original_query="What is traceability?",
+            retrieved_sources=[{"content": "test"}],
+            config=config,
+        )
+        assert result.confidence_score < 0.8
+        assert any("uncertainty" in w.lower() for w in result.warnings)
+
+    @pytest.mark.asyncio
+    async def test_confident_language_maintains_score(self):
+        config = OutputFilterConfig(toxicity_enabled=False)
+        result = await filter_output(
+            output=(
+                "According to the document, requirements traceability is defined "
+                "as the ability to trace requirements."
+            ),
+            original_query="What is traceability?",
+            retrieved_sources=[{"content": "test"}, {"content": "test2"}],
+            config=config,
+        )
+        assert result.confidence_score >= 0.7
+
+    @pytest.mark.asyncio
+    async def test_very_short_response_reduces_confidence(self):
+        config = OutputFilterConfig(toxicity_enabled=False)
+        result = await filter_output(
+            output="Yes.",
+            original_query="Is traceability important?",
+            retrieved_sources=[{"content": "test"}],
+            config=config,
+        )
+        assert result.confidence_score < 0.9
+        assert any("short" in w.lower() for w in result.warnings)
+
+    @pytest.mark.asyncio
+    async def test_limited_sources_warning(self):
+        config = OutputFilterConfig(toxicity_enabled=False)
+        result = await filter_output(
+            output="A detailed explanation about requirements management.",
+            original_query="What is requirements management?",
+            retrieved_sources=[{"content": "single source"}],  # Only one source
+            config=config,
+        )
+        assert any("limited" in w.lower() for w in result.warnings)
+
+
+class TestDisclaimerInjection:
+    """Test disclaimer injection for low-confidence answers."""
+
+    @pytest.mark.asyncio
+    async def test_disclaimer_added_for_low_confidence(self):
+        config = OutputFilterConfig(
+            toxicity_enabled=False,
+            confidence_threshold=0.8,
+            add_disclaimers=True,
+        )
+        result = await filter_output(
+            output="I think the answer might be related to traceability.",
+            original_query="What is traceability?",
+            retrieved_sources=[],  # No sources = lower confidence
+            config=config,
+        )
+        assert result.should_add_disclaimer is True
+        assert LOW_CONFIDENCE_DISCLAIMER in result.filtered_content
+        assert "Added low-confidence disclaimer" in result.modifications
+
+    @pytest.mark.asyncio
+    async def test_no_disclaimer_for_high_confidence(self):
+        config = OutputFilterConfig(
+            toxicity_enabled=False,
+            confidence_threshold=0.6,
+            add_disclaimers=True,
+        )
+        result = await filter_output(
+            output=(
+                "According to the document, requirements traceability is the ability "
+                "to trace requirements throughout the lifecycle."
+            ),
+            original_query="What is traceability?",
+            retrieved_sources=[
+                {"content": "source1"},
+                {"content": "source2"},
+                {"content": "source3"},
+            ],
+            config=config,
+        )
+        assert result.should_add_disclaimer is False
+        assert LOW_CONFIDENCE_DISCLAIMER not in result.filtered_content
+
+    @pytest.mark.asyncio
+    async def test_disclaimer_disabled_in_config(self):
+        config = OutputFilterConfig(
+            toxicity_enabled=False,
+            add_disclaimers=False,
+        )
+        result = await filter_output(
+            output="I'm not sure about this.",
+            original_query="Question",
+            retrieved_sources=[],
+            config=config,
+        )
+        assert result.should_add_disclaimer is False
+        assert LOW_CONFIDENCE_DISCLAIMER not in result.filtered_content
+
+
+class TestHallucinationIndicators:
+    """Test detection of hallucination indicators."""
+
+    @pytest.mark.asyncio
+    async def test_i_dont_know_detected(self):
+        config = OutputFilterConfig(toxicity_enabled=False)
+        result = await filter_output(
+            output="I don't know the exact definition, but it might be related to tracking.",
+            original_query="Define traceability",
+            retrieved_sources=[{"content": "test"}],
+            config=config,
+        )
+        assert result.confidence_score < 0.8
+        assert any("uncertainty" in w.lower() for w in result.warnings)
+
+    @pytest.mark.asyncio
+    async def test_i_believe_detected(self):
+        config = OutputFilterConfig(toxicity_enabled=False)
+        result = await filter_output(
+            output="I believe requirements traceability is important for project success.",
+            original_query="Why is traceability important?",
+            retrieved_sources=[{"content": "test"}],
+            config=config,
+        )
+        assert result.confidence_score < 1.0
+
+    @pytest.mark.asyncio
+    async def test_based_on_training_detected(self):
+        config = OutputFilterConfig(toxicity_enabled=False)
+        result = await filter_output(
+            output="Based on my training, I would say that requirements are important.",
+            original_query="Why are requirements important?",
+            retrieved_sources=[{"content": "test"}],
+            config=config,
+        )
+        assert result.confidence_score < 1.0
+        assert any("uncertainty" in w.lower() for w in result.warnings)
+
+    @pytest.mark.asyncio
+    async def test_according_to_boosts_confidence(self):
+        config = OutputFilterConfig(toxicity_enabled=False)
+        result = await filter_output(
+            output=(
+                "According to the retrieved documents, requirements traceability is "
+                "defined as the systematic tracking of requirements."
+            ),
+            original_query="Define traceability",
+            retrieved_sources=[{"content": "test"}, {"content": "test2"}],
+            config=config,
+        )
+        assert result.confidence_score >= 0.8
+
+
+class TestBlockedResponses:
+    """Test blocked response handling."""
+
+    def test_blocked_response_constant(self):
+        assert "apologize" in BLOCKED_RESPONSE.lower()
+        assert "requirements management" in BLOCKED_RESPONSE.lower()
+
+    def test_disclaimer_constant(self):
+        assert "Note" in LOW_CONFIDENCE_DISCLAIMER
+        assert "verify" in LOW_CONFIDENCE_DISCLAIMER.lower()

--- a/backend/tests/test_guardrails/test_topic_guard.py
+++ b/backend/tests/test_guardrails/test_topic_guard.py
@@ -1,0 +1,304 @@
+"""Tests for topic boundary enforcement."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from requirements_graphrag_api.guardrails.topic_guard import (
+    TopicCheckResult,
+    TopicClassification,
+    TopicGuardConfig,
+    check_topic_relevance,
+    check_topic_relevance_fast,
+)
+
+
+class TestTopicClassificationEnum:
+    """Test TopicClassification enum."""
+
+    def test_all_classifications_exist(self):
+        assert TopicClassification.IN_SCOPE == "in_scope"
+        assert TopicClassification.OUT_OF_SCOPE == "out_of_scope"
+        assert TopicClassification.BORDERLINE == "borderline"
+
+
+class TestTopicGuardConfig:
+    """Test TopicGuardConfig dataclass."""
+
+    def test_default_config(self):
+        config = TopicGuardConfig()
+        assert config.enabled is True
+        assert config.use_llm_classification is True
+        assert config.allow_borderline is True
+        assert "specialized assistant" in config.out_of_scope_response
+
+    def test_custom_config(self):
+        config = TopicGuardConfig(enabled=False, allow_borderline=False)
+        assert config.enabled is False
+        assert config.allow_borderline is False
+
+    def test_config_is_frozen(self):
+        config = TopicGuardConfig()
+        with pytest.raises(AttributeError):
+            config.enabled = False  # type: ignore[misc]
+
+
+class TestTopicCheckResult:
+    """Test TopicCheckResult dataclass."""
+
+    def test_result_creation(self):
+        result = TopicCheckResult(
+            classification=TopicClassification.IN_SCOPE,
+            confidence=0.9,
+            suggested_response=None,
+            reasoning="Contains in-scope topic",
+            check_type="keyword",
+        )
+        assert result.classification == TopicClassification.IN_SCOPE
+        assert result.confidence == 0.9
+
+    def test_result_is_frozen(self):
+        result = TopicCheckResult(
+            classification=TopicClassification.IN_SCOPE,
+            confidence=0.9,
+            suggested_response=None,
+            reasoning="Test",
+            check_type="keyword",
+        )
+        with pytest.raises(AttributeError):
+            result.classification = TopicClassification.OUT_OF_SCOPE  # type: ignore[misc]
+
+
+class TestTopicRelevanceFast:
+    """Test fast keyword-based topic relevance check."""
+
+    @pytest.mark.asyncio
+    async def test_in_scope_requirements_questions(self):
+        queries = [
+            "What is requirements traceability?",
+            "How do I create a traceability matrix?",
+            "Explain systems engineering best practices",
+            "What are functional requirements?",
+            "How does Jama Connect handle baselines?",
+        ]
+        for query in queries:
+            result = await check_topic_relevance_fast(query)
+            assert result.classification == TopicClassification.IN_SCOPE, (
+                f"Should be in scope: {query}"
+            )
+            assert result.confidence >= 0.9
+
+    @pytest.mark.asyncio
+    async def test_out_of_scope_politics(self):
+        queries = [
+            "What do you think about the election?",
+            "Which political party is better?",
+            "Tell me about politics",
+        ]
+        for query in queries:
+            result = await check_topic_relevance_fast(query)
+            assert result.classification == TopicClassification.OUT_OF_SCOPE, (
+                f"Should be out of scope: {query}"
+            )
+            assert result.suggested_response is not None
+
+    @pytest.mark.asyncio
+    async def test_out_of_scope_medical(self):
+        result = await check_topic_relevance_fast("What medication should I take for my headache?")
+        assert result.classification == TopicClassification.OUT_OF_SCOPE
+        assert result.suggested_response is not None
+
+    @pytest.mark.asyncio
+    async def test_out_of_scope_financial(self):
+        result = await check_topic_relevance_fast("Should I invest in cryptocurrency?")
+        assert result.classification == TopicClassification.OUT_OF_SCOPE
+
+    @pytest.mark.asyncio
+    async def test_out_of_scope_entertainment(self):
+        queries = [
+            "What's your favorite movie?",
+            "Tell me a joke",
+            "What sports team is the best?",
+        ]
+        for query in queries:
+            result = await check_topic_relevance_fast(query)
+            assert result.classification == TopicClassification.OUT_OF_SCOPE, (
+                f"Should be out of scope: {query}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_borderline_ambiguous_query(self):
+        # Query that doesn't match any keyword
+        result = await check_topic_relevance_fast("How do I do this thing?")
+        assert result.classification == TopicClassification.BORDERLINE
+        assert result.confidence == 0.5
+
+    @pytest.mark.asyncio
+    async def test_empty_string(self):
+        result = await check_topic_relevance_fast("")
+        assert result.classification == TopicClassification.IN_SCOPE
+        assert result.confidence == 0.5
+
+    @pytest.mark.asyncio
+    async def test_redirect_response_content(self):
+        result = await check_topic_relevance_fast("Tell me about politics")
+        assert result.suggested_response is not None
+        assert (
+            "Requirements" in result.suggested_response
+            or "requirements" in result.suggested_response
+        )
+
+
+class TestTopicRelevanceWithLLM:
+    """Test topic relevance check with LLM classification."""
+
+    @pytest.fixture
+    def mock_llm_in_scope(self):
+        """Mock LLM that returns IN_SCOPE."""
+        llm = AsyncMock()
+        response = MagicMock()
+        response.content = "IN_SCOPE"
+        llm.ainvoke = AsyncMock(return_value=response)
+        return llm
+
+    @pytest.fixture
+    def mock_llm_out_of_scope(self):
+        """Mock LLM that returns OUT_OF_SCOPE."""
+        llm = AsyncMock()
+        response = MagicMock()
+        response.content = "OUT_OF_SCOPE"
+        llm.ainvoke = AsyncMock(return_value=response)
+        return llm
+
+    @pytest.fixture
+    def mock_llm_borderline(self):
+        """Mock LLM that returns BORDERLINE."""
+        llm = AsyncMock()
+        response = MagicMock()
+        response.content = "BORDERLINE"
+        llm.ainvoke = AsyncMock(return_value=response)
+        return llm
+
+    @pytest.mark.asyncio
+    async def test_llm_classification_in_scope(self, mock_llm_in_scope):
+        # Ambiguous query that needs LLM
+        result = await check_topic_relevance(
+            "How do I manage this process?",
+            llm=mock_llm_in_scope,
+        )
+        assert result.classification == TopicClassification.IN_SCOPE
+        assert result.check_type == "llm"
+
+    @pytest.mark.asyncio
+    async def test_llm_classification_out_of_scope(self, mock_llm_out_of_scope):
+        # Ambiguous query that LLM classifies as out of scope
+        result = await check_topic_relevance(
+            "What should I do today?",
+            llm=mock_llm_out_of_scope,
+        )
+        assert result.classification == TopicClassification.OUT_OF_SCOPE
+        assert result.check_type == "llm"
+        assert result.suggested_response is not None
+
+    @pytest.mark.asyncio
+    async def test_llm_classification_borderline(self, mock_llm_borderline):
+        result = await check_topic_relevance(
+            "How do I organize my team?",
+            llm=mock_llm_borderline,
+        )
+        assert result.classification == TopicClassification.BORDERLINE
+
+    @pytest.mark.asyncio
+    async def test_keyword_match_skips_llm(self, mock_llm_in_scope):
+        # Clear in-scope query shouldn't need LLM
+        result = await check_topic_relevance(
+            "What is requirements traceability?",
+            llm=mock_llm_in_scope,
+        )
+        assert result.check_type == "keyword"
+        # LLM should not have been called
+        mock_llm_in_scope.ainvoke.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_no_llm_provided(self):
+        # Ambiguous query without LLM falls back to keyword result
+        result = await check_topic_relevance(
+            "How do I manage this?",
+            llm=None,
+        )
+        assert result.check_type == "keyword"
+        assert result.classification == TopicClassification.BORDERLINE
+
+    @pytest.mark.asyncio
+    async def test_llm_error_falls_back(self, mock_llm_in_scope):
+        mock_llm_in_scope.ainvoke.side_effect = Exception("LLM error")
+        result = await check_topic_relevance(
+            "Ambiguous question here",
+            llm=mock_llm_in_scope,
+        )
+        # Should fall back to keyword result
+        assert result.check_type == "keyword"
+
+    @pytest.mark.asyncio
+    async def test_disabled_config(self):
+        config = TopicGuardConfig(enabled=False)
+        result = await check_topic_relevance(
+            "Tell me about politics",
+            config=config,
+        )
+        # Should be allowed when disabled
+        assert result.classification == TopicClassification.IN_SCOPE
+        assert result.check_type == "disabled"
+
+
+class TestKeywordMatching:
+    """Test specific keyword matching behavior."""
+
+    @pytest.mark.asyncio
+    async def test_case_insensitive_matching(self):
+        queries = [
+            "REQUIREMENTS TRACEABILITY",
+            "Requirements Traceability",
+            "requirements traceability",
+        ]
+        for query in queries:
+            result = await check_topic_relevance_fast(query)
+            assert result.classification == TopicClassification.IN_SCOPE
+
+    @pytest.mark.asyncio
+    async def test_partial_word_matching(self):
+        # "iso " should match but not words containing "iso"
+        result = await check_topic_relevance_fast("ISO 26262 compliance")
+        assert result.classification == TopicClassification.IN_SCOPE
+
+    @pytest.mark.asyncio
+    async def test_jama_software_in_scope(self):
+        queries = [
+            "How does Jama Software work?",
+            "Jama Connect configuration",
+        ]
+        for query in queries:
+            result = await check_topic_relevance_fast(query)
+            assert result.classification == TopicClassification.IN_SCOPE
+
+
+class TestRedirectResponses:
+    """Test redirect response generation."""
+
+    @pytest.mark.asyncio
+    async def test_redirect_response_has_suggestions(self):
+        result = await check_topic_relevance_fast("Tell me a joke")
+        response = result.suggested_response
+        assert response is not None
+        # Should suggest in-scope topics
+        assert "traceability" in response.lower() or "requirements" in response.lower()
+
+    @pytest.mark.asyncio
+    async def test_redirect_response_is_polite(self):
+        result = await check_topic_relevance_fast("What's the weather?")
+        response = result.suggested_response
+        assert response is not None
+        # Should be polite, not confrontational
+        assert "specialized" in response.lower() or "help" in response.lower()

--- a/backend/tests/test_guardrails/test_toxicity.py
+++ b/backend/tests/test_guardrails/test_toxicity.py
@@ -1,0 +1,328 @@
+"""Tests for toxicity detection."""
+
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from requirements_graphrag_api.guardrails.toxicity import (
+    ToxicityCategory,
+    ToxicityConfig,
+    ToxicityResult,
+    check_toxicity,
+    check_toxicity_fast,
+    check_toxicity_full,
+)
+
+
+class TestToxicityFastCheck:
+    """Test fast profanity check using word lists."""
+
+    @pytest.mark.asyncio
+    async def test_clean_text_passes(self):
+        result = await check_toxicity_fast("What is requirements traceability?")
+        assert result.is_toxic is False
+        assert result.should_block is False
+        assert result.check_type == "fast"
+        assert len(result.categories) == 0
+
+    @pytest.mark.asyncio
+    async def test_profanity_detected(self):
+        # Using mild profanity that better-profanity should catch
+        result = await check_toxicity_fast("This is damn annoying")
+        assert result.is_toxic is True
+        assert result.should_block is True
+        assert result.check_type == "fast"
+        assert ToxicityCategory.HARASSMENT in result.categories
+
+    @pytest.mark.asyncio
+    async def test_empty_string(self):
+        result = await check_toxicity_fast("")
+        assert result.is_toxic is False
+        assert result.confidence == 0.0
+
+    @pytest.mark.asyncio
+    async def test_whitespace_only(self):
+        result = await check_toxicity_fast("   \n\t   ")
+        assert result.is_toxic is False
+
+    @pytest.mark.asyncio
+    async def test_technical_question_clean(self):
+        queries = [
+            "How do I manage system requirements?",
+            "Explain the V-model for product development",
+            "What are the best practices for requirements documentation?",
+        ]
+        for query in queries:
+            result = await check_toxicity_fast(query)
+            assert result.is_toxic is False, f"False positive on: {query}"
+
+
+class TestToxicityFullCheck:
+    """Test full toxicity check using OpenAI Moderation API."""
+
+    @pytest.fixture
+    def mock_openai_client(self):
+        """Create a mock OpenAI client."""
+        client = AsyncMock()
+
+        # Create mock moderation response
+        mock_result = MagicMock()
+        mock_result.flagged = False
+        mock_result.categories = MagicMock()
+        mock_result.categories.model_dump.return_value = {
+            "hate": False,
+            "hate_threatening": False,
+            "harassment": False,
+            "harassment_threatening": False,
+            "self_harm": False,
+            "self_harm_intent": False,
+            "self_harm_instructions": False,
+            "sexual": False,
+            "sexual_minors": False,
+            "violence": False,
+            "violence_graphic": False,
+        }
+        mock_result.category_scores = MagicMock()
+        mock_result.category_scores.model_dump.return_value = {
+            "hate": 0.01,
+            "hate_threatening": 0.001,
+            "harassment": 0.02,
+            "harassment_threatening": 0.001,
+            "self_harm": 0.001,
+            "self_harm_intent": 0.001,
+            "self_harm_instructions": 0.001,
+            "sexual": 0.01,
+            "sexual_minors": 0.001,
+            "violence": 0.01,
+            "violence_graphic": 0.001,
+        }
+
+        mock_response = MagicMock()
+        mock_response.results = [mock_result]
+
+        client.moderations.create = AsyncMock(return_value=mock_response)
+        return client
+
+    @pytest.fixture
+    def mock_toxic_client(self):
+        """Create a mock client that returns toxic content."""
+        client = AsyncMock()
+
+        mock_result = MagicMock()
+        mock_result.flagged = True
+        mock_result.categories = MagicMock()
+        mock_result.categories.model_dump.return_value = {
+            "hate": True,
+            "hate_threatening": False,
+            "harassment": True,
+            "harassment_threatening": False,
+            "self_harm": False,
+            "self_harm_intent": False,
+            "self_harm_instructions": False,
+            "sexual": False,
+            "sexual_minors": False,
+            "violence": False,
+            "violence_graphic": False,
+        }
+        mock_result.category_scores = MagicMock()
+        mock_result.category_scores.model_dump.return_value = {
+            "hate": 0.85,
+            "hate_threatening": 0.1,
+            "harassment": 0.75,
+            "harassment_threatening": 0.05,
+            "self_harm": 0.01,
+            "self_harm_intent": 0.01,
+            "self_harm_instructions": 0.01,
+            "sexual": 0.01,
+            "sexual_minors": 0.001,
+            "violence": 0.02,
+            "violence_graphic": 0.01,
+        }
+
+        mock_response = MagicMock()
+        mock_response.results = [mock_result]
+
+        client.moderations.create = AsyncMock(return_value=mock_response)
+        return client
+
+    @pytest.mark.asyncio
+    async def test_clean_text_passes_full_check(self, mock_openai_client):
+        result = await check_toxicity_full(
+            "What is requirements traceability?",
+            mock_openai_client,
+        )
+        assert result.is_toxic is False
+        assert result.should_block is False
+        assert result.check_type == "full"
+
+    @pytest.mark.asyncio
+    async def test_toxic_text_blocked(self, mock_toxic_client):
+        result = await check_toxicity_full(
+            "Some hateful content here",
+            mock_toxic_client,
+        )
+        assert result.is_toxic is True
+        assert result.should_block is True
+        assert result.check_type == "full"
+        assert len(result.categories) > 0
+
+    @pytest.mark.asyncio
+    async def test_empty_string_full_check(self, mock_openai_client):
+        result = await check_toxicity_full("", mock_openai_client)
+        assert result.is_toxic is False
+        assert result.confidence == 0.0
+
+    @pytest.mark.asyncio
+    async def test_category_scores_populated(self, mock_openai_client):
+        result = await check_toxicity_full("Test content", mock_openai_client)
+        assert len(result.category_scores) > 0
+
+    @pytest.mark.asyncio
+    async def test_api_error_returns_safe_result(self, mock_openai_client):
+        mock_openai_client.moderations.create.side_effect = Exception("API error")
+        result = await check_toxicity_full("Test content", mock_openai_client)
+        assert result.is_toxic is False
+        assert result.should_block is False
+
+
+class TestToxicityCheck:
+    """Test combined toxicity check function."""
+
+    @pytest.fixture
+    def mock_openai_client(self):
+        """Create a mock OpenAI client that returns clean results."""
+        client = AsyncMock()
+
+        mock_result = MagicMock()
+        mock_result.flagged = False
+        mock_result.categories = MagicMock()
+        mock_result.categories.model_dump.return_value = {
+            "hate": False,
+            "harassment": False,
+            "self_harm": False,
+            "sexual": False,
+            "violence": False,
+        }
+        mock_result.category_scores = MagicMock()
+        mock_result.category_scores.model_dump.return_value = {
+            "hate": 0.01,
+            "harassment": 0.01,
+            "self_harm": 0.01,
+            "sexual": 0.01,
+            "violence": 0.01,
+        }
+
+        mock_response = MagicMock()
+        mock_response.results = [mock_result]
+
+        client.moderations.create = AsyncMock(return_value=mock_response)
+        return client
+
+    @pytest.mark.asyncio
+    async def test_fast_check_only_when_no_client(self):
+        result = await check_toxicity("Clean text", openai_client=None)
+        assert result.check_type == "fast"
+
+    @pytest.mark.asyncio
+    async def test_full_check_when_client_provided(self, mock_openai_client):
+        result = await check_toxicity(
+            "Clean text",
+            openai_client=mock_openai_client,
+            use_full_check=True,
+        )
+        assert result.check_type == "full"
+
+    @pytest.mark.asyncio
+    async def test_fast_check_blocks_before_full_check(self, mock_openai_client):
+        # Profanity should be caught by fast check
+        result = await check_toxicity(
+            "This is damn annoying",
+            openai_client=mock_openai_client,
+        )
+        # Fast check catches it, so full check never runs
+        assert result.check_type == "fast"
+        assert result.is_toxic is True
+
+    @pytest.mark.asyncio
+    async def test_disabled_config_returns_clean(self):
+        config = ToxicityConfig(enabled=False)
+        result = await check_toxicity("Any text", config=config)
+        assert result.is_toxic is False
+        assert result.check_type == "disabled"
+
+
+class TestToxicityCategory:
+    """Test ToxicityCategory enum."""
+
+    def test_all_categories_exist(self):
+        expected = [
+            "hate",
+            "hate/threatening",
+            "harassment",
+            "harassment/threatening",
+            "self-harm",
+            "self-harm/intent",
+            "self-harm/instructions",
+            "sexual",
+            "sexual/minors",
+            "violence",
+            "violence/graphic",
+        ]
+        for cat in expected:
+            assert ToxicityCategory(cat) is not None
+
+
+class TestToxicityConfig:
+    """Test ToxicityConfig dataclass."""
+
+    def test_default_config(self):
+        config = ToxicityConfig()
+        assert config.enabled is True
+        assert config.use_full_check is True
+        assert config.block_threshold == 0.7
+        assert "hate" in config.categories_to_block
+
+    def test_custom_config(self):
+        config = ToxicityConfig(
+            enabled=False,
+            block_threshold=0.5,
+        )
+        assert config.enabled is False
+        assert config.block_threshold == 0.5
+
+    def test_config_is_frozen(self):
+        config = ToxicityConfig()
+        with pytest.raises(AttributeError):
+            config.enabled = False  # type: ignore[misc]
+
+
+class TestToxicityResult:
+    """Test ToxicityResult dataclass."""
+
+    def test_result_creation(self):
+        result = ToxicityResult(
+            is_toxic=True,
+            categories=(ToxicityCategory.HARASSMENT,),
+            category_scores={"harassment": 0.8},
+            confidence=0.8,
+            should_block=True,
+            should_warn=True,
+            check_type="fast",
+        )
+        assert result.is_toxic is True
+        assert result.confidence == 0.8
+
+    def test_result_is_frozen(self):
+        result = ToxicityResult(
+            is_toxic=False,
+            categories=(),
+            category_scores={},
+            confidence=0.0,
+            should_block=False,
+            should_warn=False,
+            check_type="fast",
+        )
+        with pytest.raises(AttributeError):
+            result.is_toxic = True  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Implements Phase 2 content moderation guardrails for the GraphRAG API:

- **Toxicity detection** - Dual-layer approach with fast profanity check (~1ms) and OpenAI Moderation API fallback
- **Topic boundary enforcement** - Keeps conversations focused on requirements management with polite redirects
- **Output content filtering** - Catches toxic LLM responses and adds disclaimers to low-confidence answers

## Changes

### New Files
- `guardrails/toxicity.py` - 11 toxicity categories aligned with OpenAI Moderation
- `guardrails/topic_guard.py` - Keyword + LLM-based topic classification
- `guardrails/output_filter.py` - Confidence scoring and disclaimer injection

### Updated Files
- `guardrails/__init__.py` - Exports Phase 2 functions
- `guardrails/events.py` - New event creation helpers

### Tests
- `test_toxicity.py` - 20 tests
- `test_topic_guard.py` - 26 tests
- `test_output_filter.py` - 22 tests

## Test plan
- [x] All 178 guardrails tests pass
- [x] All 413 total tests pass
- [x] Ruff linting passes
- [ ] CI passes

Closes #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)