### PR TITLE
fix(docker): use uv pip to install spaCy model

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -33,7 +33,8 @@ COPY backend/README.md ./
 RUN uv sync --frozen --no-dev --no-editable
 
 # Download spaCy model for PII detection (Presidio requires this)
-RUN /app/.venv/bin/python -m spacy download en_core_web_lg
+# Note: uv venvs don't include pip, so we use uv pip install directly
+RUN uv pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.8.0/en_core_web_lg-3.8.0-py3-none-any.whl
 
 # ============================================================================
 # Production stage


### PR DESCRIPTION
## Summary
Fixes the Docker build failure caused by `spacy download` requiring pip.

## Problem
The `uv` package manager creates virtual environments without pip by default. The previous Dockerfile used:
```dockerfile
RUN /app/.venv/bin/python -m spacy download en_core_web_lg
```
This failed with: `No module named pip`

## Solution
Use `uv pip install` with the direct wheel URL:
```dockerfile
RUN uv pip install https://github.com/explosion/spacy-models/releases/download/en_core_web_lg-3.8.0/en_core_web_lg-3.8.0-py3-none-any.whl
```

## Test Plan
- [x] Local Docker build succeeds
- [ ] Railway deployment succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)