### PR TITLE
feat(auth): implement Phase 3 access control guardrails

### DIFF
--- a/backend/src/requirements_graphrag_api/auth/__init__.py
+++ b/backend/src/requirements_graphrag_api/auth/__init__.py
@@ -1,0 +1,130 @@
+"""Authentication and authorization module for GraphRAG API.
+
+This module provides enterprise-grade access control:
+- API key authentication with secure hashing
+- Scope-based authorization for fine-grained access control
+- Request context management for route handlers
+- Comprehensive audit logging for compliance
+
+Phase 3 of the guardrails implementation.
+
+Usage:
+    # In FastAPI app setup
+    from requirements_graphrag_api.auth import (
+        AuthMiddleware,
+        InMemoryAPIKeyStore,
+        configure_audit_logging,
+    )
+
+    app.state.api_key_store = InMemoryAPIKeyStore()
+    app.add_middleware(AuthMiddleware, require_auth=False)
+    configure_audit_logging()
+
+    # In route handlers
+    from requirements_graphrag_api.auth import (
+        get_current_client,
+        require_scopes,
+        Scope,
+    )
+
+    @router.post("/chat")
+    async def chat(
+        request: Request,
+        client: APIKeyInfo = Depends(require_scopes(Scope.CHAT))
+    ):
+        ...
+
+    # Key management
+    from requirements_graphrag_api.auth import generate_api_key, hash_api_key
+
+    raw_key = generate_api_key()  # rgapi_<random>
+    key_hash = hash_api_key(raw_key)  # Store this in database
+"""
+
+from __future__ import annotations
+
+from requirements_graphrag_api.auth.api_key import (
+    API_KEY_HEADER_NAME,
+    API_KEY_PREFIX,
+    TIER_RATE_LIMITS,
+    APIKeyInfo,
+    APIKeyStore,
+    APIKeyTier,
+    InMemoryAPIKeyStore,
+    create_anonymous_key_info,
+    generate_api_key,
+    hash_api_key,
+    validate_api_key_format,
+    verify_api_key,
+)
+from requirements_graphrag_api.auth.audit import (
+    AuditEvent,
+    AuditEventType,
+    AuditHandler,
+    AuditLogger,
+    LoggingAuditHandler,
+    audit_logger,
+    configure_audit_logging,
+    log_api_error,
+    log_api_request,
+    log_api_response,
+    log_auth_failure,
+    log_auth_success,
+    log_guardrail_event,
+    log_rate_limit_event,
+)
+from requirements_graphrag_api.auth.middleware import (
+    AuthMiddleware,
+    get_current_client,
+    get_current_request_id,
+    get_request_duration_ms,
+)
+from requirements_graphrag_api.auth.scopes import (
+    DEFAULT_TIER_SCOPES,
+    ENDPOINT_SCOPES,
+    Scope,
+    ScopeChecker,
+    check_scopes,
+    require_scope,
+    require_scopes,
+)
+
+__all__ = [
+    "API_KEY_HEADER_NAME",
+    "API_KEY_PREFIX",
+    "DEFAULT_TIER_SCOPES",
+    "ENDPOINT_SCOPES",
+    "TIER_RATE_LIMITS",
+    "APIKeyInfo",
+    "APIKeyStore",
+    "APIKeyTier",
+    "AuditEvent",
+    "AuditEventType",
+    "AuditHandler",
+    "AuditLogger",
+    "AuthMiddleware",
+    "InMemoryAPIKeyStore",
+    "LoggingAuditHandler",
+    "Scope",
+    "ScopeChecker",
+    "audit_logger",
+    "check_scopes",
+    "configure_audit_logging",
+    "create_anonymous_key_info",
+    "generate_api_key",
+    "get_current_client",
+    "get_current_request_id",
+    "get_request_duration_ms",
+    "hash_api_key",
+    "log_api_error",
+    "log_api_request",
+    "log_api_response",
+    "log_auth_failure",
+    "log_auth_success",
+    "log_guardrail_event",
+    "log_rate_limit_event",
+    "require_scope",
+    "require_scopes",
+    "validate_api_key_format",
+    "verify_api_key",
+]

