### PR TITLE
feat: add Lighthouse CI for performance and accessibility gating

### DIFF
--- a/.github/workflows/lighthouse.yml
+++ b/.github/workflows/lighthouse.yml
@@ -1,0 +1,37 @@
+name: Lighthouse CI
+
+on:
+  push:
+    branches: [main]
+    paths: ['frontend/**', 'lighthouserc.js']
+  pull_request:
+    branches: [main]
+    paths: ['frontend/**', 'lighthouserc.js']
+
+jobs:
+  lighthouse:
+    name: Lighthouse Audit
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - name: Install dependencies
+        working-directory: frontend
+        run: npm ci
+
+      - name: Build frontend
+        working-directory: frontend
+        run: npm run build
+
+      - name: Run Lighthouse CI
+        uses: treosh/lighthouse-ci-action@v12
+        with:
+          configPath: ./lighthouserc.js
+          uploadArtifacts: true
+          temporaryPublicStorage: true

--- a/lighthouserc.js
+++ b/lighthouserc.js
@@ -1,0 +1,20 @@
+module.exports = {
+  ci: {
+    collect: {
+      staticDistDir: './frontend/dist',
+      isSinglePageApplication: true,
+      numberOfRuns: 3,
+    },
+    assert: {
+      assertions: {
+        'categories:performance': ['warn', { minScore: 0.8 }],
+        'categories:accessibility': ['error', { minScore: 0.9 }],
+        'categories:best-practices': ['warn', { minScore: 0.9 }],
+        'categories:seo': ['warn', { minScore: 0.8 }],
+      },
+    },
+    upload: {
+      target: 'temporary-public-storage',
+    },
+  },
+};


### PR DESCRIPTION
## Summary
- Add Lighthouse CI workflow that runs on PRs touching `frontend/` files
- Builds the frontend, then runs 3 Lighthouse audits against the static dist
- Assertions gate merge on accessibility (<0.9 = error) and warn on performance/best-practices/SEO
- Results uploaded to temporary public storage for PR review

## Config (lighthouserc.js)

| Category | Threshold | Level |
|----------|-----------|-------|
| Accessibility | 0.9 | error (blocks merge) |
| Performance | 0.8 | warn |
| Best Practices | 0.9 | warn |
| SEO | 0.8 | warn |

## How It Works
- **Trigger**: Push to `main` or PR to `main` when `frontend/**` or `lighthouserc.js` changes
- **Static dist**: `npm run build` → Lighthouse serves `frontend/dist/` locally
- **3 runs**: Averages across 3 runs to reduce noise
- **SPA mode**: `isSinglePageApplication: true` so client-side routes work

## Test plan
- [x] YAML validates (pre-commit check-yaml passed)
- [ ] Verify workflow runs on next PR that touches frontend/
- [ ] Review Lighthouse report link in GitHub Actions artifacts

Closes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)