### PR TITLE
fix(frontend): add X-API-Key header to all API requests

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,6 @@
+# Backend API URL
+VITE_API_URL=http://localhost:8000
+
+# API Key for authenticated requests (required in production)
+# Create a key using: python scripts/create_api_key.py create --name "Frontend App" --tier standard
+VITE_API_KEY=your_api_key_here

--- a/frontend/src/components/feedback/FeedbackBar.jsx
+++ b/frontend/src/components/feedback/FeedbackBar.jsx
@@ -1,6 +1,5 @@
 import { useState } from 'react'
-
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+import { apiFetch } from '../../utils/api'
 
 /**
  * Thumbs up icon
@@ -62,9 +61,8 @@ export function FeedbackBar({ runId, messageId, disabled }) {
     setIsSubmitting(true)
 
     try {
-      const response = await fetch(`${API_URL}/feedback`, {
+      const response = await apiFetch('/feedback', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           run_id: runId,
           score: score, // 1 for positive, 0 for negative

--- a/frontend/src/components/feedback/ResponseActions.jsx
+++ b/frontend/src/components/feedback/ResponseActions.jsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
 import { FeedbackModal } from './FeedbackModal'
-
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+import { apiFetch } from '../../utils/api'
 
 // Copy icon (outline style like Claude Desktop)
 function CopyIcon() {
@@ -78,9 +77,8 @@ export function ResponseActions({ content, runId, messageId }) {
     if (!runId) return
 
     try {
-      await fetch(`${API_URL}/feedback`, {
+      await apiFetch('/feedback', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
           run_id: runId,
           score: isPositive ? 1.0 : 0.0,

--- a/frontend/src/hooks/useSSEChat.js
+++ b/frontend/src/hooks/useSSEChat.js
@@ -1,6 +1,5 @@
 import { useState, useMemo, useCallback } from 'react'
-
-const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+import { API_URL, API_KEY } from '../utils/api'
 
 /**
  * Generate a unique conversation ID (UUID v4)
@@ -198,7 +197,10 @@ export function useSSEChat() {
 
         const response = await fetch(`${API_URL}/chat`, {
           method: 'POST',
-          headers: { 'Content-Type': 'application/json' },
+          headers: {
+            'Content-Type': 'application/json',
+            ...(API_KEY && { 'X-API-Key': API_KEY }),
+          },
           body: JSON.stringify({
             message: input,
             conversation_id: conversationId,

--- a/frontend/src/utils/api.js
+++ b/frontend/src/utils/api.js
@@ -1,0 +1,41 @@
+/**
+ * API utilities for making authenticated requests to the backend.
+ */
+
+const API_URL = import.meta.env.VITE_API_URL || 'http://localhost:8000'
+const API_KEY = import.meta.env.VITE_API_KEY || ''
+
+/**
+ * Get headers for API requests, including authentication if configured.
+ * @param {Object} additionalHeaders - Additional headers to include
+ * @returns {Object} Headers object
+ */
+export const getApiHeaders = (additionalHeaders = {}) => {
+  const headers = {
+    'Content-Type': 'application/json',
+    ...additionalHeaders,
+  }
+
+  if (API_KEY) {
+    headers['X-API-Key'] = API_KEY
+  }
+
+  return headers
+}
+
+/**
+ * Make an authenticated fetch request to the API.
+ * @param {string} endpoint - API endpoint (e.g., '/chat')
+ * @param {Object} options - Fetch options
+ * @returns {Promise<Response>}
+ */
+export const apiFetch = async (endpoint, options = {}) => {
+  const { headers: customHeaders, ...restOptions } = options
+
+  return fetch(`${API_URL}${endpoint}`, {
+    ...restOptions,
+    headers: getApiHeaders(customHeaders),
+  })
+}
+
+export { API_URL, API_KEY }


### PR DESCRIPTION
## Summary
- Creates a centralized `utils/api.js` module for authenticated API requests
- Updates `useSSEChat.js` to include `X-API-Key` header in chat requests
- Updates `FeedbackBar.jsx` and `ResponseActions.jsx` to use `apiFetch` wrapper
- Adds `VITE_API_KEY` to `.env.example` for documentation

## Problem
The frontend was failing after enabling API authentication (`REQUIRE_API_KEY=true`) because the React app wasn't including the `X-API-Key` header in its fetch requests.

## Test Plan
- [ ] Frontend loads without errors
- [ ] Chat works with API key configured
- [ ] Feedback submission (thumbs up/down) works
- [ ] Works in development with optional key
- [ ] Works in production with required key

## Deployment Note
After merging, add `VITE_API_KEY` environment variable in Vercel dashboard:
1. Go to Vercel project settings → Environment Variables
2. Add: `VITE_API_KEY` = `<your frontend API key>`
3. Redeploy

Closes #102

🤖 Generated with [Claude Code](https://claude.com/claude-code)