--- a/backend/src/requirements_graphrag_api/auth/api_key.py
+++ b/backend/src/requirements_graphrag_api/auth/api_key.py
@@ -1,0 +1,398 @@
+"""API key generation, validation, and management.
+
+This module provides secure API key handling for the GraphRAG API:
+- Key generation with cryptographically secure random bytes
+- SHA-256 hashing for secure storage (keys are never stored in plaintext)
+- Format validation and tier-based access control
+- Abstract store interface with in-memory implementation for dev/testing
+
+Security considerations:
+- Keys use 32 bytes of entropy (256 bits) for cryptographic strength
+- Hash comparison uses constant-time operations to prevent timing attacks
+- Keys are prefixed with 'rgapi_' for easy identification
+
+Usage:
+    # Generate a new key
+    raw_key = generate_api_key()  # rgapi_<random>
+    key_hash = hash_api_key(raw_key)  # Store this, not raw_key
+
+    # Validate incoming key
+    if validate_api_key_format(incoming_key):
+        info = await store.get_by_hash(hash_api_key(incoming_key))
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import secrets
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+
+from fastapi import HTTPException, Security, status
+from fastapi.security import APIKeyHeader
+
+# API key header configuration
+API_KEY_HEADER_NAME = "X-API-Key"
+API_KEY_PREFIX = "rgapi_"  # Requirements GraphRAG API
+
+# Security header for FastAPI dependency injection
+api_key_header = APIKeyHeader(name=API_KEY_HEADER_NAME, auto_error=False)
+
+
+class APIKeyTier(StrEnum):
+    """API key access tiers with different rate limits.
+
+    Tiers define the rate limits and capabilities available to API consumers:
+    - FREE: Basic access for evaluation and small projects
+    - STANDARD: Production access for typical workloads
+    - PREMIUM: High-volume access with priority support
+    - ENTERPRISE: Custom limits and SLA guarantees
+    """
+
+    FREE = "free"  # 10 requests/min
+    STANDARD = "standard"  # 50 requests/min
+    PREMIUM = "premium"  # 200 requests/min
+    ENTERPRISE = "enterprise"  # Custom limits
+
+
+# Default rate limits per tier (requests per minute)
+TIER_RATE_LIMITS: dict[APIKeyTier, str] = {
+    APIKeyTier.FREE: "10/minute",
+    APIKeyTier.STANDARD: "50/minute",
+    APIKeyTier.PREMIUM: "200/minute",
+    APIKeyTier.ENTERPRISE: "1000/minute",
+}
+
+
+@dataclass(frozen=True, slots=True)
+class APIKeyInfo:
+    """Information associated with an API key.
+
+    This dataclass is immutable (frozen) to ensure thread-safety when
+    the same key info is accessed from multiple requests.
+
+    Attributes:
+        key_id: Unique identifier for the key (not the key itself).
+        name: Human-readable name for dashboard display.
+        tier: Access tier determining rate limits and capabilities.
+        organization: Optional organization name for enterprise keys.
+        created_at: When the key was created (UTC).
+        expires_at: Optional expiration date (UTC), None means no expiry.
+        rate_limit: Rate limit string (e.g., "50/minute").
+        is_active: Whether the key is active (can be revoked).
+        scopes: Tuple of authorized scopes (e.g., ("chat", "search")).
+        metadata: Additional metadata for custom use cases.
+    """
+
+    key_id: str
+    name: str
+    tier: APIKeyTier
+    organization: str | None
+    created_at: datetime
+    expires_at: datetime | None
+    rate_limit: str
+    is_active: bool
+    scopes: tuple[str, ...]
+    metadata: dict = field(default_factory=dict)
+
+
+def generate_api_key() -> str:
+    """Generate a new API key.
+
+    Creates a cryptographically secure API key using Python's secrets module.
+    The key format is: rgapi_<32 random bytes as base64url>
+
+    Returns:
+        A new API key string (~50 characters total).
+
+    Example:
+        >>> key = generate_api_key()
+        >>> key.startswith("rgapi_")
+        True
+        >>> len(key) > 40
+        True
+    """
+    random_bytes = secrets.token_urlsafe(32)
+    return f"{API_KEY_PREFIX}{random_bytes}"
+
+
+def hash_api_key(api_key: str) -> str:
+    """Hash an API key for secure storage.
+
+    Uses SHA-256 for fast lookups while maintaining security.
+    The prefix is stripped before hashing to normalize keys.
+
+    Args:
+        api_key: The raw API key to hash.
+
+    Returns:
+        Hexadecimal SHA-256 hash of the key (64 characters).
+
+    Note:
+        The hash is deterministic - the same key always produces
+        the same hash, allowing for lookup in the database.
+    """
+    # Strip prefix if present for consistent hashing
+    key_value = api_key.removeprefix(API_KEY_PREFIX)
+    return hashlib.sha256(key_value.encode()).hexdigest()
+
+
+def validate_api_key_format(api_key: str) -> bool:
+    """Validate API key format without checking database.
+
+    Performs fast local validation to reject obviously invalid keys
+    before hitting the database.
+
+    Args:
+        api_key: The API key to validate.
+
+    Returns:
+        True if the format is valid, False otherwise.
+    """
+    if not api_key:
+        return False
+    if not api_key.startswith(API_KEY_PREFIX):
+        return False
+    if len(api_key) < 40:  # Minimum reasonable length (prefix + some chars)
+        return False
+    # Ensure only valid base64url characters after prefix
+    key_part = api_key.removeprefix(API_KEY_PREFIX)
+    return all(c.isalnum() or c in "-_" for c in key_part)
+
+
+def compare_hashes_constant_time(hash1: str, hash2: str) -> bool:
+    """Compare two hashes using constant-time comparison.
+
+    Prevents timing attacks by ensuring the comparison takes
+    the same amount of time regardless of where differences occur.
+
+    Args:
+        hash1: First hash to compare.
+        hash2: Second hash to compare.
+
+    Returns:
+        True if hashes are equal, False otherwise.
+    """
+    return hmac.compare_digest(hash1.encode(), hash2.encode())
+
+
+class APIKeyStore:
+    """Abstract base for API key storage.
+
+    This interface defines the contract for API key storage backends.
+    In production, implement with a database backend (e.g., PostgreSQL, Neo4j).
+
+    Subclasses must implement:
+    - get_by_hash: Retrieve key info by its hash
+    - create: Store a new API key
+    - revoke: Revoke an existing key
+    """
+
+    async def get_by_hash(self, key_hash: str) -> APIKeyInfo | None:
+        """Retrieve API key info by hash.
+
+        Args:
+            key_hash: SHA-256 hash of the API key.
+
+        Returns:
+            APIKeyInfo if found, None otherwise.
+        """
+        raise NotImplementedError
+
+    async def create(self, api_key: str, info: APIKeyInfo) -> None:
+        """Store a new API key.
+
+        Args:
+            api_key: The raw API key (will be hashed before storage).
+            info: The APIKeyInfo to associate with the key.
+        """
+        raise NotImplementedError
+
+    async def revoke(self, key_id: str) -> bool:
+        """Revoke an API key by its ID.
+
+        Args:
+            key_id: The unique identifier of the key to revoke.
+
+        Returns:
+            True if the key was found and revoked, False otherwise.
+        """
+        raise NotImplementedError
+
+    async def list_keys(self, organization: str | None = None) -> list[APIKeyInfo]:
+        """List all API keys, optionally filtered by organization.
+
+        Args:
+            organization: Optional organization to filter by.
+
+        Returns:
+            List of APIKeyInfo objects.
+        """
+        raise NotImplementedError
+
+
+class InMemoryAPIKeyStore(APIKeyStore):
+    """In-memory API key store for development and testing.
+
+    This implementation stores keys in a dictionary, suitable for:
+    - Local development
+    - Unit and integration testing
+    - Single-instance deployments without persistence
+
+    Warning:
+        Keys are lost when the process restarts. Use a database-backed
+        store for production deployments.
+    """
+
+    def __init__(self) -> None:
+        """Initialize an empty key store."""
+        self._keys: dict[str, APIKeyInfo] = {}
+
+    async def get_by_hash(self, key_hash: str) -> APIKeyInfo | None:
+        """Retrieve API key info by hash."""
+        return self._keys.get(key_hash)
+
+    async def create(self, api_key: str, info: APIKeyInfo) -> None:
+        """Store a new API key."""
+        key_hash = hash_api_key(api_key)
+        self._keys[key_hash] = info
+
+    async def revoke(self, key_id: str) -> bool:
+        """Revoke an API key by marking it as inactive."""
+        for key_hash, info in list(self._keys.items()):
+            if info.key_id == key_id:
+                # Create new info with is_active=False (immutable dataclass)
+                revoked_info = APIKeyInfo(
+                    key_id=info.key_id,
+                    name=info.name,
+                    tier=info.tier,
+                    organization=info.organization,
+                    created_at=info.created_at,
+                    expires_at=info.expires_at,
+                    rate_limit=info.rate_limit,
+                    is_active=False,
+                    scopes=info.scopes,
+                    metadata=info.metadata,
+                )
+                self._keys[key_hash] = revoked_info
+                return True
+        return False
+
+    async def list_keys(self, organization: str | None = None) -> list[APIKeyInfo]:
+        """List all API keys, optionally filtered by organization."""
+        if organization is None:
+            return list(self._keys.values())
+        return [info for info in self._keys.values() if info.organization == organization]
+
+
+def create_anonymous_key_info() -> APIKeyInfo:
+    """Create an APIKeyInfo for anonymous (unauthenticated) access.
+
+    Used when authentication is disabled or for public endpoints.
+
+    Returns:
+        APIKeyInfo with limited anonymous access.
+    """
+    return APIKeyInfo(
+        key_id="anonymous",
+        name="Anonymous",
+        tier=APIKeyTier.FREE,
+        organization=None,
+        created_at=datetime.now(UTC),
+        expires_at=None,
+        rate_limit="20/minute",
+        is_active=True,
+        scopes=("chat", "search"),
+        metadata={},
+    )
+
+
+async def verify_api_key(
+    api_key: str | None = Security(api_key_header),
+    *,
+    key_store: APIKeyStore | None = None,
+    require_auth: bool = False,
+) -> APIKeyInfo:
+    """Verify API key and return associated info.
+
+    This function serves as a FastAPI dependency for authentication.
+    It validates the API key format, checks it against the store,
+    and verifies it's active and not expired.
+
+    Args:
+        api_key: The API key from the request header (injected by FastAPI).
+        key_store: The API key store to check against.
+        require_auth: Whether authentication is required.
+
+    Returns:
+        APIKeyInfo for the authenticated client.
+
+    Raises:
+        HTTPException: 401 if key is missing/invalid, 403 if revoked/expired.
+    """
+    # If auth not required and no key provided, return anonymous
+    if not require_auth and not api_key:
+        return create_anonymous_key_info()
+
+    # If auth not required but key provided, validate it
+    if key_store is None:
+        # No store configured, return anonymous
+        return create_anonymous_key_info()
+
+    # Validate key presence when auth is required
+    if not api_key:
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={
+                "error": "missing_api_key",
+                "message": f"API key required. Include '{API_KEY_HEADER_NAME}' header.",
+            },
+            headers={"WWW-Authenticate": "ApiKey"},
+        )
+
+    # Validate key format
+    if not validate_api_key_format(api_key):
+        raise HTTPException(
+            status_code=status.HTTP_401_UNAUTHORIZED,
+            detail={
+                "error": "invalid_api_key_format",
+                "message": "Invalid API key format. Keys must start with 'rgapi_'.",
+            },
+        )
+
+    # Look up key in store
+    key_hash = hash_api_key(api_key)
+    key_info = await key_store.get_by_hash(key_hash)
+
+    if key_info is None:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": "invalid_api_key",
+                "message": "API key not found or invalid.",
+            },
+        )
+
+    # Check if active
+    if not key_info.is_active:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": "api_key_revoked",
+                "message": "API key has been revoked.",
+            },
+        )
+
+    # Check expiration
+    if key_info.expires_at and datetime.now(UTC) > key_info.expires_at:
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail={
+                "error": "api_key_expired",
+                "message": "API key has expired.",
+            },
+        )
+
+    return key_info

--- a/backend/src/requirements_graphrag_api/auth/audit.py
+++ b/backend/src/requirements_graphrag_api/auth/audit.py
@@ -1,0 +1,611 @@
+"""Comprehensive audit logging for compliance and security analysis.
+
+This module provides structured audit logging for:
+- Authentication events (success, failure, key creation, revocation)
+- API access events (requests, responses, errors)
+- Guardrail events (triggered, blocked)
+- Rate limiting events (warnings, exceeded)
+
+Audit events are immutable, timestamped, and include request context
+for compliance and security analysis.
+
+Usage:
+    from requirements_graphrag_api.auth.audit import (
+        audit_logger,
+        log_api_request,
+        log_api_response,
+        AuditEventType,
+    )
+
+    # Log an API request
+    await log_api_request(request, client, request_id)
+
+    # Log a response
+    await log_api_response(request, client, request_id, status_code, duration_ms)
+
+    # Custom event
+    await audit_logger.log(AuditEvent(
+        event_type=AuditEventType.AUTH_FAILURE,
+        ...
+    ))
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from dataclasses import asdict, dataclass, field
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from fastapi import Request
+
+    from requirements_graphrag_api.auth.api_key import APIKeyInfo
+
+# Dedicated audit logger with its own handlers
+# Configure in your logging setup to route to appropriate destination
+audit_log = logging.getLogger("audit")
+
+
+class AuditEventType(StrEnum):
+    """Types of audit events.
+
+    Events are categorized by domain for easier filtering and analysis:
+    - auth.*: Authentication and authorization events
+    - api.*: API request/response lifecycle events
+    - guardrail.*: Security guardrail events
+    - rate_limit.*: Rate limiting events
+    """
+
+    # Authentication events
+    AUTH_SUCCESS = "auth.success"
+    AUTH_FAILURE = "auth.failure"
+    AUTH_KEY_CREATED = "auth.key_created"
+    AUTH_KEY_REVOKED = "auth.key_revoked"
+    AUTH_KEY_EXPIRED = "auth.key_expired"
+
+    # API access events
+    API_REQUEST = "api.request"
+    API_RESPONSE = "api.response"
+    API_ERROR = "api.error"
+
+    # Guardrail events
+    GUARDRAIL_TRIGGERED = "guardrail.triggered"
+    GUARDRAIL_BLOCKED = "guardrail.blocked"
+    GUARDRAIL_PASSED = "guardrail.passed"
+
+    # Rate limiting events
+    RATE_LIMIT_WARNING = "rate_limit.warning"
+    RATE_LIMIT_EXCEEDED = "rate_limit.exceeded"
+
+
+@dataclass(frozen=True)
+class AuditEvent:
+    """Structured audit event.
+
+    Immutable (frozen) to ensure audit records cannot be modified
+    after creation, maintaining integrity for compliance.
+
+    Attributes:
+        event_type: The type of audit event.
+        timestamp: When the event occurred (UTC).
+        request_id: Unique identifier for request correlation.
+        client_id: API key ID if authenticated, None otherwise.
+        client_ip: Client IP address if available.
+        endpoint: The API endpoint path.
+        method: HTTP method (GET, POST, etc.).
+        status_code: HTTP status code (for response events).
+        duration_ms: Request duration in milliseconds.
+        details: Additional event-specific details.
+    """
+
+    event_type: AuditEventType
+    timestamp: datetime
+    request_id: str
+    client_id: str | None
+    client_ip: str | None
+    endpoint: str
+    method: str
+    status_code: int | None = None
+    duration_ms: float | None = None
+    details: dict[str, Any] = field(default_factory=dict)
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for logging/serialization.
+
+        Returns:
+            Dictionary representation with ISO timestamp.
+        """
+        data = asdict(self)
+        data["timestamp"] = self.timestamp.isoformat()
+        data["event_type"] = self.event_type.value
+        return data
+
+    def to_json(self) -> str:
+        """Convert to JSON string for logging.
+
+        Returns:
+            JSON string representation.
+        """
+        return json.dumps(self.to_dict(), default=str)
+
+
+class AuditHandler:
+    """Base class for audit event handlers.
+
+    Subclass this to implement custom audit event destinations
+    (e.g., database, external service, file).
+
+    Handlers are async to support non-blocking I/O operations.
+    """
+
+    async def handle(self, event: AuditEvent) -> None:
+        """Handle an audit event.
+
+        Args:
+            event: The audit event to process.
+
+        Raises:
+            NotImplementedError: Must be implemented by subclasses.
+        """
+        raise NotImplementedError
+
+    async def close(self) -> None:
+        """Clean up handler resources.
+
+        Called during application shutdown.
+        """
+
+
+class LoggingAuditHandler(AuditHandler):
+    """Handler that logs audit events to Python logging.
+
+    Uses structured logging with JSON format for easy parsing
+    by log aggregation systems.
+    """
+
+    def __init__(self, logger: logging.Logger | None = None) -> None:
+        """Initialize the logging handler.
+
+        Args:
+            logger: Logger to use. Defaults to the 'audit' logger.
+        """
+        self.logger = logger or audit_log
+
+    async def handle(self, event: AuditEvent) -> None:
+        """Log the audit event.
+
+        Args:
+            event: The audit event to log.
+        """
+        # Determine log level based on event type
+        if event.event_type in (
+            AuditEventType.AUTH_FAILURE,
+            AuditEventType.GUARDRAIL_BLOCKED,
+            AuditEventType.RATE_LIMIT_EXCEEDED,
+            AuditEventType.API_ERROR,
+        ):
+            level = logging.WARNING
+        elif event.event_type in (
+            AuditEventType.RATE_LIMIT_WARNING,
+            AuditEventType.GUARDRAIL_TRIGGERED,
+        ):
+            level = logging.INFO
+        else:
+            level = logging.INFO
+
+        self.logger.log(
+            level,
+            "Audit: %s %s %s",
+            event.event_type.value,
+            event.method,
+            event.endpoint,
+            extra={"audit_event": event.to_dict()},
+        )
+
+
+class LangSmithAuditHandler(AuditHandler):
+    """Handler that sends audit events to LangSmith as feedback.
+
+    Integrates audit events with LangSmith for correlation with
+    LLM traces and performance analysis.
+    """
+
+    def __init__(self, enabled: bool = False) -> None:
+        """Initialize the LangSmith handler.
+
+        Args:
+            enabled: Whether to actually send events to LangSmith.
+        """
+        self.enabled = enabled
+
+    async def handle(self, event: AuditEvent) -> None:
+        """Send audit event to LangSmith.
+
+        Currently a placeholder - implement integration with LangSmith
+        feedback API when needed.
+
+        Args:
+            event: The audit event to send.
+        """
+        if not self.enabled:
+            return
+
+        # TODO: Implement LangSmith integration
+        # Could use langsmith.Client().create_feedback() to correlate
+        # audit events with LLM traces
+
+
+class AuditLogger:
+    """Audit logger with configurable handlers.
+
+    Central point for logging audit events to multiple destinations.
+    Handlers are processed in order, and failures in one handler
+    don't prevent others from receiving the event.
+
+    Example:
+        logger = AuditLogger()
+        logger.add_handler(LoggingAuditHandler())
+        logger.add_handler(DatabaseAuditHandler(db))
+
+        await logger.log(event)
+    """
+
+    def __init__(self) -> None:
+        """Initialize the audit logger with no handlers."""
+        self._handlers: list[AuditHandler] = []
+
+    def add_handler(self, handler: AuditHandler) -> None:
+        """Add a handler to receive audit events.
+
+        Args:
+            handler: The handler to add.
+        """
+        self._handlers.append(handler)
+
+    def remove_handler(self, handler: AuditHandler) -> None:
+        """Remove a handler.
+
+        Args:
+            handler: The handler to remove.
+        """
+        self._handlers.remove(handler)
+
+    async def log(self, event: AuditEvent) -> None:
+        """Log an audit event to all handlers.
+
+        Errors in individual handlers are caught and logged,
+        but don't prevent other handlers from receiving the event.
+
+        Args:
+            event: The audit event to log.
+        """
+        for handler in self._handlers:
+            try:
+                await handler.handle(event)
+            except Exception as e:
+                # Use standard logger to avoid infinite recursion
+                logging.getLogger(__name__).exception(
+                    "Audit handler error: %s",
+                    e,
+                    extra={"handler": handler.__class__.__name__},
+                )
+
+    async def close(self) -> None:
+        """Close all handlers.
+
+        Call during application shutdown to clean up resources.
+        """
+        for handler in self._handlers:
+            try:
+                await handler.close()
+            except Exception as e:
+                logging.getLogger(__name__).exception("Error closing audit handler: %s", e)
+
+
+# Global audit logger instance
+# Add handlers during application startup
+audit_logger = AuditLogger()
+
+
+def configure_audit_logging(
+    enable_logging: bool = True,
+    enable_langsmith: bool = False,
+) -> None:
+    """Configure the global audit logger with default handlers.
+
+    Call this during application startup to set up audit logging.
+
+    Args:
+        enable_logging: Whether to enable Python logging handler.
+        enable_langsmith: Whether to enable LangSmith handler.
+    """
+    if enable_logging:
+        audit_logger.add_handler(LoggingAuditHandler())
+    if enable_langsmith:
+        audit_logger.add_handler(LangSmithAuditHandler(enabled=True))
+
+
+# Convenience functions for common audit events
+
+
+def _get_client_ip(request: Request) -> str | None:
+    """Extract client IP from request.
+
+    Handles X-Forwarded-For header for proxied requests.
+
+    Args:
+        request: The FastAPI request.
+
+    Returns:
+        Client IP address or None.
+    """
+    # Check for forwarded IP first (behind proxy/load balancer)
+    forwarded = request.headers.get("X-Forwarded-For")
+    if forwarded:
+        # Take the first IP in the chain (original client)
+        return forwarded.split(",")[0].strip()
+    # Direct connection
+    if request.client:
+        return request.client.host
+    return None
+
+
+async def log_api_request(
+    request: Request,
+    client: APIKeyInfo | None,
+    request_id: str,
+) -> None:
+    """Log an API request event.
+
+    Call this at the start of request processing for comprehensive
+    request logging.
+
+    Args:
+        request: The FastAPI request.
+        client: The authenticated client info, or None.
+        request_id: Unique request identifier.
+    """
+    await audit_logger.log(
+        AuditEvent(
+            event_type=AuditEventType.API_REQUEST,
+            timestamp=datetime.now(UTC),
+            request_id=request_id,
+            client_id=client.key_id if client else None,
+            client_ip=_get_client_ip(request),
+            endpoint=request.url.path,
+            method=request.method,
+            status_code=None,
+            duration_ms=None,
+            details={
+                "query_params": dict(request.query_params),
+                "content_type": request.headers.get("content-type"),
+                "user_agent": request.headers.get("user-agent"),
+                "tier": client.tier if client else None,
+            },
+        )
+    )
+
+
+async def log_api_response(
+    request: Request,
+    client: APIKeyInfo | None,
+    request_id: str,
+    status_code: int,
+    duration_ms: float,
+) -> None:
+    """Log an API response event.
+
+    Call this after request processing completes.
+
+    Args:
+        request: The FastAPI request.
+        client: The authenticated client info, or None.
+        request_id: Unique request identifier.
+        status_code: HTTP response status code.
+        duration_ms: Request duration in milliseconds.
+    """
+    await audit_logger.log(
+        AuditEvent(
+            event_type=AuditEventType.API_RESPONSE,
+            timestamp=datetime.now(UTC),
+            request_id=request_id,
+            client_id=client.key_id if client else None,
+            client_ip=_get_client_ip(request),
+            endpoint=request.url.path,
+            method=request.method,
+            status_code=status_code,
+            duration_ms=duration_ms,
+            details={
+                "tier": client.tier if client else None,
+            },
+        )
+    )
+
+
+async def log_api_error(
+    request: Request,
+    client: APIKeyInfo | None,
+    request_id: str,
+    status_code: int,
+    error_type: str,
+    error_message: str,
+    duration_ms: float | None = None,
+) -> None:
+    """Log an API error event.
+
+    Call this when an error occurs during request processing.
+
+    Args:
+        request: The FastAPI request.
+        client: The authenticated client info, or None.
+        request_id: Unique request identifier.
+        status_code: HTTP error status code.
+        error_type: Error type/code for categorization.
+        error_message: Human-readable error message.
+        duration_ms: Request duration if available.
+    """
+    await audit_logger.log(
+        AuditEvent(
+            event_type=AuditEventType.API_ERROR,
+            timestamp=datetime.now(UTC),
+            request_id=request_id,
+            client_id=client.key_id if client else None,
+            client_ip=_get_client_ip(request),
+            endpoint=request.url.path,
+            method=request.method,
+            status_code=status_code,
+            duration_ms=duration_ms,
+            details={
+                "error_type": error_type,
+                "error_message": error_message,
+                "tier": client.tier if client else None,
+            },
+        )
+    )
+
+
+async def log_auth_success(
+    request: Request,
+    client: APIKeyInfo,
+    request_id: str,
+) -> None:
+    """Log a successful authentication event.
+
+    Args:
+        request: The FastAPI request.
+        client: The authenticated client info.
+        request_id: Unique request identifier.
+    """
+    await audit_logger.log(
+        AuditEvent(
+            event_type=AuditEventType.AUTH_SUCCESS,
+            timestamp=datetime.now(UTC),
+            request_id=request_id,
+            client_id=client.key_id,
+            client_ip=_get_client_ip(request),
+            endpoint=request.url.path,
+            method=request.method,
+            details={
+                "tier": client.tier,
+                "organization": client.organization,
+                "scopes": list(client.scopes),
+            },
+        )
+    )
+
+
+async def log_auth_failure(
+    request: Request,
+    request_id: str,
+    reason: str,
+) -> None:
+    """Log a failed authentication attempt.
+
+    Args:
+        request: The FastAPI request.
+        request_id: Unique request identifier.
+        reason: Why authentication failed.
+    """
+    await audit_logger.log(
+        AuditEvent(
+            event_type=AuditEventType.AUTH_FAILURE,
+            timestamp=datetime.now(UTC),
+            request_id=request_id,
+            client_id=None,
+            client_ip=_get_client_ip(request),
+            endpoint=request.url.path,
+            method=request.method,
+            details={
+                "reason": reason,
+            },
+        )
+    )
+
+
+async def log_guardrail_event(
+    request: Request,
+    client: APIKeyInfo | None,
+    request_id: str,
+    guardrail_name: str,
+    triggered: bool,
+    blocked: bool,
+    details: dict[str, Any] | None = None,
+) -> None:
+    """Log a guardrail event.
+
+    Args:
+        request: The FastAPI request.
+        client: The authenticated client info, or None.
+        request_id: Unique request identifier.
+        guardrail_name: Name of the guardrail (e.g., "prompt_injection").
+        triggered: Whether the guardrail was triggered.
+        blocked: Whether the request was blocked.
+        details: Additional guardrail-specific details.
+    """
+    if blocked:
+        event_type = AuditEventType.GUARDRAIL_BLOCKED
+    elif triggered:
+        event_type = AuditEventType.GUARDRAIL_TRIGGERED
+    else:
+        event_type = AuditEventType.GUARDRAIL_PASSED
+
+    await audit_logger.log(
+        AuditEvent(
+            event_type=event_type,
+            timestamp=datetime.now(UTC),
+            request_id=request_id,
+            client_id=client.key_id if client else None,
+            client_ip=_get_client_ip(request),
+            endpoint=request.url.path,
+            method=request.method,
+            details={
+                "guardrail": guardrail_name,
+                "triggered": triggered,
+                "blocked": blocked,
+                **(details or {}),
+            },
+        )
+    )
+
+
+async def log_rate_limit_event(
+    request: Request,
+    client: APIKeyInfo | None,
+    request_id: str,
+    exceeded: bool,
+    limit: str,
+    current_count: int | None = None,
+) -> None:
+    """Log a rate limit event.
+
+    Args:
+        request: The FastAPI request.
+        client: The authenticated client info, or None.
+        request_id: Unique request identifier.
+        exceeded: Whether the rate limit was exceeded.
+        limit: The rate limit string (e.g., "50/minute").
+        current_count: Current request count if available.
+    """
+    event_type = (
+        AuditEventType.RATE_LIMIT_EXCEEDED if exceeded else AuditEventType.RATE_LIMIT_WARNING
+    )
+
+    await audit_logger.log(
+        AuditEvent(
+            event_type=event_type,
+            timestamp=datetime.now(UTC),
+            request_id=request_id,
+            client_id=client.key_id if client else None,
+            client_ip=_get_client_ip(request),
+            endpoint=request.url.path,
+            method=request.method,
+            details={
+                "limit": limit,
+                "current_count": current_count,
+                "tier": client.tier if client else None,
+            },
+        )
+    )

--- a/backend/src/requirements_graphrag_api/auth/middleware.py
+++ b/backend/src/requirements_graphrag_api/auth/middleware.py
@@ -1,0 +1,353 @@
+"""FastAPI middleware for authentication and request context.
+
+This module provides authentication middleware that:
+- Validates API keys on incoming requests
+- Sets up request context with client information
+- Supports optional authentication (disabled by default)
+- Skips authentication for health checks and documentation endpoints
+
+Usage:
+    from requirements_graphrag_api.auth.middleware import AuthMiddleware
+
+    # In FastAPI app setup
+    app.add_middleware(AuthMiddleware, require_auth=False)
+
+    # In route handlers
+    from requirements_graphrag_api.auth.middleware import get_current_client
+    client = get_current_client()  # Returns APIKeyInfo or None
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+import uuid
+from contextvars import ContextVar
+from datetime import UTC
+from typing import TYPE_CHECKING
+
+from starlette.middleware.base import BaseHTTPMiddleware
+
+from requirements_graphrag_api.auth.api_key import (
+    API_KEY_HEADER_NAME,
+    APIKeyInfo,
+    APIKeyStore,
+    create_anonymous_key_info,
+    hash_api_key,
+    validate_api_key_format,
+)
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from fastapi import Request
+    from starlette.responses import Response
+    from starlette.types import ASGIApp
+
+    # Type alias for the call_next function
+    RequestResponseEndpoint = Callable[[Request], Response]
+
+logger = logging.getLogger(__name__)
+
+# Context variables for request-scoped state
+# These are async-safe and provide isolation between concurrent requests
+_current_client: ContextVar[APIKeyInfo | None] = ContextVar("current_client", default=None)
+_current_request_id: ContextVar[str | None] = ContextVar("current_request_id", default=None)
+_request_start_time: ContextVar[float | None] = ContextVar("request_start_time", default=None)
+
+
+def get_current_client() -> APIKeyInfo | None:
+    """Get the current authenticated client from request context.
+
+    Call this from anywhere within a request handler to access
+    the authenticated client's information.
+
+    Returns:
+        APIKeyInfo for the authenticated client, or None if anonymous.
+
+    Example:
+        @router.get("/protected")
+        async def protected_endpoint():
+            client = get_current_client()
+            if client:
+                return {"message": f"Hello, {client.name}"}
+            return {"message": "Anonymous access"}
+    """
+    return _current_client.get()
+
+
+def get_current_request_id() -> str | None:
+    """Get the current request ID from context.
+
+    Returns:
+        The unique request ID string, or None if not in a request context.
+    """
+    return _current_request_id.get()
+
+
+def get_request_duration_ms() -> float | None:
+    """Get the current request duration in milliseconds.
+
+    Returns:
+        Duration since request started, or None if not in a request context.
+    """
+    start = _request_start_time.get()
+    if start is None:
+        return None
+    return (time.perf_counter() - start) * 1000
+
+
+# Paths that skip authentication
+SKIP_AUTH_PATHS: frozenset[str] = frozenset(
+    {
+        "/",
+        "/health",
+        "/docs",
+        "/openapi.json",
+        "/redoc",
+    }
+)
+
+
+class AuthMiddleware(BaseHTTPMiddleware):
+    """Middleware to handle authentication and set request context.
+
+    This middleware:
+    1. Generates a unique request ID for tracing
+    2. Records request start time for duration metrics
+    3. Extracts and validates API keys from headers
+    4. Sets up context variables for access in route handlers
+    5. Cleans up context after request completion
+
+    Args:
+        app: The ASGI application to wrap.
+        require_auth: If True, requests without valid API keys are rejected.
+            If False (default), anonymous access is allowed.
+
+    Attributes:
+        require_auth: Whether authentication is required for API access.
+
+    Example:
+        app = FastAPI()
+        app.add_middleware(AuthMiddleware, require_auth=False)
+    """
+
+    def __init__(self, app: ASGIApp, require_auth: bool = False) -> None:
+        """Initialize the authentication middleware.
+
+        Args:
+            app: The ASGI application to wrap.
+            require_auth: Whether to require authentication.
+        """
+        super().__init__(app)
+        self.require_auth = require_auth
+
+    async def dispatch(self, request: Request, call_next: RequestResponseEndpoint) -> Response:
+        """Process the request through the authentication pipeline.
+
+        Args:
+            request: The incoming HTTP request.
+            call_next: The next handler in the middleware chain.
+
+        Returns:
+            The HTTP response from the route handler.
+        """
+        from fastapi import HTTPException
+        from starlette.responses import JSONResponse
+
+        # Generate request ID and start timing
+        request_id = str(uuid.uuid4())
+        start_time = time.perf_counter()
+
+        # Set context variables
+        _current_request_id.set(request_id)
+        _request_start_time.set(start_time)
+
+        # Add request ID to response headers for tracing
+        # This will be done after call_next
+
+        # Skip auth for specific paths
+        if request.url.path in SKIP_AUTH_PATHS:
+            request.state.client = None
+            request.state.request_id = request_id
+            try:
+                response = await call_next(request)
+                response.headers["X-Request-ID"] = request_id
+                return response
+            finally:
+                self._cleanup_context()
+
+        # Extract API key from header
+        api_key = request.headers.get(API_KEY_HEADER_NAME)
+
+        # Handle authentication - catch HTTPException and return proper response
+        try:
+            client_info = await self._authenticate(request, api_key)
+        except HTTPException as exc:
+            self._cleanup_context()
+            response = JSONResponse(
+                status_code=exc.status_code,
+                content={"detail": exc.detail},
+                headers=exc.headers,
+            )
+            response.headers["X-Request-ID"] = request_id
+            return response
+
+        # Store in request state for route handlers
+        request.state.client = client_info
+        request.state.request_id = request_id
+
+        # Set context variable for access anywhere in the request
+        _current_client.set(client_info)
+
+        try:
+            response = await call_next(request)
+            response.headers["X-Request-ID"] = request_id
+            return response
+        finally:
+            self._cleanup_context()
+
+    async def _authenticate(self, request: Request, api_key: str | None) -> APIKeyInfo | None:
+        """Authenticate the request using the provided API key.
+
+        Args:
+            request: The incoming HTTP request.
+            api_key: The API key from the header, if present.
+
+        Returns:
+            APIKeyInfo for authenticated requests, None for anonymous.
+
+        Raises:
+            HTTPException: If authentication fails and is required.
+        """
+        from fastapi import HTTPException, status
+
+        # Get key store from app state (initialized during app startup)
+        key_store: APIKeyStore | None = getattr(request.app.state, "api_key_store", None)
+
+        # No key provided
+        if not api_key:
+            if self.require_auth:
+                logger.warning(
+                    "Missing API key on protected endpoint",
+                    extra={
+                        "path": request.url.path,
+                        "method": request.method,
+                        "client_ip": request.client.host if request.client else None,
+                    },
+                )
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail={
+                        "error": "missing_api_key",
+                        "message": f"API key required. Include '{API_KEY_HEADER_NAME}' header.",
+                    },
+                    headers={"WWW-Authenticate": "ApiKey"},
+                )
+            # Anonymous access allowed
+            return create_anonymous_key_info()
+
+        # Validate format first (fast path for obviously invalid keys)
+        if not validate_api_key_format(api_key):
+            logger.warning(
+                "Invalid API key format",
+                extra={
+                    "path": request.url.path,
+                    "method": request.method,
+                    "client_ip": request.client.host if request.client else None,
+                },
+            )
+            if self.require_auth:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail={
+                        "error": "invalid_api_key_format",
+                        "message": "Invalid API key format. Keys must start with 'rgapi_'.",
+                    },
+                )
+            return create_anonymous_key_info()
+
+        # No store configured, allow with anonymous access
+        if key_store is None:
+            return create_anonymous_key_info()
+
+        # Look up key in store
+        key_hash = hash_api_key(api_key)
+        key_info = await key_store.get_by_hash(key_hash)
+
+        if key_info is None:
+            logger.warning(
+                "API key not found",
+                extra={
+                    "path": request.url.path,
+                    "method": request.method,
+                    "client_ip": request.client.host if request.client else None,
+                },
+            )
+            if self.require_auth:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail={
+                        "error": "invalid_api_key",
+                        "message": "API key not found or invalid.",
+                    },
+                )
+            return create_anonymous_key_info()
+
+        # Check if active
+        if not key_info.is_active:
+            logger.warning(
+                "Revoked API key used",
+                extra={
+                    "path": request.url.path,
+                    "method": request.method,
+                    "key_id": key_info.key_id,
+                    "client_ip": request.client.host if request.client else None,
+                },
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "error": "api_key_revoked",
+                    "message": "API key has been revoked.",
+                },
+            )
+
+        # Check expiration
+        from datetime import datetime
+
+        if key_info.expires_at and datetime.now(UTC) > key_info.expires_at:
+            logger.warning(
+                "Expired API key used",
+                extra={
+                    "path": request.url.path,
+                    "method": request.method,
+                    "key_id": key_info.key_id,
+                    "client_ip": request.client.host if request.client else None,
+                },
+            )
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "error": "api_key_expired",
+                    "message": "API key has expired.",
+                },
+            )
+
+        # Successfully authenticated
+        logger.debug(
+            "API key authenticated",
+            extra={
+                "key_id": key_info.key_id,
+                "tier": key_info.tier,
+                "organization": key_info.organization,
+            },
+        )
+
+        return key_info
+
+    def _cleanup_context(self) -> None:
+        """Reset context variables after request completion."""
+        _current_client.set(None)
+        _current_request_id.set(None)
+        _request_start_time.set(None)

