### PR TITLE
fix(auth): serialize metadata to JSON for PostgreSQL JSONB column

### DIFF
--- a/backend/src/requirements_graphrag_api/auth/postgres_store.py
+++ b/backend/src/requirements_graphrag_api/auth/postgres_store.py
@@ -16,6 +16,7 @@ Usage:
 
 from __future__ import annotations
 
+import json
 import logging
 from typing import TYPE_CHECKING
 
@@ -221,7 +222,7 @@ class PostgresAPIKeyStore(APIKeyStore):
                 info.rate_limit,
                 info.is_active,
                 list(info.scopes),
-                info.metadata,
+                json.dumps(info.metadata),  # Serialize dict to JSON string for JSONB
             )
         logger.info("Created API key: key_id=%s, tier=%s", info.key_id, info.tier)
 


### PR DESCRIPTION
## Summary

Fixes bug when creating API keys with PostgreSQL store. The asyncpg driver requires explicit JSON serialization for JSONB columns.

**Error:**
```
ERROR: Failed to create key: invalid input for query argument $11: {'created_by': 'create_api_key.py'} (expected str, got dict)
```

**Fix:**
Added `json.dumps()` when storing the metadata dict in the `create()` method.

## Test plan
- [x] All 20 postgres store tests pass
- [x] Ruff passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)