### PR TITLE
Fix: Studio returns identical responses on same thread

### DIFF
--- a/backend/src/requirements_graphrag_api/core/agentic/orchestrator.py
+++ b/backend/src/requirements_graphrag_api/core/agentic/orchestrator.py
@@ -106,10 +106,11 @@ def create_orchestrator_graph(
         Extracts the query from messages and sets up initial state.
         """
         messages = state.get("messages", [])
-        query = state.get("query", "")
+        query = ""
 
-        # Extract query from last human message if not explicitly set
-        if not query and messages:
+        # Always extract query from the latest human message so that
+        # checkpointer-restored state doesn't shadow new user input.
+        if messages:
             for msg in reversed(messages):
                 if isinstance(msg, HumanMessage):
                     query = msg.content


### PR DESCRIPTION
## Summary
- `initialize` node used persisted `query` from checkpointer state instead of reading the latest `HumanMessage`
- All queries on the same Studio thread returned the first query's response
- One-line fix: always extract query from messages, ignore persisted `query` field

## Test plan
- [x] 837 unit tests pass
- [x] Verified in LangGraph Studio: different queries on same thread now return distinct responses

🤖 Generated with [Claude Code](https://claude.com/claude-code)