--- a/backend/src/requirements_graphrag_api/auth/scopes.py
+++ b/backend/src/requirements_graphrag_api/auth/scopes.py
@@ -1,0 +1,300 @@
+"""Scope-based authorization for API endpoints.
+
+This module implements fine-grained access control using scopes:
+- Each scope grants access to specific functionality
+- API keys are assigned scopes based on their tier and use case
+- Endpoints can require one or more scopes for access
+
+Scopes follow a coarse-grained model appropriate for this API:
+- chat: Access to chat/RAG endpoints
+- search: Access to search endpoints (hybrid, vector, graph)
+- feedback: Access to submit feedback
+- admin: Access to administrative endpoints
+
+Usage:
+    from requirements_graphrag_api.auth.scopes import Scope, require_scopes
+
+    @router.post("/chat")
+    @require_scopes(Scope.CHAT)
+    async def chat_endpoint(request: Request):
+        ...
+
+    # Or as FastAPI dependency
+    @router.post("/admin/keys")
+    async def create_key(
+        _: None = Depends(require_scopes(Scope.ADMIN))
+    ):
+        ...
+"""
+
+from __future__ import annotations
+
+from enum import StrEnum
+from functools import wraps
+from typing import TYPE_CHECKING, ParamSpec, TypeVar
+
+from fastapi import HTTPException, Request, status
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from requirements_graphrag_api.auth.api_key import APIKeyInfo
+
+P = ParamSpec("P")
+T = TypeVar("T")
+
+
+class Scope(StrEnum):
+    """API access scopes.
+
+    Scopes define what actions an API key is authorized to perform.
+    Keys can have multiple scopes, and endpoints can require multiple scopes.
+
+    Attributes:
+        CHAT: Access to /chat endpoint for RAG-powered Q&A.
+        SEARCH: Access to /search/* endpoints for semantic search.
+        FEEDBACK: Access to /feedback endpoint for submitting feedback.
+        ADMIN: Access to administrative endpoints (key management, metrics).
+    """
+
+    CHAT = "chat"
+    SEARCH = "search"
+    FEEDBACK = "feedback"
+    ADMIN = "admin"
+
+
+# Default scopes for each API key tier
+DEFAULT_TIER_SCOPES: dict[str, tuple[str, ...]] = {
+    "free": (Scope.CHAT, Scope.SEARCH),
+    "standard": (Scope.CHAT, Scope.SEARCH, Scope.FEEDBACK),
+    "premium": (Scope.CHAT, Scope.SEARCH, Scope.FEEDBACK),
+    "enterprise": (Scope.CHAT, Scope.SEARCH, Scope.FEEDBACK, Scope.ADMIN),
+}
+
+# Endpoint to required scopes mapping
+# Used for documentation and automatic scope checking
+ENDPOINT_SCOPES: dict[str, list[Scope]] = {
+    "/chat": [Scope.CHAT],
+    "/search/hybrid": [Scope.SEARCH],
+    "/search/vector": [Scope.SEARCH],
+    "/search/graph": [Scope.SEARCH],
+    "/feedback": [Scope.FEEDBACK],
+    "/definitions": [Scope.SEARCH],
+    "/definitions/search": [Scope.SEARCH],
+    "/glossary": [Scope.SEARCH],
+    "/standards": [Scope.SEARCH],
+    "/standards/list": [Scope.SEARCH],
+}
+
+
+def check_scopes(
+    client_scopes: tuple[str, ...] | list[str],
+    required_scopes: tuple[Scope, ...] | list[Scope],
+) -> tuple[bool, set[str]]:
+    """Check if client has required scopes.
+
+    Args:
+        client_scopes: Scopes assigned to the client's API key.
+        required_scopes: Scopes required for the operation.
+
+    Returns:
+        Tuple of (has_all_scopes, missing_scopes).
+
+    Example:
+        >>> has_scopes, missing = check_scopes(("chat", "search"), (Scope.CHAT,))
+        >>> has_scopes
+        True
+        >>> missing
+        set()
+    """
+    client_scope_set = set(client_scopes)
+    required_scope_set = {str(s) for s in required_scopes}
+    missing = required_scope_set - client_scope_set
+    return len(missing) == 0, missing
+
+
+def get_client_from_request(request: Request) -> APIKeyInfo | None:
+    """Extract client info from request state.
+
+    The AuthMiddleware sets request.state.client during authentication.
+
+    Args:
+        request: The FastAPI request object.
+
+    Returns:
+        APIKeyInfo if authenticated, None otherwise.
+    """
+    return getattr(request.state, "client", None)
+
+
+class ScopeChecker:
+    """FastAPI dependency for checking scopes.
+
+    Use this as a dependency to enforce scope requirements on endpoints.
+    It extracts the client from request state (set by AuthMiddleware)
+    and verifies they have the required scopes.
+
+    Example:
+        @router.post("/admin/keys")
+        async def create_key(
+            request: Request,
+            _: None = Depends(ScopeChecker(Scope.ADMIN))
+        ):
+            ...
+    """
+
+    def __init__(self, *required_scopes: Scope, allow_anonymous: bool = False) -> None:
+        """Initialize the scope checker.
+
+        Args:
+            *required_scopes: Scopes required for access.
+            allow_anonymous: If True, allow access without authentication
+                (but still check scopes if authenticated).
+        """
+        self.required_scopes = required_scopes
+        self.allow_anonymous = allow_anonymous
+
+    async def __call__(self, request: Request) -> APIKeyInfo | None:
+        """Check scopes when used as a dependency.
+
+        Args:
+            request: The FastAPI request object.
+
+        Returns:
+            The APIKeyInfo if authorized.
+
+        Raises:
+            HTTPException: 401 if not authenticated and required.
+            HTTPException: 403 if missing required scopes.
+        """
+        client = get_client_from_request(request)
+
+        # Handle unauthenticated requests
+        if client is None:
+            if self.allow_anonymous:
+                return None
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail={
+                    "error": "authentication_required",
+                    "message": "Authentication required for this endpoint.",
+                },
+                headers={"WWW-Authenticate": "ApiKey"},
+            )
+
+        # Check if client has required scopes
+        has_scopes, missing = check_scopes(client.scopes, self.required_scopes)
+
+        if not has_scopes:
+            raise HTTPException(
+                status_code=status.HTTP_403_FORBIDDEN,
+                detail={
+                    "error": "insufficient_scope",
+                    "message": f"Missing required scopes: {', '.join(sorted(missing))}",
+                    "required": [str(s) for s in self.required_scopes],
+                    "granted": list(client.scopes),
+                },
+            )
+
+        return client
+
+
+def require_scopes(*required_scopes: Scope, allow_anonymous: bool = False) -> ScopeChecker:
+    """Create a FastAPI dependency that requires specific scopes.
+
+    This is a convenience function that creates a ScopeChecker dependency.
+
+    Args:
+        *required_scopes: Scopes required for access.
+        allow_anonymous: If True, allow unauthenticated access.
+
+    Returns:
+        A ScopeChecker dependency.
+
+    Example:
+        @router.post("/chat")
+        async def chat(
+            request: Request,
+            client: APIKeyInfo = Depends(require_scopes(Scope.CHAT))
+        ):
+            # client is guaranteed to have CHAT scope
+            ...
+    """
+    return ScopeChecker(*required_scopes, allow_anonymous=allow_anonymous)
+
+
+def require_scope(*required_scopes: Scope) -> Callable[[Callable[P, T]], Callable[P, T]]:
+    """Decorator to require specific scopes for an endpoint.
+
+    This decorator wraps an endpoint function to check scopes before execution.
+    It expects the request object to have client info set by AuthMiddleware.
+
+    Note: For new code, prefer using the `require_scopes` dependency instead,
+    as it integrates better with FastAPI's dependency injection.
+
+    Args:
+        *required_scopes: Scopes required for access.
+
+    Returns:
+        Decorator function.
+
+    Example:
+        @router.post("/chat")
+        @require_scope(Scope.CHAT)
+        async def chat_endpoint(request: Request):
+            client = get_client_from_request(request)
+            ...
+    """
+
+    def decorator(func: Callable[P, T]) -> Callable[P, T]:
+        @wraps(func)
+        async def wrapper(*args: P.args, **kwargs: P.kwargs) -> T:
+            # Find request in args or kwargs
+            request: Request | None = None
+            for arg in args:
+                if isinstance(arg, Request):
+                    request = arg
+                    break
+            if request is None:
+                request = kwargs.get("request")
+
+            if request is None:
+                raise HTTPException(
+                    status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+                    detail={
+                        "error": "internal_error",
+                        "message": "Request object not found in endpoint arguments.",
+                    },
+                )
+
+            client = get_client_from_request(request)
+
+            if client is None:
+                raise HTTPException(
+                    status_code=status.HTTP_401_UNAUTHORIZED,
+                    detail={
+                        "error": "authentication_required",
+                        "message": "Authentication required for this endpoint.",
+                    },
+                    headers={"WWW-Authenticate": "ApiKey"},
+                )
+
+            # Check if client has required scopes
+            has_scopes, missing = check_scopes(client.scopes, required_scopes)
+
+            if not has_scopes:
+                raise HTTPException(
+                    status_code=status.HTTP_403_FORBIDDEN,
+                    detail={
+                        "error": "insufficient_scope",
+                        "message": f"Missing required scopes: {', '.join(sorted(missing))}",
+                        "required": [str(s) for s in required_scopes],
+                        "granted": list(client.scopes),
+                    },
+                )
+
+            return await func(*args, **kwargs)
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator

