### PR TITLE
fix: add intent metadata to structured and explanatory handlers

### DIFF
--- a/backend/src/requirements_graphrag_api/routes/feedback.py
+++ b/backend/src/requirements_graphrag_api/routes/feedback.py
@@ -101,6 +101,10 @@ class FeedbackRequest(BaseModel):
         default=None,
         description="Per-dimension rubric scores",
     )
+    trace_id: str | None = Field(
+        default=None,
+        description="OTel trace ID for cross-system correlation (Sentry, frontend)",
+    )
 
 
 class FeedbackResponse(BaseModel):
@@ -196,6 +200,8 @@ async def submit_feedback(
             comment_parts.append(f"Conversation ID: {body.conversation_id}")
         if body.intent:
             comment_parts.append(f"Intent: {body.intent}")
+        if body.trace_id:
+            comment_parts.append(f"Trace ID: {body.trace_id}")
 
         comment = " | ".join(comment_parts) if comment_parts else None
 


### PR DESCRIPTION
## Summary
- Add `metadata["intent"] = "structured"` to the structured handler
- Add `metadata["intent"] = "explanatory"` to the explanatory handler  
- Add `trace_id` field to `FeedbackRequest` model (was silently dropped by Pydantic)

## Problem
Only the conversational handler set `intent` metadata on LangSmith traces. This meant:
- `online_eval_cypher.py` filter `eq(metadata["intent"], "structured")` returned zero traces
- Online evaluators couldn't filter by intent for explanatory traces
- Dashboards couldn't group by intent across all 3 vectors

## Test plan
- [ ] 800 tests pass
- [ ] Deploy to production
- [ ] Send 1 explanatory query → verify `intent: explanatory` in LangSmith trace metadata
- [ ] Send 1 structured query → verify `intent: structured` in LangSmith trace metadata
- [ ] Send 1 conversational query → verify `intent: conversational` (already worked)
- [ ] Submit feedback with `trace_id` → verify it appears in LangSmith comment

Closes #190

🤖 Generated with [Claude Code](https://claude.com/claude-code)