### PR TITLE
fix(agentic): extract source titles from correct metadata path

### DIFF
--- a/backend/src/requirements_graphrag_api/core/agentic/streaming.py
+++ b/backend/src/requirements_graphrag_api/core/agentic/streaming.py
@@ -212,6 +212,7 @@ async def stream_agentic_events(
         # Stream graph execution
         last_phase = None
         sources_emitted = False
+        source_count = 0
         final_answer = ""
 
         async for event in graph.astream_events(
@@ -263,7 +264,9 @@ async def stream_agentic_events(
                                     "score": doc.get("score", 0),
                                 }
                             )
-                    yield create_sources_event(sources).to_sse()
+                    if sources:
+                        yield create_sources_event(sources).to_sse()
+                        source_count = len(sources)
                     sources_emitted = True
 
             # Emit entities when research completes
@@ -305,8 +308,7 @@ async def stream_agentic_events(
                 chunk = final_answer[i : i + chunk_size]
                 yield create_token_event(chunk).to_sse()
 
-        # Emit done event
-        source_count = len(initial_state.get("ranked_results", []))
+        # Emit done event (source_count tracked when sources were emitted)
         yield create_done_event(
             full_answer=final_answer,
             source_count=source_count,

--- a/backend/src/requirements_graphrag_api/core/agentic/subgraphs/rag.py
+++ b/backend/src/requirements_graphrag_api/core/agentic/subgraphs/rag.py
@@ -190,13 +190,28 @@ def create_rag_subgraph(
         # Convert to RetrievedDocument format
         ranked_results = []
         for result in unique_results:
+            # Get metadata dict (graph_enriched_search returns nested metadata)
+            metadata = result.get("metadata", {})
+
+            # Extract content - may be at 'text' or 'content' depending on source
+            content = result.get("text") or result.get("content", "")
+
+            # Extract source title from metadata (title) or top-level (article_title)
+            source_title = (
+                metadata.get("title")
+                or metadata.get("article_title")
+                or result.get("article_title")
+                or "Unknown"
+            )
+
             doc = RetrievedDocument(
-                content=result.get("text", ""),
-                source=result.get("article_title", "Unknown"),
+                content=content,
+                source=source_title,
                 score=result.get("score", 0.0),
                 metadata={
-                    "chunk_id": result.get("chunk_id"),
-                    "url": result.get("url"),
+                    "chunk_id": metadata.get("chunk_id") or result.get("chunk_id"),
+                    "url": metadata.get("url") or result.get("url"),
+                    "chapter": metadata.get("chapter"),
                     "entities": result.get("entities", []),
                     "source_query": result.get("_source_query"),
                 },


### PR DESCRIPTION
## Summary

Fixes production bug where sources displayed as "[1] Unknown" instead of showing article titles.

**Root Cause:**
- The RAG subgraph was looking for `result["article_title"]` 
- But `graph_enriched_search` returns titles at `result["metadata"]["title"]`

**Changes:**

### `subgraphs/rag.py`
- Fix source title extraction to check `metadata.title` first
- Handle content at both `content` and `text` keys
- Include chapter metadata for richer source information

### `streaming.py`
- Track `source_count` when sources are actually emitted (not from initial_state)
- Only emit sources event if sources array is non-empty

## Test plan

- [x] All 46 agentic tests pass
- [x] Ruff linting passes
- [ ] Manual test in production after deploy

## Screenshots

**Before:** Sources show "[1] Unknown"
**After:** Sources should show actual article titles

🤖 Generated with [Claude Code](https://claude.com/claude-code)