### PR TITLE
feat: sync schema — add Organization, Outcome, 4 new relationship types

### DIFF
--- a/backend/src/requirements_graphrag_api/core/retrieval.py
+++ b/backend/src/requirements_graphrag_api/core/retrieval.py
@@ -981,7 +981,8 @@ async def search_entities_by_name(
                 MATCH (n)
                 WHERE (n:Concept OR n:Challenge OR n:Bestpractice OR n:Standard
                        OR n:Methodology OR n:Artifact OR n:Tool OR n:Role
-                       OR n:Processstage OR n:Industry)
+                       OR n:Processstage OR n:Industry OR n:Organization
+                       OR n:Outcome)
                       AND (toLower(n.name) CONTAINS toLower($term)
                            OR toLower(n.display_name) CONTAINS toLower($term))
                 WITH n, labels(n)[0] AS label
@@ -1070,7 +1071,8 @@ async def explore_entity(
                 MATCH (e)
                 WHERE (e:Concept OR e:Challenge OR e:Bestpractice OR e:Standard
                        OR e:Methodology OR e:Artifact OR e:Tool OR e:Role
-                       OR e:Processstage OR e:Industry)
+                       OR e:Processstage OR e:Industry OR e:Organization
+                       OR e:Outcome)
                   AND (toLower(e.name) CONTAINS toLower($name)
                        OR toLower(e.display_name) CONTAINS toLower($name))
                 RETURN e, labels(e) AS labels

--- a/backend/src/requirements_graphrag_api/evaluation/constants.py
+++ b/backend/src/requirements_graphrag_api/evaluation/constants.py
@@ -89,6 +89,8 @@ VALID_LABELS: Final[frozenset[str]] = frozenset(
         "Image",
         "Industry",
         "Methodology",
+        "Organization",
+        "Outcome",
         "Processstage",
         "Role",
         "Standard",
@@ -100,11 +102,13 @@ VALID_LABELS: Final[frozenset[str]] = frozenset(
 
 VALID_RELATIONSHIPS: Final[frozenset[str]] = frozenset(
     {
+        "ACHIEVES",
         "ADDRESSES",
         "ALTERNATIVE_TO",
         "APPLIES_TO",
         "COMPONENT_OF",
         "DEFINES",
+        "DEVELOPS",
         "FROM_ARTICLE",
         "HAS_IMAGE",
         "HAS_VIDEO",
@@ -113,7 +117,9 @@ VALID_RELATIONSHIPS: Final[frozenset[str]] = frozenset(
         "NEXT_CHUNK",
         "PREREQUISITE_FOR",
         "PRODUCES",
+        "PUBLISHES",
         "REFERENCES",
+        "REGULATES",
         "RELATED_TO",
         "REQUIRES",
         "USED_BY",

--- a/backend/src/requirements_graphrag_api/prompts/definitions.py
+++ b/backend/src/requirements_graphrag_api/prompts/definitions.py
@@ -266,6 +266,8 @@ article_id, content_type, document_type, path
 - Artifact: name, display_name, abbreviation, artifact_type
 - Role: name, display_name, responsibilities
 - Bestpractice: name, display_name, rationale
+- Organization: name, display_name, organization_type, abbreviation
+- Outcome: name, display_name, outcome_type
 
 **Media Nodes** (embedded resources):
 - Image: url, alt_text, context, resource_id, source_article_id
@@ -297,11 +299,14 @@ source_article_id
 - (Concept)-[:PREREQUISITE_FOR]->(Concept)
 - (Concept)-[:REQUIRES]->(Concept|Artifact)
 - (Concept)-[:ADDRESSES]->(Challenge)
+- (Concept)-[:ACHIEVES]->(Outcome)
 - (Tool)-[:ADDRESSES]->(Challenge)
 - (Tool)-[:REQUIRES]->(Concept)
 - (Tool)-[:ALTERNATIVE_TO]->(Tool)
+- (Tool)-[:ACHIEVES]->(Outcome)
 - (Methodology)-[:ADDRESSES]->(Challenge)
 - (Methodology)-[:ALTERNATIVE_TO]->(Methodology)
+- (Methodology)-[:ACHIEVES]->(Outcome)
 - (Processstage)-[:COMPONENT_OF]->(Methodology)
 - (Processstage)-[:PREREQUISITE_FOR]->(Processstage)
 - (Processstage)-[:REQUIRES]->(Artifact)
@@ -309,15 +314,19 @@ source_article_id
 - (Bestpractice)-[:ADDRESSES]->(Challenge)
 - (Bestpractice)-[:APPLIES_TO]->(Processstage)
 - (Bestpractice)-[:REQUIRES]->(Concept)
+- (Bestpractice)-[:ACHIEVES]->(Outcome)
 - (Role)-[:PRODUCES]->(Artifact)
 - (Role)-[:USED_BY]->(Artifact|Tool)
 - (Industry)-[:USED_BY]->(Tool)
+- (Organization)-[:PUBLISHES]->(Standard)
+- (Organization)-[:REGULATES]->(Industry)
+- (Organization)-[:DEVELOPS]->(Tool)
 - (Artifact)-[:COMPONENT_OF]->(Artifact)
 - (Artifact)-[:PREREQUISITE_FOR]->(Processstage)
 
 ### Labels to NEVER use in queries
 - __KGBuilder__, __Entity__ — internal metadata labels (multi-labeled on domain nodes)
-- Entity — DEPRECATED, 0 nodes (use specific labels: Concept, Tool, Standard, etc.)
+- Entity — DEPRECATED, 0 nodes (use specific labels: Concept, Standard, Organization, etc.)
 - GlossaryTerm — DEPRECATED, 0 nodes (replaced by Definition)
 
 ## Few-Shot Examples


### PR DESCRIPTION
## Summary
- Add `Organization` and `Outcome` to `VALID_LABELS` (17→19 labels)
- Add `ACHIEVES`, `DEVELOPS`, `PUBLISHES`, `REGULATES` to `VALID_RELATIONSHIPS` (17→21 relationships)
- Update Cypher WHERE clauses in `search_entities_by_name()` and `explore_entity()` to match Organization and Outcome nodes
- Update TEXT2CYPHER prompt with Organization/Outcome property schemas and 7 new relationship pattern examples

Companion to arthurfantaci/graphrag-api-db#44 (schema expansion PR).

## Test plan
- [x] All 813 tests pass
- [x] Ruff lint + pre-commit hooks pass
- [ ] Verify Text2Cypher generates valid queries for Organization/Outcome entities
- [ ] Verify entity search returns Organization and Outcome nodes after re-ingestion

Closes #210

🤖 Generated with [Claude Code](https://claude.com/claude-code)