### PR TITLE
fix(docker): pre-install spaCy model for PII detection

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -32,6 +32,9 @@ COPY backend/README.md ./
 # Install dependencies (no dev dependencies for production)
 RUN uv sync --frozen --no-dev --no-editable
 
+# Download spaCy model for PII detection (Presidio requires this)
+RUN /app/.venv/bin/python -m spacy download en_core_web_lg
+
 # ============================================================================
 # Production stage
 # ============================================================================


### PR DESCRIPTION
## Summary
Pre-installs the spaCy `en_core_web_lg` model during Docker build for PII detection.

## Problem
The Presidio PII analyzer requires a spaCy language model. Previously, it tried to download the model on first use, causing:
- Request timeouts (model download takes too long)
- Container crashes (`SystemExit: 1` from failed download)
- PII detection had to be disabled as a workaround

## Solution
Add `python -m spacy download en_core_web_lg` to the Dockerfile builder stage, so the model is pre-installed and available immediately at runtime.

## Test Plan
- [x] Dockerfile syntax valid
- [ ] After merge: re-enable PII detection (`GUARDRAIL_PII_DETECTION_ENABLED=true`)
- [ ] Verify PII detection works in production

## Note
This will increase Docker image size by ~500MB (the spaCy model). This is acceptable for production use.

🤖 Generated with [Claude Code](https://claude.com/claude-code)