### PR TITLE
fix(docker): upgrade base image to python:3.13-slim

### DIFF
--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,5 +1,5 @@
 # Production Dockerfile for Requirements GraphRAG API
-FROM python:3.12-slim AS base
+FROM python:3.13-slim AS base
 
 # Set environment variables
 ENV PYTHONDONTWRITEBYTECODE=1 \


### PR DESCRIPTION
## Summary
- Upgrade Dockerfile base image from `python:3.12-slim` to `python:3.13-slim` to match the Python 3.13 migration in PR #214
- Railway deployment was failing because `uv sync --frozen` enforces the `requires-python >= 3.13` constraint from `uv.lock`, which can't be satisfied on a Python 3.12 base image
- Additionally, Python 3.13-only syntax (`AsyncGenerator[str]` short-form via PEP 696) would cause runtime errors even if the build were bypassed

## Test plan
- [ ] CI passes (ruff, pytest — no Dockerfile-specific tests, but validates lockfile/dependency integrity)
- [ ] Railway deployment succeeds with `/health` endpoint returning 200
- [ ] Verify spaCy model installs correctly on python:3.13-slim

Closes #216

🤖 Generated with [Claude Code](https://claude.com/claude-code)