### PR TITLE
feat: add custom useSSEMetrics hook for SSE streaming observability

### DIFF
--- a/frontend/src/hooks/useSSEMetrics.js
+++ b/frontend/src/hooks/useSSEMetrics.js
@@ -1,0 +1,115 @@
+import * as Sentry from '@sentry/react'
+import { useRef, useCallback } from 'react'
+
+/**
+ * Custom hook for SSE streaming performance metrics.
+ *
+ * Tracks TTFT, tokens/second, connection time, total duration,
+ * and event sequence. Reports to Sentry as a custom span + breadcrumb.
+ *
+ * Usage:
+ *   const { startStream, recordEvent, finishStream } = useSSEMetrics()
+ *   startStream()           // before fetch()
+ *   recordEvent('token')    // for each SSE event
+ *   const m = finishStream() // on completion or error
+ */
+export function useSSEMetrics() {
+  const metricsRef = useRef(null)
+  const spanRef = useRef(null)
+
+  const startStream = useCallback(() => {
+    metricsRef.current = {
+      sendTimestamp: performance.now(),
+      firstEventTimestamp: null,
+      firstTokenTimestamp: null,
+      lastTokenTimestamp: null,
+      tokenCount: 0,
+      eventSequence: [],
+      errors: [],
+    }
+    spanRef.current = Sentry.startInactiveSpan({
+      name: 'sse.stream',
+      op: 'http.stream',
+    })
+  }, [])
+
+  const recordEvent = useCallback((eventType, data) => {
+    const m = metricsRef.current
+    if (!m) return
+    const now = performance.now()
+
+    if (!m.firstEventTimestamp) m.firstEventTimestamp = now
+    m.eventSequence.push(eventType)
+
+    if (eventType === 'token') {
+      if (!m.firstTokenTimestamp) m.firstTokenTimestamp = now
+      m.lastTokenTimestamp = now
+      m.tokenCount++
+    }
+    if (eventType === 'error') {
+      m.errors.push(data?.error || 'unknown')
+    }
+  }, [])
+
+  const finishStream = useCallback(() => {
+    const m = metricsRef.current
+    if (!m) return null
+    const now = performance.now()
+
+    const streamingDuration =
+      m.lastTokenTimestamp && m.firstTokenTimestamp
+        ? m.lastTokenTimestamp - m.firstTokenTimestamp
+        : null
+
+    const metrics = {
+      ttftMs: m.firstTokenTimestamp
+        ? Math.round(m.firstTokenTimestamp - m.sendTimestamp)
+        : null,
+      connectionTimeMs: m.firstEventTimestamp
+        ? Math.round(m.firstEventTimestamp - m.sendTimestamp)
+        : null,
+      totalDurationMs: Math.round(now - m.sendTimestamp),
+      streamingDurationMs: streamingDuration ? Math.round(streamingDuration) : null,
+      tokenCount: m.tokenCount,
+      tokensPerSecond:
+        streamingDuration && m.tokenCount > 1
+          ? Math.round((m.tokenCount / (streamingDuration / 1000)) * 10) / 10
+          : null,
+      errorCount: m.errors.length,
+      eventSequence: m.eventSequence,
+      success: m.errors.length === 0,
+    }
+
+    // Report to Sentry span
+    const span = spanRef.current
+    if (span) {
+      if (metrics.ttftMs != null) span.setAttribute('sse.ttft_ms', metrics.ttftMs)
+      if (metrics.tokensPerSecond != null)
+        span.setAttribute('sse.tokens_per_second', metrics.tokensPerSecond)
+      span.setAttribute('sse.token_count', metrics.tokenCount)
+      span.setAttribute('sse.total_duration_ms', metrics.totalDurationMs)
+      span.setAttribute('sse.success', metrics.success)
+      if (!metrics.success) span.setStatus({ code: 2, message: 'stream_error' })
+      span.end()
+      spanRef.current = null
+    }
+
+    // Add breadcrumb for error context
+    Sentry.addBreadcrumb({
+      category: 'sse',
+      message: `Stream ${metrics.success ? 'completed' : 'failed'}: ${metrics.tokenCount} tokens in ${metrics.totalDurationMs}ms`,
+      level: metrics.success ? 'info' : 'error',
+      data: {
+        ttft_ms: metrics.ttftMs,
+        tokens_per_second: metrics.tokensPerSecond,
+        token_count: metrics.tokenCount,
+        total_duration_ms: metrics.totalDurationMs,
+      },
+    })
+
+    metricsRef.current = null
+    return metrics
+  }, [])
+
+  return { startStream, recordEvent, finishStream }
+}


### PR DESCRIPTION
## Summary
- New `useSSEMetrics` hook that tracks SSE streaming performance metrics no vendor provides out of the box
- Integrated into `useSSEChat` at three lifecycle points (start, each event, finish)
- Reports to Sentry as a custom `sse.stream` span with attributes + breadcrumb
- Stores metrics on the message object for optional UI display

## Metrics Tracked

| Metric | Field | Description |
|--------|-------|-------------|
| TTFT | `ttftMs` | Time from fetch send to first `token` event |
| Tokens/sec | `tokensPerSecond` | Token throughput during streaming |
| Connection time | `connectionTimeMs` | Time to first SSE event (any type) |
| Total duration | `totalDurationMs` | Full stream lifecycle |
| Streaming duration | `streamingDurationMs` | First token → last token |
| Token count | `tokenCount` | Total tokens received |
| Event sequence | `eventSequence` | Ordered list of SSE event types |
| Success | `success` | Whether stream completed without errors |

## Sentry Integration

```
Sentry Trace View:
  └── sse.stream (custom span)
        ├── sse.ttft_ms: 423
        ├── sse.tokens_per_second: 38.5
        ├── sse.token_count: 156
        ├── sse.total_duration_ms: 4850
        └── sse.success: true
```

Also adds a breadcrumb: `"Stream completed: 156 tokens in 4850ms"` visible on any error event.

## Why This Matters
No observability vendor (Sentry, Datadog, New Relic, LogRocket) instruments SSE streams — they all treat `fetch()` as a single transaction that ends at response headers. For AI chat, the user experience IS the streaming phase. This hook fills that gap.

## Test plan
- [x] `npm run build` succeeds (622 KB — +2 KB over Phase 2)
- [x] `npm run lint` passes
- [ ] Send a chat message, verify `metrics` object appears on the message in React DevTools
- [ ] Verify `sse.stream` span appears in Sentry Performance trace view

Closes #178

🤖 Generated with [Claude Code](https://claude.com/claude-code)