### PR TITLE
fix: disable LLM grader and fix entity formatting

### DIFF
--- a/backend/src/requirements_graphrag_api/core/agentic/state.py
+++ b/backend/src/requirements_graphrag_api/core/agentic/state.py
@@ -110,8 +110,8 @@ class GradeDocuments(BaseModel):
     """
 
     binary_score: Literal["yes", "no"] = Field(
-        description="Relevance score: 'yes' if the document is relevant "
-        "to the question, 'no' otherwise.",
+        description="'yes' if the document could provide useful context "
+        "or background knowledge for the question, 'no' otherwise.",
     )
 
 

--- a/backend/src/requirements_graphrag_api/core/agentic/subgraphs/research.py
+++ b/backend/src/requirements_graphrag_api/core/agentic/subgraphs/research.py
@@ -167,7 +167,10 @@ def create_research_subgraph(
                     related_entities=[
                         r.get("name", "") for r in result.get("related_entities", [])
                     ],
-                    mentioned_in=result.get("mentioned_in", [])[:5],
+                    mentioned_in=[
+                        m if isinstance(m, str) else m.get("title", str(m))
+                        for m in result.get("mentioned_in", [])[:5]
+                    ],
                 )
                 logger.info(
                     "Explored %s: %d related, %d articles",


### PR DESCRIPTION
## Summary
- **Disable `grade_documents` LLM grader** — converted to pass-through that keeps all ranked docs. The per-document LLM grading (10 sequential API calls) rejected valid webinar/domain-qualified content, causing 0-result regressions. Vector similarity from retrieval is a sufficient relevance signal.
- **Fix `format_entity_info_for_synthesis` TypeError** — `entity.mentioned_in` contained dicts from `explore_entity`, not strings. Coerced to strings so research context reaches synthesis intact.
- **Update `GradeDocuments` field description** — aligned with softer "useful context" framing.

## Test plan
- [x] 837 tests pass (3 pre-existing auth errors unrelated)
- [x] Verified in LangGraph Studio: "List all webinars about traceability" returns 10 docs → synthesis produces answer with citations
- [ ] Broader query testing tomorrow

Closes #147

🤖 Generated with [Claude Code](https://claude.com/claude-code)