### PR TITLE
fix(auth): allow CORS preflight OPTIONS requests without authentication

### DIFF
--- a/backend/src/requirements_graphrag_api/auth/middleware.py
+++ b/backend/src/requirements_graphrag_api/auth/middleware.py
@@ -166,8 +166,9 @@ class AuthMiddleware(BaseHTTPMiddleware):
         # Add request ID to response headers for tracing
         # This will be done after call_next
 
-        # Skip auth for specific paths
-        if request.url.path in SKIP_AUTH_PATHS:
+        # Skip auth for specific paths and CORS preflight requests
+        # OPTIONS requests are sent by browsers before actual requests to check CORS
+        if request.url.path in SKIP_AUTH_PATHS or request.method == "OPTIONS":
             request.state.client = None
             request.state.request_id = request_id
             try:


### PR DESCRIPTION
## Summary
Fixes CORS preflight requests being blocked by authentication middleware.

## Problem
Browser CORS preflight (OPTIONS) requests were returning 401 because the auth middleware required API keys for all non-health endpoints. Browsers send OPTIONS requests **without** custom headers to check CORS policy before the actual request.

## Solution
Skip authentication for `OPTIONS` method requests, allowing the CORS middleware to handle them properly.

## Test Plan
- [x] All 641 backend tests pass
- [ ] Test CORS preflight request returns 200
- [ ] Test frontend chat works from https://graphrag.norfolkaibi.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)