--- a/backend/tests/test_auth/__init__.py
+++ b/backend/tests/test_auth/__init__.py
@@ -1,0 +1,1 @@
+"""Tests for authentication and authorization module."""

--- a/backend/tests/test_auth/test_api_key.py
+++ b/backend/tests/test_auth/test_api_key.py
@@ -1,0 +1,445 @@
+"""Tests for API key generation, validation, and storage."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from requirements_graphrag_api.auth.api_key import (
+    API_KEY_PREFIX,
+    APIKeyInfo,
+    APIKeyTier,
+    InMemoryAPIKeyStore,
+    compare_hashes_constant_time,
+    create_anonymous_key_info,
+    generate_api_key,
+    hash_api_key,
+    validate_api_key_format,
+    verify_api_key,
+)
+
+
+class TestAPIKeyGeneration:
+    """Tests for API key generation."""
+
+    def test_generates_key_with_correct_prefix(self):
+        """Generated keys should start with the rgapi_ prefix."""
+        key = generate_api_key()
+        assert key.startswith(API_KEY_PREFIX)
+
+    def test_generates_key_with_minimum_length(self):
+        """Generated keys should be at least 40 characters."""
+        key = generate_api_key()
+        assert len(key) >= 40
+
+    def test_generates_unique_keys(self):
+        """Each generated key should be unique."""
+        keys = [generate_api_key() for _ in range(100)]
+        assert len(set(keys)) == 100, "Generated keys should be unique"
+
+    def test_key_contains_valid_characters(self):
+        """Key should only contain alphanumeric chars and url-safe chars."""
+        key = generate_api_key()
+        key_part = key.removeprefix(API_KEY_PREFIX)
+        assert all(c.isalnum() or c in "-_" for c in key_part)
+
+
+class TestAPIKeyHashing:
+    """Tests for API key hashing."""
+
+    def test_hash_is_consistent(self):
+        """Same key should always produce the same hash."""
+        key = generate_api_key()
+        hash1 = hash_api_key(key)
+        hash2 = hash_api_key(key)
+        assert hash1 == hash2
+
+    def test_different_keys_different_hashes(self):
+        """Different keys should produce different hashes."""
+        key1 = generate_api_key()
+        key2 = generate_api_key()
+        assert hash_api_key(key1) != hash_api_key(key2)
+
+    def test_hash_is_hex_string(self):
+        """Hash should be a valid hexadecimal string."""
+        key = generate_api_key()
+        key_hash = hash_api_key(key)
+        assert len(key_hash) == 64  # SHA-256 produces 64 hex chars
+        assert all(c in "0123456789abcdef" for c in key_hash)
+
+    def test_hash_strips_prefix(self):
+        """Hash should be the same with or without prefix."""
+        key = generate_api_key()
+        key_without_prefix = key.removeprefix(API_KEY_PREFIX)
+        # Hash should be of the key part only
+        hash_with_prefix = hash_api_key(key)
+        hash_without_prefix = hash_api_key(key_without_prefix)
+        assert hash_with_prefix == hash_without_prefix
+
+
+class TestConstantTimeComparison:
+    """Tests for timing-safe hash comparison."""
+
+    def test_equal_hashes_return_true(self):
+        """Equal hashes should compare as equal."""
+        hash1 = hash_api_key(generate_api_key())
+        assert compare_hashes_constant_time(hash1, hash1)
+
+    def test_different_hashes_return_false(self):
+        """Different hashes should compare as not equal."""
+        hash1 = hash_api_key(generate_api_key())
+        hash2 = hash_api_key(generate_api_key())
+        assert not compare_hashes_constant_time(hash1, hash2)
+
+
+class TestAPIKeyFormatValidation:
+    """Tests for API key format validation."""
+
+    def test_valid_key_passes(self):
+        """Valid generated keys should pass validation."""
+        key = generate_api_key()
+        assert validate_api_key_format(key)
+
+    def test_empty_string_fails(self):
+        """Empty string should fail validation."""
+        assert not validate_api_key_format("")
+
+    def test_none_like_values_fail(self):
+        """None-like values should fail validation."""
+        assert not validate_api_key_format(None)  # type: ignore[arg-type]
+
+    def test_missing_prefix_fails(self):
+        """Keys without the correct prefix should fail."""
+        key = generate_api_key()
+        key_without_prefix = key.removeprefix(API_KEY_PREFIX)
+        assert not validate_api_key_format(key_without_prefix)
+
+    def test_wrong_prefix_fails(self):
+        """Keys with wrong prefix should fail."""
+        assert not validate_api_key_format("wrong_prefix_abc123")
+        assert not validate_api_key_format("sk_live_abc123")  # Stripe-like key
+
+    def test_too_short_key_fails(self):
+        """Keys that are too short should fail."""
+        assert not validate_api_key_format("rgapi_short")
+        assert not validate_api_key_format(f"{API_KEY_PREFIX}abc")
+
+    def test_invalid_characters_fail(self):
+        """Keys with invalid characters should fail."""
+        assert not validate_api_key_format(f"{API_KEY_PREFIX}abc!@#$%")
+        assert not validate_api_key_format(f"{API_KEY_PREFIX}abc def")  # space
+
+
+class TestAPIKeyInfo:
+    """Tests for APIKeyInfo dataclass."""
+
+    def test_is_immutable(self):
+        """APIKeyInfo should be immutable (frozen)."""
+        info = APIKeyInfo(
+            key_id="test-id",
+            name="Test Key",
+            tier=APIKeyTier.FREE,
+            organization=None,
+            created_at=datetime.now(UTC),
+            expires_at=None,
+            rate_limit="10/minute",
+            is_active=True,
+            scopes=("chat", "search"),
+            metadata={},
+        )
+        with pytest.raises(AttributeError):
+            info.name = "New Name"  # type: ignore[misc]
+
+    def test_default_metadata(self):
+        """Metadata should default to empty dict."""
+        info = APIKeyInfo(
+            key_id="test-id",
+            name="Test Key",
+            tier=APIKeyTier.FREE,
+            organization=None,
+            created_at=datetime.now(UTC),
+            expires_at=None,
+            rate_limit="10/minute",
+            is_active=True,
+            scopes=("chat",),
+        )
+        assert info.metadata == {}
+
+
+class TestAPIKeyTier:
+    """Tests for APIKeyTier enum."""
+
+    def test_tier_values(self):
+        """Verify tier string values."""
+        assert APIKeyTier.FREE == "free"
+        assert APIKeyTier.STANDARD == "standard"
+        assert APIKeyTier.PREMIUM == "premium"
+        assert APIKeyTier.ENTERPRISE == "enterprise"
+
+    def test_all_tiers_defined(self):
+        """Ensure all expected tiers are defined."""
+        tiers = list(APIKeyTier)
+        assert len(tiers) == 4
+
+
+class TestAnonymousKeyInfo:
+    """Tests for anonymous key creation."""
+
+    def test_creates_anonymous_info(self):
+        """Should create info for anonymous access."""
+        info = create_anonymous_key_info()
+        assert info.key_id == "anonymous"
+        assert info.name == "Anonymous"
+        assert info.tier == APIKeyTier.FREE
+        assert info.is_active is True
+
+    def test_anonymous_has_limited_scopes(self):
+        """Anonymous should have limited scopes."""
+        info = create_anonymous_key_info()
+        assert "chat" in info.scopes
+        assert "search" in info.scopes
+        assert "admin" not in info.scopes
+
+
+class TestInMemoryAPIKeyStore:
+    """Tests for the in-memory API key store."""
+
+    @pytest.fixture
+    def store(self) -> InMemoryAPIKeyStore:
+        """Create a fresh store for each test."""
+        return InMemoryAPIKeyStore()
+
+    @pytest.fixture
+    def sample_key_info(self) -> APIKeyInfo:
+        """Create sample API key info."""
+        return APIKeyInfo(
+            key_id="test-key-id",
+            name="Test Key",
+            tier=APIKeyTier.STANDARD,
+            organization="Test Org",
+            created_at=datetime.now(UTC),
+            expires_at=None,
+            rate_limit="50/minute",
+            is_active=True,
+            scopes=("chat", "search", "feedback"),
+            metadata={"created_by": "test"},
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_and_retrieve(
+        self, store: InMemoryAPIKeyStore, sample_key_info: APIKeyInfo
+    ):
+        """Should store and retrieve key info."""
+        raw_key = generate_api_key()
+        await store.create(raw_key, sample_key_info)
+
+        key_hash = hash_api_key(raw_key)
+        retrieved = await store.get_by_hash(key_hash)
+
+        assert retrieved is not None
+        assert retrieved.key_id == sample_key_info.key_id
+        assert retrieved.name == sample_key_info.name
+        assert retrieved.tier == sample_key_info.tier
+
+    @pytest.mark.asyncio
+    async def test_get_nonexistent_returns_none(self, store: InMemoryAPIKeyStore):
+        """Should return None for nonexistent keys."""
+        result = await store.get_by_hash("nonexistent_hash")
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_revoke_key(self, store: InMemoryAPIKeyStore, sample_key_info: APIKeyInfo):
+        """Should revoke a key by ID."""
+        raw_key = generate_api_key()
+        await store.create(raw_key, sample_key_info)
+
+        # Revoke
+        result = await store.revoke(sample_key_info.key_id)
+        assert result is True
+
+        # Verify revoked
+        key_hash = hash_api_key(raw_key)
+        retrieved = await store.get_by_hash(key_hash)
+        assert retrieved is not None
+        assert retrieved.is_active is False
+
+    @pytest.mark.asyncio
+    async def test_revoke_nonexistent_returns_false(self, store: InMemoryAPIKeyStore):
+        """Should return False when revoking nonexistent key."""
+        result = await store.revoke("nonexistent-id")
+        assert result is False
+
+    @pytest.mark.asyncio
+    async def test_list_all_keys(self, store: InMemoryAPIKeyStore, sample_key_info: APIKeyInfo):
+        """Should list all stored keys."""
+        # Create multiple keys
+        for i in range(3):
+            raw_key = generate_api_key()
+            info = APIKeyInfo(
+                key_id=f"key-{i}",
+                name=f"Key {i}",
+                tier=APIKeyTier.STANDARD,
+                organization="Test Org",
+                created_at=datetime.now(UTC),
+                expires_at=None,
+                rate_limit="50/minute",
+                is_active=True,
+                scopes=("chat",),
+                metadata={},
+            )
+            await store.create(raw_key, info)
+
+        keys = await store.list_keys()
+        assert len(keys) == 3
+
+    @pytest.mark.asyncio
+    async def test_list_keys_by_organization(self, store: InMemoryAPIKeyStore):
+        """Should filter keys by organization."""
+        # Create keys for different orgs
+        for org in ["Org A", "Org A", "Org B"]:
+            raw_key = generate_api_key()
+            info = APIKeyInfo(
+                key_id=f"key-{raw_key[:8]}",
+                name="Key",
+                tier=APIKeyTier.STANDARD,
+                organization=org,
+                created_at=datetime.now(UTC),
+                expires_at=None,
+                rate_limit="50/minute",
+                is_active=True,
+                scopes=("chat",),
+                metadata={},
+            )
+            await store.create(raw_key, info)
+
+        org_a_keys = await store.list_keys(organization="Org A")
+        org_b_keys = await store.list_keys(organization="Org B")
+
+        assert len(org_a_keys) == 2
+        assert len(org_b_keys) == 1
+
+
+class TestVerifyAPIKey:
+    """Tests for the verify_api_key function."""
+
+    @pytest.fixture
+    def store(self) -> InMemoryAPIKeyStore:
+        """Create a fresh store for each test."""
+        return InMemoryAPIKeyStore()
+
+    @pytest.fixture
+    async def valid_key_and_store(
+        self, store: InMemoryAPIKeyStore
+    ) -> tuple[str, InMemoryAPIKeyStore]:
+        """Create a store with a valid key."""
+        raw_key = generate_api_key()
+        info = APIKeyInfo(
+            key_id="valid-key-id",
+            name="Valid Key",
+            tier=APIKeyTier.STANDARD,
+            organization="Test Org",
+            created_at=datetime.now(UTC),
+            expires_at=None,
+            rate_limit="50/minute",
+            is_active=True,
+            scopes=("chat", "search"),
+            metadata={},
+        )
+        await store.create(raw_key, info)
+        return raw_key, store
+
+    @pytest.mark.asyncio
+    async def test_valid_key_returns_info(
+        self, valid_key_and_store: tuple[str, InMemoryAPIKeyStore]
+    ):
+        """Valid key should return APIKeyInfo."""
+        raw_key, store = valid_key_and_store
+        info = await verify_api_key(raw_key, key_store=store, require_auth=True)
+        assert info.key_id == "valid-key-id"
+        assert info.tier == APIKeyTier.STANDARD
+
+    @pytest.mark.asyncio
+    async def test_no_key_when_auth_not_required_returns_anonymous(
+        self, store: InMemoryAPIKeyStore
+    ):
+        """No key when auth not required should return anonymous."""
+        info = await verify_api_key(None, key_store=store, require_auth=False)
+        assert info.key_id == "anonymous"
+
+    @pytest.mark.asyncio
+    async def test_no_key_when_auth_required_raises_401(self, store: InMemoryAPIKeyStore):
+        """No key when auth required should raise 401."""
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await verify_api_key(None, key_store=store, require_auth=True)
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail["error"] == "missing_api_key"
+
+    @pytest.mark.asyncio
+    async def test_invalid_format_when_auth_required_raises_401(self, store: InMemoryAPIKeyStore):
+        """Invalid format when auth required should raise 401."""
+        from fastapi import HTTPException
+
+        with pytest.raises(HTTPException) as exc_info:
+            await verify_api_key("invalid_key", key_store=store, require_auth=True)
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail["error"] == "invalid_api_key_format"
+
+    @pytest.mark.asyncio
+    async def test_unknown_key_raises_403(self, store: InMemoryAPIKeyStore):
+        """Unknown key should raise 403."""
+        from fastapi import HTTPException
+
+        unknown_key = generate_api_key()
+        with pytest.raises(HTTPException) as exc_info:
+            await verify_api_key(unknown_key, key_store=store, require_auth=True)
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail["error"] == "invalid_api_key"
+
+    @pytest.mark.asyncio
+    async def test_revoked_key_raises_403(
+        self, valid_key_and_store: tuple[str, InMemoryAPIKeyStore]
+    ):
+        """Revoked key should raise 403."""
+        from fastapi import HTTPException
+
+        raw_key, store = valid_key_and_store
+        await store.revoke("valid-key-id")
+
+        with pytest.raises(HTTPException) as exc_info:
+            await verify_api_key(raw_key, key_store=store, require_auth=True)
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail["error"] == "api_key_revoked"
+
+    @pytest.mark.asyncio
+    async def test_expired_key_raises_403(self, store: InMemoryAPIKeyStore):
+        """Expired key should raise 403."""
+        from fastapi import HTTPException
+
+        raw_key = generate_api_key()
+        info = APIKeyInfo(
+            key_id="expired-key-id",
+            name="Expired Key",
+            tier=APIKeyTier.STANDARD,
+            organization=None,
+            created_at=datetime.now(UTC) - timedelta(days=30),
+            expires_at=datetime.now(UTC) - timedelta(days=1),  # Expired yesterday
+            rate_limit="50/minute",
+            is_active=True,
+            scopes=("chat",),
+            metadata={},
+        )
+        await store.create(raw_key, info)
+
+        with pytest.raises(HTTPException) as exc_info:
+            await verify_api_key(raw_key, key_store=store, require_auth=True)
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail["error"] == "api_key_expired"
+
+    @pytest.mark.asyncio
+    async def test_no_store_returns_anonymous(self):
+        """No store configured should return anonymous."""
+        info = await verify_api_key("any_key", key_store=None, require_auth=False)
+        assert info.key_id == "anonymous"

--- a/backend/tests/test_auth/test_audit.py
+++ b/backend/tests/test_auth/test_audit.py
@@ -1,0 +1,488 @@
+"""Tests for audit logging."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from requirements_graphrag_api.auth.api_key import APIKeyInfo, APIKeyTier
+from requirements_graphrag_api.auth.audit import (
+    AuditEvent,
+    AuditEventType,
+    AuditHandler,
+    AuditLogger,
+    LoggingAuditHandler,
+    log_api_error,
+    log_api_request,
+    log_api_response,
+    log_auth_failure,
+    log_auth_success,
+    log_guardrail_event,
+    log_rate_limit_event,
+)
+
+
+class TestAuditEventType:
+    """Tests for AuditEventType enum."""
+
+    def test_auth_event_types(self):
+        """Verify auth event type values."""
+        assert AuditEventType.AUTH_SUCCESS == "auth.success"
+        assert AuditEventType.AUTH_FAILURE == "auth.failure"
+        assert AuditEventType.AUTH_KEY_CREATED == "auth.key_created"
+        assert AuditEventType.AUTH_KEY_REVOKED == "auth.key_revoked"
+
+    def test_api_event_types(self):
+        """Verify API event type values."""
+        assert AuditEventType.API_REQUEST == "api.request"
+        assert AuditEventType.API_RESPONSE == "api.response"
+        assert AuditEventType.API_ERROR == "api.error"
+
+    def test_guardrail_event_types(self):
+        """Verify guardrail event type values."""
+        assert AuditEventType.GUARDRAIL_TRIGGERED == "guardrail.triggered"
+        assert AuditEventType.GUARDRAIL_BLOCKED == "guardrail.blocked"
+
+    def test_rate_limit_event_types(self):
+        """Verify rate limit event type values."""
+        assert AuditEventType.RATE_LIMIT_WARNING == "rate_limit.warning"
+        assert AuditEventType.RATE_LIMIT_EXCEEDED == "rate_limit.exceeded"
+
+
+class TestAuditEvent:
+    """Tests for AuditEvent dataclass."""
+
+    @pytest.fixture
+    def sample_event(self) -> AuditEvent:
+        """Create a sample audit event."""
+        return AuditEvent(
+            event_type=AuditEventType.API_REQUEST,
+            timestamp=datetime(2024, 1, 15, 12, 0, 0, tzinfo=UTC),
+            request_id="test-request-id",
+            client_id="test-client-id",
+            client_ip="192.168.1.1",
+            endpoint="/chat",
+            method="POST",
+            status_code=200,
+            duration_ms=150.5,
+            details={"key": "value"},
+        )
+
+    def test_event_is_immutable(self, sample_event: AuditEvent):
+        """AuditEvent should be immutable."""
+        with pytest.raises(AttributeError):
+            sample_event.request_id = "new-id"  # type: ignore[misc]
+
+    def test_to_dict(self, sample_event: AuditEvent):
+        """to_dict should convert event to dictionary."""
+        data = sample_event.to_dict()
+
+        assert data["event_type"] == "api.request"
+        assert data["timestamp"] == "2024-01-15T12:00:00+00:00"
+        assert data["request_id"] == "test-request-id"
+        assert data["client_id"] == "test-client-id"
+        assert data["endpoint"] == "/chat"
+        assert data["method"] == "POST"
+        assert data["status_code"] == 200
+        assert data["duration_ms"] == 150.5
+        assert data["details"]["key"] == "value"
+
+    def test_to_json(self, sample_event: AuditEvent):
+        """to_json should return valid JSON string."""
+        json_str = sample_event.to_json()
+        import json
+
+        data = json.loads(json_str)
+        assert data["event_type"] == "api.request"
+
+
+class TestAuditLogger:
+    """Tests for AuditLogger."""
+
+    @pytest.fixture
+    def logger(self) -> AuditLogger:
+        """Create a fresh audit logger."""
+        return AuditLogger()
+
+    @pytest.fixture
+    def sample_event(self) -> AuditEvent:
+        """Create a sample audit event."""
+        return AuditEvent(
+            event_type=AuditEventType.API_REQUEST,
+            timestamp=datetime.now(UTC),
+            request_id="test-request-id",
+            client_id=None,
+            client_ip="127.0.0.1",
+            endpoint="/test",
+            method="GET",
+        )
+
+    @pytest.mark.asyncio
+    async def test_log_with_no_handlers(self, logger: AuditLogger, sample_event: AuditEvent):
+        """Should handle logging with no handlers gracefully."""
+        # Should not raise
+        await logger.log(sample_event)
+
+    @pytest.mark.asyncio
+    async def test_log_calls_all_handlers(self, logger: AuditLogger, sample_event: AuditEvent):
+        """Should call all registered handlers."""
+        handler1 = AsyncMock(spec=AuditHandler)
+        handler2 = AsyncMock(spec=AuditHandler)
+
+        logger.add_handler(handler1)
+        logger.add_handler(handler2)
+
+        await logger.log(sample_event)
+
+        handler1.handle.assert_called_once_with(sample_event)
+        handler2.handle.assert_called_once_with(sample_event)
+
+    @pytest.mark.asyncio
+    async def test_handler_error_doesnt_stop_others(
+        self, logger: AuditLogger, sample_event: AuditEvent
+    ):
+        """Error in one handler shouldn't prevent others from running."""
+        handler1 = AsyncMock(spec=AuditHandler)
+        handler1.handle.side_effect = Exception("Handler 1 error")
+        handler2 = AsyncMock(spec=AuditHandler)
+
+        logger.add_handler(handler1)
+        logger.add_handler(handler2)
+
+        await logger.log(sample_event)
+
+        # Handler 2 should still be called
+        handler2.handle.assert_called_once_with(sample_event)
+
+    def test_add_and_remove_handler(self, logger: AuditLogger):
+        """Should add and remove handlers."""
+        handler = AsyncMock(spec=AuditHandler)
+
+        logger.add_handler(handler)
+        assert handler in logger._handlers
+
+        logger.remove_handler(handler)
+        assert handler not in logger._handlers
+
+    @pytest.mark.asyncio
+    async def test_close_calls_all_handlers(self, logger: AuditLogger):
+        """close should call close on all handlers."""
+        handler1 = AsyncMock(spec=AuditHandler)
+        handler2 = AsyncMock(spec=AuditHandler)
+
+        logger.add_handler(handler1)
+        logger.add_handler(handler2)
+
+        await logger.close()
+
+        handler1.close.assert_called_once()
+        handler2.close.assert_called_once()
+
+
+class TestLoggingAuditHandler:
+    """Tests for LoggingAuditHandler."""
+
+    @pytest.fixture
+    def mock_logger(self) -> MagicMock:
+        """Create a mock Python logger."""
+        return MagicMock()
+
+    @pytest.fixture
+    def handler(self, mock_logger: MagicMock) -> LoggingAuditHandler:
+        """Create handler with mock logger."""
+        return LoggingAuditHandler(logger=mock_logger)
+
+    @pytest.mark.asyncio
+    async def test_logs_api_request(self, handler: LoggingAuditHandler, mock_logger: MagicMock):
+        """Should log API request events."""
+        event = AuditEvent(
+            event_type=AuditEventType.API_REQUEST,
+            timestamp=datetime.now(UTC),
+            request_id="req-123",
+            client_id=None,
+            client_ip="127.0.0.1",
+            endpoint="/chat",
+            method="POST",
+        )
+
+        await handler.handle(event)
+
+        mock_logger.log.assert_called_once()
+        args, _kwargs = mock_logger.log.call_args
+        assert args[0] == 20  # INFO level
+        # Check that event type is passed as argument (will be formatted by logger)
+        assert args[2] == "api.request"
+
+    @pytest.mark.asyncio
+    async def test_logs_auth_failure_as_warning(
+        self, handler: LoggingAuditHandler, mock_logger: MagicMock
+    ):
+        """Should log auth failure events at WARNING level."""
+        event = AuditEvent(
+            event_type=AuditEventType.AUTH_FAILURE,
+            timestamp=datetime.now(UTC),
+            request_id="req-123",
+            client_id=None,
+            client_ip="127.0.0.1",
+            endpoint="/chat",
+            method="POST",
+        )
+
+        await handler.handle(event)
+
+        args, _kwargs = mock_logger.log.call_args
+        assert args[0] == 30  # WARNING level
+
+
+class TestConvenienceFunctions:
+    """Tests for audit convenience functions."""
+
+    @pytest.fixture
+    def mock_request(self) -> MagicMock:
+        """Create a mock FastAPI request."""
+        request = MagicMock()
+        request.url.path = "/chat"
+        request.method = "POST"
+        request.client.host = "192.168.1.1"
+        request.query_params = {"limit": "10"}
+        request.headers = {
+            "content-type": "application/json",
+            "user-agent": "test-agent",
+        }
+        return request
+
+    @pytest.fixture
+    def sample_client(self) -> APIKeyInfo:
+        """Create a sample client."""
+        return APIKeyInfo(
+            key_id="test-key-id",
+            name="Test Key",
+            tier=APIKeyTier.STANDARD,
+            organization="Test Org",
+            created_at=datetime.now(UTC),
+            expires_at=None,
+            rate_limit="50/minute",
+            is_active=True,
+            scopes=("chat", "search"),
+            metadata={},
+        )
+
+    @pytest.mark.asyncio
+    async def test_log_api_request(self, mock_request: MagicMock, sample_client: APIKeyInfo):
+        """log_api_request should create correct event."""
+        # Use a fresh logger to capture the event
+        logger = AuditLogger()
+        captured_events: list[AuditEvent] = []
+
+        class CaptureHandler(AuditHandler):
+            async def handle(self, event: AuditEvent) -> None:
+                captured_events.append(event)
+
+        logger.add_handler(CaptureHandler())
+
+        # Temporarily replace global logger
+        from requirements_graphrag_api.auth import audit
+
+        original_logger = audit.audit_logger
+        audit.audit_logger = logger
+
+        try:
+            await log_api_request(mock_request, sample_client, "req-123")
+
+            assert len(captured_events) == 1
+            event = captured_events[0]
+            assert event.event_type == AuditEventType.API_REQUEST
+            assert event.client_id == "test-key-id"
+            assert event.endpoint == "/chat"
+            assert event.method == "POST"
+        finally:
+            audit.audit_logger = original_logger
+
+    @pytest.mark.asyncio
+    async def test_log_api_response(self, mock_request: MagicMock, sample_client: APIKeyInfo):
+        """log_api_response should create correct event."""
+        logger = AuditLogger()
+        captured_events: list[AuditEvent] = []
+
+        class CaptureHandler(AuditHandler):
+            async def handle(self, event: AuditEvent) -> None:
+                captured_events.append(event)
+
+        logger.add_handler(CaptureHandler())
+
+        from requirements_graphrag_api.auth import audit
+
+        original_logger = audit.audit_logger
+        audit.audit_logger = logger
+
+        try:
+            await log_api_response(mock_request, sample_client, "req-123", 200, 150.5)
+
+            assert len(captured_events) == 1
+            event = captured_events[0]
+            assert event.event_type == AuditEventType.API_RESPONSE
+            assert event.status_code == 200
+            assert event.duration_ms == 150.5
+        finally:
+            audit.audit_logger = original_logger
+
+    @pytest.mark.asyncio
+    async def test_log_api_error(self, mock_request: MagicMock):
+        """log_api_error should create correct event."""
+        logger = AuditLogger()
+        captured_events: list[AuditEvent] = []
+
+        class CaptureHandler(AuditHandler):
+            async def handle(self, event: AuditEvent) -> None:
+                captured_events.append(event)
+
+        logger.add_handler(CaptureHandler())
+
+        from requirements_graphrag_api.auth import audit
+
+        original_logger = audit.audit_logger
+        audit.audit_logger = logger
+
+        try:
+            await log_api_error(
+                mock_request,
+                None,
+                "req-123",
+                500,
+                "internal_error",
+                "Something went wrong",
+            )
+
+            assert len(captured_events) == 1
+            event = captured_events[0]
+            assert event.event_type == AuditEventType.API_ERROR
+            assert event.status_code == 500
+            assert event.details["error_type"] == "internal_error"
+        finally:
+            audit.audit_logger = original_logger
+
+    @pytest.mark.asyncio
+    async def test_log_auth_success(self, mock_request: MagicMock, sample_client: APIKeyInfo):
+        """log_auth_success should create correct event."""
+        logger = AuditLogger()
+        captured_events: list[AuditEvent] = []
+
+        class CaptureHandler(AuditHandler):
+            async def handle(self, event: AuditEvent) -> None:
+                captured_events.append(event)
+
+        logger.add_handler(CaptureHandler())
+
+        from requirements_graphrag_api.auth import audit
+
+        original_logger = audit.audit_logger
+        audit.audit_logger = logger
+
+        try:
+            await log_auth_success(mock_request, sample_client, "req-123")
+
+            assert len(captured_events) == 1
+            event = captured_events[0]
+            assert event.event_type == AuditEventType.AUTH_SUCCESS
+            assert event.client_id == "test-key-id"
+        finally:
+            audit.audit_logger = original_logger
+
+    @pytest.mark.asyncio
+    async def test_log_auth_failure(self, mock_request: MagicMock):
+        """log_auth_failure should create correct event."""
+        logger = AuditLogger()
+        captured_events: list[AuditEvent] = []
+
+        class CaptureHandler(AuditHandler):
+            async def handle(self, event: AuditEvent) -> None:
+                captured_events.append(event)
+
+        logger.add_handler(CaptureHandler())
+
+        from requirements_graphrag_api.auth import audit
+
+        original_logger = audit.audit_logger
+        audit.audit_logger = logger
+
+        try:
+            await log_auth_failure(mock_request, "req-123", "invalid_key")
+
+            assert len(captured_events) == 1
+            event = captured_events[0]
+            assert event.event_type == AuditEventType.AUTH_FAILURE
+            assert event.details["reason"] == "invalid_key"
+        finally:
+            audit.audit_logger = original_logger
+
+    @pytest.mark.asyncio
+    async def test_log_guardrail_event_blocked(self, mock_request: MagicMock):
+        """log_guardrail_event should use BLOCKED type when blocked."""
+        logger = AuditLogger()
+        captured_events: list[AuditEvent] = []
+
+        class CaptureHandler(AuditHandler):
+            async def handle(self, event: AuditEvent) -> None:
+                captured_events.append(event)
+
+        logger.add_handler(CaptureHandler())
+
+        from requirements_graphrag_api.auth import audit
+
+        original_logger = audit.audit_logger
+        audit.audit_logger = logger
+
+        try:
+            await log_guardrail_event(
+                mock_request,
+                None,
+                "req-123",
+                "prompt_injection",
+                triggered=True,
+                blocked=True,
+                details={"risk_level": "high"},
+            )
+
+            assert len(captured_events) == 1
+            event = captured_events[0]
+            assert event.event_type == AuditEventType.GUARDRAIL_BLOCKED
+            assert event.details["guardrail"] == "prompt_injection"
+        finally:
+            audit.audit_logger = original_logger
+
+    @pytest.mark.asyncio
+    async def test_log_rate_limit_exceeded(self, mock_request: MagicMock):
+        """log_rate_limit_event should use EXCEEDED type when exceeded."""
+        logger = AuditLogger()
+        captured_events: list[AuditEvent] = []
+
+        class CaptureHandler(AuditHandler):
+            async def handle(self, event: AuditEvent) -> None:
+                captured_events.append(event)
+
+        logger.add_handler(CaptureHandler())
+
+        from requirements_graphrag_api.auth import audit
+
+        original_logger = audit.audit_logger
+        audit.audit_logger = logger
+
+        try:
+            await log_rate_limit_event(
+                mock_request,
+                None,
+                "req-123",
+                exceeded=True,
+                limit="50/minute",
+                current_count=51,
+            )
+
+            assert len(captured_events) == 1
+            event = captured_events[0]
+            assert event.event_type == AuditEventType.RATE_LIMIT_EXCEEDED
+            assert event.details["limit"] == "50/minute"
+            assert event.details["current_count"] == 51
+        finally:
+            audit.audit_logger = original_logger

