### PR TITLE
feat: hub-first prompt infrastructure (#155)

### DIFF
--- a/.github/workflows/sync-prompts.yml
+++ b/.github/workflows/sync-prompts.yml
@@ -39,9 +39,8 @@ jobs:
           LANGSMITH_API_KEY: ${{ secrets.LANGSMITH_API_KEY }}
           # LangSmith Hub requires an owner (user or org) for prompts
           LANGSMITH_ORG: ${{ secrets.LANGSMITH_ORG }}
-          # Workspace ID - try both env vars the SDK might check
-          LANGSMITH_TENANT_ID: ${{ secrets.LANGSMITH_WORKSPACE }}
-          LANGCHAIN_TENANT_ID: ${{ secrets.LANGSMITH_WORKSPACE }}
+          # Workspace ID for org-scoped API keys (catalog.py reads this)
+          LANGSMITH_WORKSPACE_ID: ${{ secrets.LANGSMITH_WORKSPACE }}
 
       - name: Summary
         run: |

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -44,7 +44,7 @@ dependencies = [
     "tiktoken>=0.7.0",
     "httpx>=0.27.0",
     # Observability (LangSmith)
-    "langsmith>=0.1.0",
+    "langsmith>=0.7.0",
     # Guardrails - Phase 1 (Critical Security)
     "slowapi>=0.1.9",
     "presidio-analyzer>=2.2.0",

--- a/backend/scripts/run_ragas_evaluation.py
+++ b/backend/scripts/run_ragas_evaluation.py
@@ -80,9 +80,9 @@ async def create_rag_target(
     from langchain_core.output_parsers import StrOutputParser
     from langchain_openai import ChatOpenAI
 
-    from requirements_graphrag_api.prompts import PromptName, get_prompt_sync
+    from requirements_graphrag_api.prompts import PromptName, get_prompt
 
-    prompt_template = get_prompt_sync(PromptName.RAG_GENERATION)
+    prompt_template = await get_prompt(PromptName.RAG_GENERATION)
     llm = ChatOpenAI(model=model, temperature=0.1)
 
     async def rag_target(inputs: dict[str, Any]) -> dict[str, Any]:

--- a/backend/src/requirements_graphrag_api/core/agentic/subgraphs/rag.py
+++ b/backend/src/requirements_graphrag_api/core/agentic/subgraphs/rag.py
@@ -30,7 +30,7 @@ from requirements_graphrag_api.core.agentic.state import (
     RetrievedDocument,
 )
 from requirements_graphrag_api.evaluation.cost_analysis import get_global_cost_tracker
-from requirements_graphrag_api.prompts import PromptName, get_prompt_sync
+from requirements_graphrag_api.prompts import PromptName, get_prompt
 
 if TYPE_CHECKING:
     from neo4j import Driver
@@ -77,7 +77,7 @@ def create_rag_subgraph(
         logger.info("Expanding query: %s", query[:50])
 
         try:
-            prompt_template = get_prompt_sync(PromptName.QUERY_EXPANSION)
+            prompt_template = await get_prompt(PromptName.QUERY_EXPANSION)
             llm = ChatOpenAI(
                 model=config.conversational_model,
                 temperature=0.3,

--- a/backend/src/requirements_graphrag_api/core/agentic/subgraphs/research.py
+++ b/backend/src/requirements_graphrag_api/core/agentic/subgraphs/research.py
@@ -23,7 +23,7 @@ from langgraph.graph import END, START, StateGraph
 
 from requirements_graphrag_api.core.agentic.state import EntityInfo, ResearchState
 from requirements_graphrag_api.evaluation.cost_analysis import get_global_cost_tracker
-from requirements_graphrag_api.prompts import PromptName, get_prompt_sync
+from requirements_graphrag_api.prompts import PromptName, get_prompt
 
 if TYPE_CHECKING:
     from neo4j import Driver
@@ -74,7 +74,7 @@ def create_research_subgraph(
             }
 
         try:
-            prompt_template = get_prompt_sync(PromptName.ENTITY_SELECTOR)
+            prompt_template = await get_prompt(PromptName.ENTITY_SELECTOR)
             llm = ChatOpenAI(
                 model=config.chat_model,
                 temperature=0.2,

--- a/backend/src/requirements_graphrag_api/core/agentic/subgraphs/synthesis.py
+++ b/backend/src/requirements_graphrag_api/core/agentic/subgraphs/synthesis.py
@@ -24,7 +24,7 @@ from langgraph.graph import END, START, StateGraph
 
 from requirements_graphrag_api.core.agentic.state import CriticEvaluation, SynthesisState
 from requirements_graphrag_api.evaluation.cost_analysis import get_global_cost_tracker
-from requirements_graphrag_api.prompts import PromptName, get_prompt_sync
+from requirements_graphrag_api.prompts import PromptName, get_prompt
 
 if TYPE_CHECKING:
     from requirements_graphrag_api.config import AppConfig
@@ -74,7 +74,7 @@ def create_synthesis_subgraph(config: AppConfig) -> StateGraph:
             }
 
         try:
-            prompt_template = get_prompt_sync(PromptName.SYNTHESIS)
+            prompt_template = await get_prompt(PromptName.SYNTHESIS)
             llm = ChatOpenAI(
                 model=config.chat_model,
                 temperature=0.3,
@@ -171,7 +171,7 @@ def create_synthesis_subgraph(config: AppConfig) -> StateGraph:
 
         try:
             # Get detailed critique using CRITIC prompt
-            critic_template = get_prompt_sync(PromptName.CRITIC)
+            critic_template = await get_prompt(PromptName.CRITIC)
             llm = ChatOpenAI(
                 model=config.chat_model,
                 temperature=0.2,
@@ -205,7 +205,7 @@ def create_synthesis_subgraph(config: AppConfig) -> StateGraph:
                 guidance += f"\nConsider: {critic_data.get('followup_query')}"
 
             # Regenerate with guidance
-            synth_template = get_prompt_sync(PromptName.SYNTHESIS)
+            synth_template = await get_prompt(PromptName.SYNTHESIS)
             synth_chain = synth_template | llm
 
             # Augment context with previous draft and critique

--- a/backend/src/requirements_graphrag_api/core/conversation.py
+++ b/backend/src/requirements_graphrag_api/core/conversation.py
@@ -21,7 +21,7 @@ from langsmith import get_current_run_tree
 
 from requirements_graphrag_api.core.definitions import StreamEventType
 from requirements_graphrag_api.observability import traceable_safe
-from requirements_graphrag_api.prompts import PromptName, get_prompt_sync
+from requirements_graphrag_api.prompts import PromptName, get_prompt
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -147,7 +147,7 @@ async def stream_conversational_events(
         return
 
     formatted_history = _format_conversation_history(conversation_history)
-    prompt_template = get_prompt_sync(PromptName.CONVERSATIONAL)
+    prompt_template = await get_prompt(PromptName.CONVERSATIONAL)
 
     # Build prompt messages for astream
     messages = prompt_template.format_messages(history=formatted_history, question=question)

--- a/backend/src/requirements_graphrag_api/core/routing.py
+++ b/backend/src/requirements_graphrag_api/core/routing.py
@@ -20,7 +20,7 @@ from langchain_openai import ChatOpenAI
 
 from requirements_graphrag_api.evaluation.cost_analysis import get_global_cost_tracker
 from requirements_graphrag_api.observability import traceable_safe
-from requirements_graphrag_api.prompts import PromptName, get_prompt_sync
+from requirements_graphrag_api.prompts import PromptName, get_prompt
 
 if TYPE_CHECKING:
     from requirements_graphrag_api.config import AppConfig
@@ -195,7 +195,7 @@ async def classify_intent(
             return quick_result
 
     # Stage 2: LLM-based classification
-    prompt_template = get_prompt_sync(PromptName.INTENT_CLASSIFIER)
+    prompt_template = await get_prompt(PromptName.INTENT_CLASSIFIER)
 
     llm = ChatOpenAI(
         model=config.chat_model,

--- a/backend/src/requirements_graphrag_api/core/text2cypher.py
+++ b/backend/src/requirements_graphrag_api/core/text2cypher.py
@@ -27,8 +27,7 @@ from neo4j.exceptions import ClientError, CypherSyntaxError, DatabaseError, Serv
 
 from requirements_graphrag_api.evaluation.cost_analysis import get_global_cost_tracker
 from requirements_graphrag_api.observability import traceable_safe
-from requirements_graphrag_api.prompts import PromptName, get_prompt_sync
-from requirements_graphrag_api.prompts.definitions import TEXT2CYPHER_EXAMPLES
+from requirements_graphrag_api.prompts import PromptName, get_prompt
 
 if TYPE_CHECKING:
     from neo4j import Driver
@@ -134,7 +133,7 @@ async def generate_cypher(
         schema_info = "Schema information unavailable"
 
     # Get prompt from catalog (uses cache if available)
-    prompt_template = get_prompt_sync(PromptName.TEXT2CYPHER)
+    prompt_template = await get_prompt(PromptName.TEXT2CYPHER)
 
     llm = ChatOpenAI(
         model=config.chat_model,
@@ -148,7 +147,6 @@ async def generate_cypher(
     response = await chain.ainvoke(
         {
             "schema": schema_info,
-            "examples": TEXT2CYPHER_EXAMPLES,
             "question": question,
         }
     )

--- a/backend/src/requirements_graphrag_api/prompts/__init__.py
+++ b/backend/src/requirements_graphrag_api/prompts/__init__.py
@@ -3,14 +3,10 @@
 This package provides:
 - Centralized prompt definitions with metadata
 - LangSmith Hub integration for version control
-- Caching for performance optimization
-- Evaluation utilities for A/B testing
+- Environment-based prompt selection
 
 Quick Start:
-    from requirements_graphrag_api.prompts import PromptName, get_prompt_sync
-
-    # Get a prompt synchronously
-    prompt = get_prompt_sync(PromptName.INTENT_CLASSIFIER)
+    from requirements_graphrag_api.prompts import PromptName, get_prompt
 
     # Get a prompt asynchronously (supports Hub lookup)
     prompt = await get_prompt(PromptName.INTENT_CLASSIFIER)
@@ -19,16 +15,13 @@ Quick Start:
 from __future__ import annotations
 
 from requirements_graphrag_api.prompts.catalog import (
-    CacheEntry,
     PromptCatalog,
     get_catalog,
     get_prompt,
-    get_prompt_sync,
     initialize_catalog,
 )
 from requirements_graphrag_api.prompts.definitions import (
     PROMPT_DEFINITIONS,
-    TEXT2CYPHER_EXAMPLES,
     PromptDefinition,
     PromptMetadata,
     PromptName,
@@ -36,14 +29,11 @@ from requirements_graphrag_api.prompts.definitions import (
 
 __all__ = [
     "PROMPT_DEFINITIONS",
-    "TEXT2CYPHER_EXAMPLES",
-    "CacheEntry",
     "PromptCatalog",
     "PromptDefinition",
     "PromptMetadata",
     "PromptName",
     "get_catalog",
     "get_prompt",
-    "get_prompt_sync",
     "initialize_catalog",
 ]

--- a/backend/src/requirements_graphrag_api/prompts/definitions.py
+++ b/backend/src/requirements_graphrag_api/prompts/definitions.py
@@ -351,47 +351,8 @@ Key Relationships:
 - (Chunk)-[:NEXT_CHUNK]->(Chunk)
 
 Few-Shot Examples:
-{examples}
 
-Guidelines:
-1. Use MATCH for read queries only (no CREATE, MERGE, DELETE)
-2. Use toLower() for case-insensitive matching
-3. Use CONTAINS for partial text matching
-4. Return meaningful property values, not just node counts
-5. Limit results to 25 unless aggregating
-6. For media queries (webinars, videos, images), traverse from Article
-7. For media listing queries, use COLLECT(DISTINCT ...) to aggregate
-   source articles and avoid duplicate rows
-
-Generate only the Cypher query, no explanation."""
-
-TEXT2CYPHER_TEMPLATE = ChatPromptTemplate.from_messages(
-    [
-        ("system", TEXT2CYPHER_SYSTEM),
-        ("human", "Question: {question}\n\nCypher:"),
-    ]
-)
-
-TEXT2CYPHER_METADATA = PromptMetadata(
-    version="1.0.0",
-    description="Converts natural language questions to Cypher queries",
-    input_variables=["schema", "examples", "question"],
-    output_format="cypher",
-    evaluation_criteria=[
-        "syntactic_validity",
-        "semantic_correctness",
-        "result_accuracy",
-        "read_only_compliance",
-    ],
-    tags=["text2cypher", "graph", "query_generation"],
-)
-
-
-# =============================================================================
-# TEXT2CYPHER FEW-SHOT EXAMPLES
-# =============================================================================
-
-TEXT2CYPHER_EXAMPLES: Final[str] = """Example 1:
+Example 1:
 Question: How many articles are in the knowledge base?
 Cypher: MATCH (a:Article)
 RETURN count(a) AS article_count
@@ -467,7 +428,39 @@ Cypher: MATCH (w:Webinar)
 WITH count(w) AS webinar_count
 MATCH (v:Video)
 RETURN webinar_count, count(v) AS video_count
-"""
+
+Guidelines:
+1. Use MATCH for read queries only (no CREATE, MERGE, DELETE)
+2. Use toLower() for case-insensitive matching
+3. Use CONTAINS for partial text matching
+4. Return meaningful property values, not just node counts
+5. Limit results to 25 unless aggregating
+6. For media queries (webinars, videos, images), traverse from Article
+7. For media listing queries, use COLLECT(DISTINCT ...) to aggregate
+   source articles and avoid duplicate rows
+
+Generate only the Cypher query, no explanation."""
+
+TEXT2CYPHER_TEMPLATE = ChatPromptTemplate.from_messages(
+    [
+        ("system", TEXT2CYPHER_SYSTEM),
+        ("human", "Question: {question}\n\nCypher:"),
+    ]
+)
+
+TEXT2CYPHER_METADATA = PromptMetadata(
+    version="1.0.0",
+    description="Converts natural language questions to Cypher queries",
+    input_variables=["schema", "question"],
+    output_format="cypher",
+    evaluation_criteria=[
+        "syntactic_validity",
+        "semantic_correctness",
+        "result_accuracy",
+        "read_only_compliance",
+    ],
+    tags=["text2cypher", "graph", "query_generation"],
+)
 
 
 # =============================================================================
@@ -854,7 +847,6 @@ PROMPT_DEFINITIONS: Final[dict[PromptName, PromptDefinition]] = {
 
 __all__ = [
     "PROMPT_DEFINITIONS",
-    "TEXT2CYPHER_EXAMPLES",
     "PromptDefinition",
     "PromptMetadata",
     "PromptName",

--- a/backend/src/requirements_graphrag_api/routes/chat.py
+++ b/backend/src/requirements_graphrag_api/routes/chat.py
@@ -70,7 +70,7 @@ from requirements_graphrag_api.guardrails.events import (
 )
 from requirements_graphrag_api.middleware.rate_limit import CHAT_RATE_LIMIT, get_rate_limiter
 from requirements_graphrag_api.observability import create_thread_metadata
-from requirements_graphrag_api.prompts import PromptName, get_prompt_sync
+from requirements_graphrag_api.prompts import PromptName, get_prompt
 
 if TYPE_CHECKING:
     from collections.abc import AsyncIterator
@@ -677,7 +677,7 @@ async def _generate_explanatory_events(
                     f"Q: {msg.content}" if msg.role == "user" else f"A: {msg.content}"
                     for msg in request.conversation_history
                 )
-                updater_template = get_prompt_sync(PromptName.QUERY_UPDATER)
+                updater_template = await get_prompt(PromptName.QUERY_UPDATER)
                 llm = ChatOpenAI(
                     model=config.conversational_model,
                     temperature=0.1,
@@ -791,7 +791,7 @@ async def _resolve_coreferences(
                 for msg in conversation_history
             )
 
-            template = get_prompt_sync(PromptName.COREFERENCE_RESOLVER)
+            template = await get_prompt(PromptName.COREFERENCE_RESOLVER)
             llm = ChatOpenAI(
                 model=config.conversational_model,
                 temperature=0,

--- a/backend/tests/test_core/test_agentic/test_subgraphs.py
+++ b/backend/tests/test_core/test_agentic/test_subgraphs.py
@@ -100,7 +100,8 @@ class TestRAGSubgraph:
 
             # We need to patch at the prompt level since the chain is built inside
             with patch(
-                "requirements_graphrag_api.core.agentic.subgraphs.rag.get_prompt_sync"
+                "requirements_graphrag_api.core.agentic.subgraphs.rag.get_prompt",
+                new_callable=AsyncMock,
             ) as mock_prompt:
                 mock_template = MagicMock()
                 mock_template.__or__ = MagicMock(
@@ -158,7 +159,8 @@ class TestRAGSubgraph:
 
         with (
             patch(
-                "requirements_graphrag_api.core.agentic.subgraphs.rag.get_prompt_sync",
+                "requirements_graphrag_api.core.agentic.subgraphs.rag.get_prompt",
+                new_callable=AsyncMock,
                 return_value=mock_prompt_template,
             ),
             patch(

--- a/backend/tests/test_core/test_cost_tracker_wiring.py
+++ b/backend/tests/test_core/test_cost_tracker_wiring.py
@@ -55,7 +55,8 @@ class TestCostTrackerText2Cypher:
 
         with (
             patch(
-                "requirements_graphrag_api.core.text2cypher.get_prompt_sync",
+                "requirements_graphrag_api.core.text2cypher.get_prompt",
+                new_callable=AsyncMock,
                 return_value=mock_prompt,
             ),
             patch("requirements_graphrag_api.core.text2cypher.ChatOpenAI"),
@@ -96,7 +97,8 @@ class TestCostTrackerRouting:
                 return_value=None,
             ),
             patch(
-                "requirements_graphrag_api.core.routing.get_prompt_sync",
+                "requirements_graphrag_api.core.routing.get_prompt",
+                new_callable=AsyncMock,
                 return_value=mock_prompt,
             ),
             patch("requirements_graphrag_api.core.routing.ChatOpenAI"),
@@ -151,7 +153,8 @@ class TestCostTrackerRAG:
 
         with (
             patch(
-                "requirements_graphrag_api.core.agentic.subgraphs.rag.get_prompt_sync",
+                "requirements_graphrag_api.core.agentic.subgraphs.rag.get_prompt",
+                new_callable=AsyncMock,
                 return_value=mock_prompt,
             ),
             patch("requirements_graphrag_api.core.agentic.subgraphs.rag.ChatOpenAI"),
@@ -199,7 +202,8 @@ class TestCostTrackerSynthesis:
 
         with (
             patch(
-                "requirements_graphrag_api.core.agentic.subgraphs.synthesis.get_prompt_sync",
+                "requirements_graphrag_api.core.agentic.subgraphs.synthesis.get_prompt",
+                new_callable=AsyncMock,
                 return_value=mock_prompt,
             ),
             patch("requirements_graphrag_api.core.agentic.subgraphs.synthesis.ChatOpenAI"),
@@ -248,7 +252,8 @@ class TestCostTrackerResearch:
 
         with (
             patch(
-                "requirements_graphrag_api.core.agentic.subgraphs.research.get_prompt_sync",
+                "requirements_graphrag_api.core.agentic.subgraphs.research.get_prompt",
+                new_callable=AsyncMock,
                 return_value=mock_prompt,
             ),
             patch("requirements_graphrag_api.core.agentic.subgraphs.research.ChatOpenAI"),

--- a/backend/tests/test_core/test_routing.py
+++ b/backend/tests/test_core/test_routing.py
@@ -338,7 +338,8 @@ class TestClassifyIntentConversational:
                 return_value=None,
             ),
             patch(
-                "requirements_graphrag_api.core.routing.get_prompt_sync",
+                "requirements_graphrag_api.core.routing.get_prompt",
+                new_callable=AsyncMock,
                 return_value=mock_prompt,
             ),
             patch("requirements_graphrag_api.core.routing.ChatOpenAI"),

--- a/backend/tests/test_routes/test_chat.py
+++ b/backend/tests/test_routes/test_chat.py
@@ -730,7 +730,8 @@ class TestCoreferenceResolution:
 
         with (
             patch(
-                "requirements_graphrag_api.routes.chat.get_prompt_sync",
+                "requirements_graphrag_api.routes.chat.get_prompt",
+                new_callable=AsyncMock,
                 return_value=mock_prompt,
             ),
             patch("langchain_openai.ChatOpenAI"),
@@ -760,7 +761,8 @@ class TestCoreferenceResolution:
 
         with (
             patch(
-                "requirements_graphrag_api.routes.chat.get_prompt_sync",
+                "requirements_graphrag_api.routes.chat.get_prompt",
+                new_callable=AsyncMock,
                 return_value=mock_prompt,
             ),
             patch("langchain_openai.ChatOpenAI"),
@@ -788,7 +790,8 @@ class TestCoreferenceResolution:
 
         with (
             patch(
-                "requirements_graphrag_api.routes.chat.get_prompt_sync",
+                "requirements_graphrag_api.routes.chat.get_prompt",
+                new_callable=AsyncMock,
                 return_value=mock_prompt,
             ),
             patch("langchain_openai.ChatOpenAI"),

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -1091,7 +1091,7 @@ wheels = [
 
 [[package]]
 name = "langsmith"
-version = "0.6.4"
+version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1101,11 +1101,12 @@ dependencies = [
     { name = "requests" },
     { name = "requests-toolbelt" },
     { name = "uuid-utils" },
+    { name = "xxhash" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/e7/85/9c7933052a997da1b85bc5c774f3865e9b1da1c8d71541ea133178b13229/langsmith-0.6.4.tar.gz", hash = "sha256:36f7223a01c218079fbb17da5e536ebbaf5c1468c028abe070aa3ae59bc99ec8", size = 919964, upload-time = "2026-01-15T20:02:28.873Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/67/48/3151de6df96e0977b8d319b03905e29db0df6929a85df1d922a030b7e68d/langsmith-0.7.1.tar.gz", hash = "sha256:e3fec2f97f7c5192f192f4873d6a076b8c6469768022323dded07087d8cb70a4", size = 984367, upload-time = "2026-02-10T01:55:24.696Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/66/0f/09a6637a7ba777eb307b7c80852d9ee26438e2bdafbad6fcc849ff9d9192/langsmith-0.6.4-py3-none-any.whl", hash = "sha256:ac4835860160be371042c7adbba3cb267bcf8d96a5ea976c33a8a4acad6c5486", size = 283503, upload-time = "2026-01-15T20:02:26.662Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/87/6f2b008a456b4f5fd0fb1509bb7e1e9368c1a0c9641a535f224a9ddc10f3/langsmith-0.7.1-py3-none-any.whl", hash = "sha256:92cfa54253d35417184c297ad25bfd921d95f15d60a1ca75f14d4e7acd152a29", size = 322515, upload-time = "2026-02-10T01:55:22.531Z" },
 ]
 
 [package.optional-dependencies]
@@ -2362,7 +2363,7 @@ requires-dist = [
     { name = "langchain-openai", specifier = ">=0.2.0" },
     { name = "langgraph", specifier = ">=1.0.7" },
     { name = "langgraph-checkpoint-postgres", specifier = ">=3.0.4" },
-    { name = "langsmith", specifier = ">=0.1.0" },
+    { name = "langsmith", specifier = ">=0.7.0" },
     { name = "langsmith-fetch", marker = "extra == 'dev'", specifier = ">=0.3.1" },
     { name = "neo4j", specifier = ">=5.15.0" },
     { name = "neo4j-graphrag", specifier = ">=1.0.0" },


### PR DESCRIPTION
## Summary
- Migrate all 10 `get_prompt_sync()` → `await get_prompt()` calls across 8 source files + 1 script
- Remove triple caching layer (CacheEntry + lru_cache + manual TTL) from `catalog.py` — SDK 0.7+ handles this natively
- Embed `TEXT2CYPHER_EXAMPLES` into template string for LangSmith Playground compatibility
- Fix env var: `LANGSMITH_TENANT_ID` → `LANGSMITH_WORKSPACE_ID` in catalog.py + CI workflow
- Bump `langsmith` SDK: `>=0.1.0` → `>=0.7.0` (built-in stale-while-revalidate prompt cache)
- Remove dead exports: `get_prompt_sync`, `CacheEntry`, `TEXT2CYPHER_EXAMPLES`
- Update 4 test files with `AsyncMock` patches for async `get_prompt`

## Test plan
- [x] All 790 tests pass
- [x] Ruff lint + format clean
- [x] Zero `get_prompt_sync` references remain in codebase
- [ ] Verify LangSmith Hub pull works in staging with new `LANGSMITH_WORKSPACE_ID` env var

Closes #155

🤖 Generated with [Claude Code](https://claude.com/claude-code)