### PR TITLE
fix: correct LangSmith project name defaults and add UI config guides

### DIFF
--- a/backend/scripts/online_eval_cypher.py
+++ b/backend/scripts/online_eval_cypher.py
@@ -7,10 +7,10 @@ queries against Neo4j, and posts per-metric feedback to LangSmith.
 
 Usage:
     # Evaluate last 24h of structured traces
-    uv run python scripts/online_eval_cypher.py --project jama-mcp-graphrag
+    uv run python scripts/online_eval_cypher.py --project graphrag-api-prod
 
     # Evaluate last 48h, limit 100, dry run
-    uv run python scripts/online_eval_cypher.py --project jama-mcp-graphrag \
+    uv run python scripts/online_eval_cypher.py --project graphrag-api-prod \
         --hours-back 48 --limit 100 --dry-run
 
     # Show help
@@ -190,8 +190,8 @@ def main() -> int:
     parser.add_argument(
         "--project",
         "-p",
-        default="jama-mcp-graphrag",
-        help="LangSmith project name (default: jama-mcp-graphrag)",
+        default="graphrag-api-prod",
+        help="LangSmith project name (default: graphrag-api-prod)",
     )
     parser.add_argument(
         "--limit",

--- a/backend/scripts/quality_check.py
+++ b/backend/scripts/quality_check.py
@@ -8,14 +8,14 @@ when degradation is detected.
 
 Usage:
     # Run with defaults (7-day window vs 30-day baseline)
-    uv run python scripts/quality_check.py --project jama-mcp-graphrag
+    uv run python scripts/quality_check.py --project graphrag-api-prod
 
     # Custom windows
-    uv run python scripts/quality_check.py --project jama-mcp-graphrag \
+    uv run python scripts/quality_check.py --project graphrag-api-prod \
         --recent-days 3 --baseline-days 14
 
     # Show details without failing
-    uv run python scripts/quality_check.py --project jama-mcp-graphrag --dry-run
+    uv run python scripts/quality_check.py --project graphrag-api-prod --dry-run
 
 Exit codes:
     0 — no degradation detected (or insufficient data)
@@ -175,8 +175,8 @@ def main() -> int:
     parser.add_argument(
         "--project",
         "-p",
-        default="jama-mcp-graphrag",
-        help="LangSmith project name (default: jama-mcp-graphrag)",
+        default="graphrag-api-prod",
+        help="LangSmith project name (default: graphrag-api-prod)",
     )
     parser.add_argument(
         "--recent-days",

--- a/docs/guides/langsmith-user-manual.md
+++ b/docs/guides/langsmith-user-manual.md
@@ -3,6 +3,8 @@
 > Detailed workflows with concrete examples for operating the GraphRAG
 > LangSmith integration. For initial setup, see
 > [langsmith-ui-setup.md](langsmith-ui-setup.md).
+>
+> **Organization**: Norfolk AI|BI | **Workspace**: graphrag-api | **Project**: graphrag-api-prod
 
 ---
 
@@ -30,7 +32,7 @@ When the annotation queues have accumulated traces for review, typically from:
 
 ### Step-by-step
 
-1. **Open the queue**: LangSmith → Annotation Queues → select a queue (e.g., `review-explanatory`)
+1. **Open the queue**: LangSmith → **graphrag-api** workspace → Annotation Queues → select a queue (e.g., `review-explanatory`)
 
 2. **Review the trace**: For each item in the queue:
    - Read the **user question** (input)
@@ -127,7 +129,7 @@ quality review.
 
 4. **Cross-reference with quality_check.py**:
    ```bash
-   uv run python scripts/quality_check.py --project jama-mcp-graphrag --dry-run
+   uv run python scripts/quality_check.py --project graphrag-api-prod --dry-run
    ```
    This compares the last 7 days against a 30-day baseline and shows degradation
    across 6 monitored keys.
@@ -189,7 +191,7 @@ Investigation steps:
    ```
 
 3. **Review results in LangSmith**:
-   - Go to **Experiments** tab in your project
+   - Go to **Experiments** tab in **graphrag-api-prod**
    - Find the experiment by name: `graphrag-{vector}-production-{timestamp}`
    - Check per-evaluator scores
    - Compare against previous experiments to detect regressions
@@ -254,13 +256,13 @@ generated Cypher against Neo4j.
 1. **Run manually**:
    ```bash
    # Default: last 24h, up to 50 traces
-   uv run python scripts/online_eval_cypher.py --project jama-mcp-graphrag
+   uv run python scripts/online_eval_cypher.py --project graphrag-api-prod
 
    # Preview without posting feedback
-   uv run python scripts/online_eval_cypher.py --project jama-mcp-graphrag --dry-run
+   uv run python scripts/online_eval_cypher.py --project graphrag-api-prod --dry-run
 
    # Broader window
-   uv run python scripts/online_eval_cypher.py --project jama-mcp-graphrag \
+   uv run python scripts/online_eval_cypher.py --project graphrag-api-prod \
        --hours-back 72 --limit 200
    ```
 
@@ -282,7 +284,7 @@ generated Cypher against Neo4j.
    ```bash
    # Example crontab entry: run daily at 2 AM
    0 2 * * * cd /path/to/backend && uv run python scripts/online_eval_cypher.py \
-       --project jama-mcp-graphrag >> /var/log/online_eval_cypher.log 2>&1
+       --project graphrag-api-prod >> /var/log/online_eval_cypher.log 2>&1
    ```
 
 4. **Check results in LangSmith**: After running, structured traces will have


### PR DESCRIPTION
## Summary
- Fix `online_eval_cypher.py` and `quality_check.py` default project name from non-existent `jama-mcp-graphrag` to actual production project `graphrag-api-prod`
- Add 3 LangSmith UI configuration guides (setup, getting started, user manual)
- Update all guides with correct Norfolk AI|BI org, graphrag-api workspace, and project hierarchy

## Bug Fix
Scripts merged in PR #187 defaulted `--project` to `jama-mcp-graphrag`, which doesn't exist in the LangSmith workspace. The actual projects are `graphrag-api-prod`, `graphrag-api-dev`, and `evaluators`.

## New Docs
- `docs/guides/langsmith-ui-setup.md` — Step-by-step for queues, evaluators, rules, dashboards, alerts
- `docs/guides/langsmith-getting-started.md` — Quick reference with architecture diagram and command cheat sheet
- `docs/guides/langsmith-user-manual.md` — 8 use cases with concrete examples

## Test plan
- [ ] `uv run python scripts/online_eval_cypher.py --help` shows `graphrag-api-prod` as default
- [ ] `uv run python scripts/quality_check.py --help` shows `graphrag-api-prod` as default
- [ ] No remaining references to `jama-mcp-graphrag` in scripts or guides
- [ ] Docs reference correct org/workspace hierarchy

Closes #188

🤖 Generated with [Claude Code](https://claude.com/claude-code)