--- a/backend/tests/test_auth/test_middleware.py
+++ b/backend/tests/test_auth/test_middleware.py
@@ -1,0 +1,296 @@
+"""Tests for authentication middleware."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from requirements_graphrag_api.auth.api_key import (
+    APIKeyInfo,
+    APIKeyTier,
+    InMemoryAPIKeyStore,
+    generate_api_key,
+)
+from requirements_graphrag_api.auth.middleware import (
+    AuthMiddleware,
+    get_current_client,
+    get_current_request_id,
+)
+
+
+class TestAuthMiddlewareAnonymousAccess:
+    """Tests for middleware with anonymous access allowed."""
+
+    @pytest.fixture
+    def app_anonymous_allowed(self) -> FastAPI:
+        """Create app allowing anonymous access."""
+        app = FastAPI()
+        app.state.api_key_store = InMemoryAPIKeyStore()
+        app.add_middleware(AuthMiddleware, require_auth=False)
+
+        @app.get("/test")
+        async def test_endpoint():
+            client = get_current_client()
+            request_id = get_current_request_id()
+            return {
+                "client_id": client.key_id if client else None,
+                "request_id": request_id,
+            }
+
+        @app.get("/health")
+        async def health():
+            return {"status": "ok"}
+
+        return app
+
+    @pytest.fixture
+    def client_anonymous(self, app_anonymous_allowed: FastAPI) -> TestClient:
+        """Create test client."""
+        return TestClient(app_anonymous_allowed)
+
+    def test_allows_request_without_key(self, client_anonymous: TestClient):
+        """Should allow requests without API key."""
+        response = client_anonymous.get("/test")
+        assert response.status_code == 200
+        # Should be anonymous
+        assert response.json()["client_id"] == "anonymous"
+
+    def test_includes_request_id_header(self, client_anonymous: TestClient):
+        """Should include X-Request-ID in response."""
+        response = client_anonymous.get("/test")
+        assert "X-Request-ID" in response.headers
+        assert len(response.headers["X-Request-ID"]) == 36  # UUID length
+
+    def test_health_endpoint_skips_auth(self, client_anonymous: TestClient):
+        """Should skip auth for health endpoint."""
+        response = client_anonymous.get("/health")
+        assert response.status_code == 200
+
+
+class TestAuthMiddlewareRequiredAuth:
+    """Tests for middleware with required authentication."""
+
+    @pytest.fixture
+    def app_auth_required(self) -> FastAPI:
+        """Create app requiring authentication."""
+        app = FastAPI()
+        app.state.api_key_store = InMemoryAPIKeyStore()
+        app.add_middleware(AuthMiddleware, require_auth=True)
+
+        @app.get("/test")
+        async def test_endpoint():
+            client = get_current_client()
+            return {
+                "client_id": client.key_id if client else None,
+                "tier": client.tier if client else None,
+            }
+
+        @app.get("/health")
+        async def health():
+            return {"status": "ok"}
+
+        return app
+
+    @pytest.fixture
+    def client_auth_required(self, app_auth_required: FastAPI) -> TestClient:
+        """Create test client."""
+        return TestClient(app_auth_required)
+
+    def test_rejects_request_without_key(self, client_auth_required: TestClient):
+        """Should reject requests without API key."""
+        response = client_auth_required.get("/test")
+        assert response.status_code == 401
+        assert response.json()["detail"]["error"] == "missing_api_key"
+
+    def test_rejects_invalid_key_format(self, client_auth_required: TestClient):
+        """Should reject keys with invalid format."""
+        response = client_auth_required.get("/test", headers={"X-API-Key": "invalid_key"})
+        assert response.status_code == 401
+        assert response.json()["detail"]["error"] == "invalid_api_key_format"
+
+    def test_rejects_unknown_key(self, client_auth_required: TestClient):
+        """Should reject unknown keys."""
+        unknown_key = generate_api_key()
+        response = client_auth_required.get("/test", headers={"X-API-Key": unknown_key})
+        assert response.status_code == 403
+        assert response.json()["detail"]["error"] == "invalid_api_key"
+
+    def test_health_endpoint_skips_auth(self, client_auth_required: TestClient):
+        """Should skip auth for health endpoint even when required."""
+        response = client_auth_required.get("/health")
+        assert response.status_code == 200
+
+
+class TestAuthMiddlewareWithValidKey:
+    """Tests for middleware with valid API key."""
+
+    @pytest.fixture
+    async def app_with_valid_key(self) -> tuple[FastAPI, str]:
+        """Create app with a valid API key in store."""
+        app = FastAPI()
+        store = InMemoryAPIKeyStore()
+
+        # Create valid key
+        raw_key = generate_api_key()
+        info = APIKeyInfo(
+            key_id="valid-key-id",
+            name="Valid Key",
+            tier=APIKeyTier.STANDARD,
+            organization="Test Org",
+            created_at=datetime.now(UTC),
+            expires_at=None,
+            rate_limit="50/minute",
+            is_active=True,
+            scopes=("chat", "search", "feedback"),
+            metadata={},
+        )
+        await store.create(raw_key, info)
+
+        app.state.api_key_store = store
+        app.add_middleware(AuthMiddleware, require_auth=True)
+
+        @app.get("/test")
+        async def test_endpoint():
+            client = get_current_client()
+            return {
+                "client_id": client.key_id if client else None,
+                "tier": client.tier if client else None,
+                "organization": client.organization if client else None,
+            }
+
+        return app, raw_key
+
+    @pytest.mark.asyncio
+    async def test_allows_valid_key(self, app_with_valid_key: tuple[FastAPI, str]):
+        """Should allow requests with valid API key."""
+        app, raw_key = app_with_valid_key
+        with TestClient(app) as client:
+            response = client.get("/test", headers={"X-API-Key": raw_key})
+            assert response.status_code == 200
+            data = response.json()
+            assert data["client_id"] == "valid-key-id"
+            assert data["tier"] == "standard"
+            assert data["organization"] == "Test Org"
+
+    @pytest.mark.asyncio
+    async def test_context_available_in_handler(self, app_with_valid_key: tuple[FastAPI, str]):
+        """Should make client available via get_current_client()."""
+        app, raw_key = app_with_valid_key
+        with TestClient(app) as client:
+            response = client.get("/test", headers={"X-API-Key": raw_key})
+            assert response.status_code == 200
+            # Client info should be available
+            assert response.json()["client_id"] is not None
+
+
+class TestAuthMiddlewareRevokedKey:
+    """Tests for middleware with revoked API key."""
+
+    @pytest.fixture
+    async def app_with_revoked_key(self) -> tuple[FastAPI, str]:
+        """Create app with a revoked API key."""
+        app = FastAPI()
+        store = InMemoryAPIKeyStore()
+
+        # Create and revoke key
+        raw_key = generate_api_key()
+        info = APIKeyInfo(
+            key_id="revoked-key-id",
+            name="Revoked Key",
+            tier=APIKeyTier.STANDARD,
+            organization=None,
+            created_at=datetime.now(UTC),
+            expires_at=None,
+            rate_limit="50/minute",
+            is_active=True,
+            scopes=("chat",),
+            metadata={},
+        )
+        await store.create(raw_key, info)
+        await store.revoke("revoked-key-id")
+
+        app.state.api_key_store = store
+        app.add_middleware(AuthMiddleware, require_auth=True)
+
+        @app.get("/test")
+        async def test_endpoint():
+            return {"status": "ok"}
+
+        return app, raw_key
+
+    @pytest.mark.asyncio
+    async def test_rejects_revoked_key(self, app_with_revoked_key: tuple[FastAPI, str]):
+        """Should reject revoked keys."""
+        app, raw_key = app_with_revoked_key
+        with TestClient(app) as client:
+            response = client.get("/test", headers={"X-API-Key": raw_key})
+            assert response.status_code == 403
+            assert response.json()["detail"]["error"] == "api_key_revoked"
+
+
+class TestContextVariables:
+    """Tests for context variable functions."""
+
+    def test_get_current_client_outside_request(self):
+        """Should return None outside request context."""
+        client = get_current_client()
+        assert client is None
+
+    def test_get_current_request_id_outside_request(self):
+        """Should return None outside request context."""
+        request_id = get_current_request_id()
+        assert request_id is None
+
+
+class TestSkipAuthPaths:
+    """Tests for paths that skip authentication."""
+
+    @pytest.fixture
+    def app_with_skip_paths(self) -> FastAPI:
+        """Create app with common paths."""
+        app = FastAPI(docs_url="/docs", redoc_url="/redoc")
+        app.state.api_key_store = InMemoryAPIKeyStore()
+        app.add_middleware(AuthMiddleware, require_auth=True)
+
+        @app.get("/")
+        async def root():
+            return {"status": "ok"}
+
+        @app.get("/health")
+        async def health():
+            return {"status": "healthy"}
+
+        @app.get("/protected")
+        async def protected():
+            return {"status": "protected"}
+
+        return app
+
+    @pytest.fixture
+    def client_skip_paths(self, app_with_skip_paths: FastAPI) -> TestClient:
+        """Create test client."""
+        return TestClient(app_with_skip_paths)
+
+    def test_root_skips_auth(self, client_skip_paths: TestClient):
+        """Root path should skip auth."""
+        response = client_skip_paths.get("/")
+        assert response.status_code == 200
+
+    def test_health_skips_auth(self, client_skip_paths: TestClient):
+        """Health path should skip auth."""
+        response = client_skip_paths.get("/health")
+        assert response.status_code == 200
+
+    def test_docs_skips_auth(self, client_skip_paths: TestClient):
+        """Docs path should skip auth."""
+        response = client_skip_paths.get("/docs")
+        # May redirect or return 200
+        assert response.status_code in (200, 307)
+
+    def test_protected_requires_auth(self, client_skip_paths: TestClient):
+        """Protected path should require auth."""
+        response = client_skip_paths.get("/protected")
+        assert response.status_code == 401

--- a/backend/tests/test_auth/test_scopes.py
+++ b/backend/tests/test_auth/test_scopes.py
@@ -1,0 +1,223 @@
+"""Tests for scope-based authorization."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import HTTPException
+
+from requirements_graphrag_api.auth.api_key import APIKeyInfo, APIKeyTier
+from requirements_graphrag_api.auth.scopes import (
+    DEFAULT_TIER_SCOPES,
+    ENDPOINT_SCOPES,
+    Scope,
+    ScopeChecker,
+    check_scopes,
+    require_scopes,
+)
+
+
+class TestScopeEnum:
+    """Tests for the Scope enum."""
+
+    def test_scope_values(self):
+        """Verify scope string values."""
+        assert Scope.CHAT == "chat"
+        assert Scope.SEARCH == "search"
+        assert Scope.FEEDBACK == "feedback"
+        assert Scope.ADMIN == "admin"
+
+    def test_all_scopes_defined(self):
+        """Ensure all expected scopes are defined."""
+        scopes = list(Scope)
+        assert len(scopes) == 4
+
+
+class TestDefaultTierScopes:
+    """Tests for default tier scope mappings."""
+
+    def test_free_tier_scopes(self):
+        """Free tier should have basic scopes."""
+        scopes = DEFAULT_TIER_SCOPES["free"]
+        assert Scope.CHAT in scopes
+        assert Scope.SEARCH in scopes
+        assert Scope.FEEDBACK not in scopes
+        assert Scope.ADMIN not in scopes
+
+    def test_standard_tier_scopes(self):
+        """Standard tier should have chat, search, feedback."""
+        scopes = DEFAULT_TIER_SCOPES["standard"]
+        assert Scope.CHAT in scopes
+        assert Scope.SEARCH in scopes
+        assert Scope.FEEDBACK in scopes
+        assert Scope.ADMIN not in scopes
+
+    def test_enterprise_tier_scopes(self):
+        """Enterprise tier should have all scopes."""
+        scopes = DEFAULT_TIER_SCOPES["enterprise"]
+        assert Scope.CHAT in scopes
+        assert Scope.SEARCH in scopes
+        assert Scope.FEEDBACK in scopes
+        assert Scope.ADMIN in scopes
+
+
+class TestEndpointScopes:
+    """Tests for endpoint scope mappings."""
+
+    def test_chat_endpoint_requires_chat_scope(self):
+        """Chat endpoint should require chat scope."""
+        assert Scope.CHAT in ENDPOINT_SCOPES["/chat"]
+
+    def test_search_endpoints_require_search_scope(self):
+        """Search endpoints should require search scope."""
+        assert Scope.SEARCH in ENDPOINT_SCOPES["/search/hybrid"]
+        assert Scope.SEARCH in ENDPOINT_SCOPES["/search/vector"]
+        assert Scope.SEARCH in ENDPOINT_SCOPES["/search/graph"]
+
+    def test_feedback_endpoint_requires_feedback_scope(self):
+        """Feedback endpoint should require feedback scope."""
+        assert Scope.FEEDBACK in ENDPOINT_SCOPES["/feedback"]
+
+
+class TestCheckScopes:
+    """Tests for the check_scopes function."""
+
+    def test_has_all_required_scopes(self):
+        """Should return True when client has all required scopes."""
+        client_scopes = ("chat", "search", "feedback")
+        required = (Scope.CHAT, Scope.SEARCH)
+        has_scopes, missing = check_scopes(client_scopes, required)
+        assert has_scopes is True
+        assert missing == set()
+
+    def test_missing_required_scopes(self):
+        """Should return False and list missing scopes."""
+        client_scopes = ("chat",)
+        required = (Scope.CHAT, Scope.SEARCH)
+        has_scopes, missing = check_scopes(client_scopes, required)
+        assert has_scopes is False
+        assert "search" in missing
+
+    def test_empty_required_scopes(self):
+        """Should return True when no scopes required."""
+        client_scopes = ("chat",)
+        required: tuple[Scope, ...] = ()
+        has_scopes, missing = check_scopes(client_scopes, required)
+        assert has_scopes is True
+        assert missing == set()
+
+    def test_empty_client_scopes(self):
+        """Should return False when client has no scopes."""
+        client_scopes: tuple[str, ...] = ()
+        required = (Scope.CHAT,)
+        has_scopes, missing = check_scopes(client_scopes, required)
+        assert has_scopes is False
+        assert "chat" in missing
+
+
+class TestScopeChecker:
+    """Tests for the ScopeChecker dependency."""
+
+    @pytest.fixture
+    def mock_request_with_client(self) -> MagicMock:
+        """Create a mock request with authenticated client."""
+        request = MagicMock()
+        request.state.client = APIKeyInfo(
+            key_id="test-key",
+            name="Test Key",
+            tier=APIKeyTier.STANDARD,
+            organization="Test Org",
+            created_at=datetime.now(UTC),
+            expires_at=None,
+            rate_limit="50/minute",
+            is_active=True,
+            scopes=("chat", "search", "feedback"),
+            metadata={},
+        )
+        return request
+
+    @pytest.fixture
+    def mock_request_anonymous(self) -> MagicMock:
+        """Create a mock request with no client."""
+        request = MagicMock()
+        request.state.client = None
+        return request
+
+    @pytest.mark.asyncio
+    async def test_allows_when_has_scope(self, mock_request_with_client: MagicMock):
+        """Should allow when client has required scope."""
+        checker = ScopeChecker(Scope.CHAT)
+        result = await checker(mock_request_with_client)
+        assert result is not None
+        assert result.key_id == "test-key"
+
+    @pytest.mark.asyncio
+    async def test_allows_multiple_scopes(self, mock_request_with_client: MagicMock):
+        """Should allow when client has all required scopes."""
+        checker = ScopeChecker(Scope.CHAT, Scope.SEARCH)
+        result = await checker(mock_request_with_client)
+        assert result is not None
+
+    @pytest.mark.asyncio
+    async def test_denies_missing_scope(self, mock_request_with_client: MagicMock):
+        """Should deny when client lacks required scope."""
+        checker = ScopeChecker(Scope.ADMIN)  # Client doesn't have admin
+        with pytest.raises(HTTPException) as exc_info:
+            await checker(mock_request_with_client)
+        assert exc_info.value.status_code == 403
+        assert exc_info.value.detail["error"] == "insufficient_scope"
+        assert "admin" in exc_info.value.detail["message"]
+
+    @pytest.mark.asyncio
+    async def test_denies_anonymous_when_required(self, mock_request_anonymous: MagicMock):
+        """Should deny anonymous when scopes required."""
+        checker = ScopeChecker(Scope.CHAT)
+        with pytest.raises(HTTPException) as exc_info:
+            await checker(mock_request_anonymous)
+        assert exc_info.value.status_code == 401
+        assert exc_info.value.detail["error"] == "authentication_required"
+
+    @pytest.mark.asyncio
+    async def test_allows_anonymous_when_configured(self, mock_request_anonymous: MagicMock):
+        """Should allow anonymous when allow_anonymous=True."""
+        checker = ScopeChecker(Scope.CHAT, allow_anonymous=True)
+        result = await checker(mock_request_anonymous)
+        assert result is None
+
+
+class TestRequireScopesDependency:
+    """Tests for the require_scopes convenience function."""
+
+    @pytest.fixture
+    def mock_request_with_client(self) -> MagicMock:
+        """Create a mock request with authenticated client."""
+        request = MagicMock()
+        request.state.client = APIKeyInfo(
+            key_id="test-key",
+            name="Test Key",
+            tier=APIKeyTier.STANDARD,
+            organization=None,
+            created_at=datetime.now(UTC),
+            expires_at=None,
+            rate_limit="50/minute",
+            is_active=True,
+            scopes=("chat", "search"),
+            metadata={},
+        )
+        return request
+
+    @pytest.mark.asyncio
+    async def test_returns_scope_checker(self, mock_request_with_client: MagicMock):
+        """Should return a callable ScopeChecker."""
+        checker = require_scopes(Scope.CHAT)
+        assert isinstance(checker, ScopeChecker)
+
+    @pytest.mark.asyncio
+    async def test_checker_works_correctly(self, mock_request_with_client: MagicMock):
+        """Returned checker should work correctly."""
+        checker = require_scopes(Scope.CHAT, Scope.SEARCH)
+        result = await checker(mock_request_with_client)
+        assert result is not None
+        assert result.key_id == "test-key"


