### PR TITLE
fix(agentic): restore rich metadata in sources event

### DIFF
--- a/backend/src/requirements_graphrag_api/core/agentic/subgraphs/rag.py
+++ b/backend/src/requirements_graphrag_api/core/agentic/subgraphs/rag.py
@@ -214,6 +214,11 @@ def create_rag_subgraph(
                     "chapter": metadata.get("chapter"),
                     "entities": result.get("entities", []),
                     "source_query": result.get("_source_query"),
+                    # Preserve enriched data for frontend display
+                    "media": result.get("media", {}),
+                    "glossary_definitions": result.get("glossary_definitions", []),
+                    "industry_standards": result.get("industry_standards", []),
+                    "semantic_relationships": result.get("semantic_relationships", {}),
                 },
             )
             ranked_results.append(doc)


### PR DESCRIPTION
## Summary

**Critical regression fix** - restores missing functionality in the agentic RAG system.

The new agentic system was losing rich metadata that the old system provided:
- ❌ Sources missing URLs (showed "[1] Unknown" with no links)
- ❌ Entities/Concepts section gone
- ❌ Webinars section gone  
- ❌ Images section gone
- ❌ Videos section gone

### Root Cause

When converting enriched results to `RetrievedDocument`, we were only preserving basic metadata. The streaming code then only extracted minimal source info.

### Changes

**`subgraphs/rag.py`:**
- Preserve full enriched metadata in RetrievedDocument:
  - `media` (webinars, images, videos)
  - `glossary_definitions`
  - `industry_standards`
  - `semantic_relationships`

**`streaming.py`:**
- Extract URLs from metadata and include in sources
- Extract entities with definitions and labels
- Extract glossary definitions as Definition-labeled entities
- Extract and deduplicate media resources (webinars, images, videos)
- Emit complete sources event with `entities` and `resources` dicts

### Frontend Data Structure (Restored)

```json
{
  "sources": [
    {"title": "Article Title", "url": "https://...", "content": "...", "relevance_score": 0.95}
  ],
  "entities": [
    {"name": "Requirements Traceability", "definition": "...", "label": "Concept"}
  ],
  "resources": {
    "webinars": [{"title": "...", "url": "...", "thumbnail_url": "..."}],
    "images": [{"title": "...", "url": "...", "alt_text": "..."}],
    "videos": [{"title": "...", "url": "..."}]
  }
}
```

## Test plan

- [x] All 46 agentic tests pass
- [x] Ruff linting passes
- [ ] Manual verification in production: sources show URLs, entities appear, webinars appear

🤖 Generated with [Claude Code](https://claude.com/claude-code)