### PR DESCRIPTION
## Summary

Implements Phase 3 of the guardrails system as specified in `docs/guardrails/PHASE3_ACCESS_CONTROL.md`:

- **API Key Authentication**: Secure key generation (`rgapi_` prefix), SHA-256 hashing, format validation, and `InMemoryAPIKeyStore`
- **Authentication Middleware**: Request validation with context variables, automatic request ID tracing
- **Scope-Based Authorization**: `CHAT`, `SEARCH`, `FEEDBACK`, `ADMIN` scopes with tier-based defaults
- **Audit Logging**: Structured events with pluggable handlers for compliance tracking

### Key Design Decisions

| Decision | Rationale |
|----------|-----------|
| `REQUIRE_API_KEY=false` default | Backward compatibility - existing deployments continue working |
| `InMemoryAPIKeyStore` | Development/testing only - production needs DB backend |
| Audit logging enabled by default | Compliance and security monitoring from day one |

### Files Changed

**New Auth Module** (`backend/src/requirements_graphrag_api/auth/`):
- `api_key.py` - Key generation, hashing, validation, storage
- `middleware.py` - FastAPI middleware with context variables
- `scopes.py` - Scope enum and authorization decorators/dependencies
- `audit.py` - Structured audit events and handlers
- `__init__.py` - Clean module exports

**Modified**:
- `config.py` - Added `AuthConfig` dataclass
- `api.py` - Integrated middleware and audit logging

**Tests** (93 new tests):
- `test_api_key.py`, `test_middleware.py`, `test_scopes.py`, `test_audit.py`

## Test plan

- [x] All 506 tests pass locally (93 new + 413 existing)
- [x] `uv run ruff check` passes
- [ ] CI pipeline passes

Closes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)