### PR TITLE
feat: Dependabot + dependency review (Phase 3c)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,34 @@
+version: 2
+updates:
+  # Python dependencies (backend)
+  - package-ecosystem: "pip"
+    directory: "/backend"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "python"
+    commit-message:
+      prefix: "chore(deps):"
+
+  # npm dependencies (frontend)
+  - package-ecosystem: "npm"
+    directory: "/frontend"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "javascript"
+    commit-message:
+      prefix: "chore(deps):"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "dependencies"
+      - "ci"
+    commit-message:
+      prefix: "ci(deps):"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -118,6 +118,16 @@ jobs:
           name: coverage-report
           path: backend/htmlcov/
 
+  dependency-review:
+    name: Dependency Review
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Dependency Review
+        uses: actions/dependency-review-action@v4
+
   type-check:
     name: Type Check (Advisory)
     runs-on: ubuntu-latest

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,7 +15,7 @@
 ## Conventions
 - Conventional commits: `fix:`, `feat:`, `refactor:`, `docs:`
 - Git workflow: Issue → Branch → PR (always use RC branch strategy for phases)
-- **CLAUDE.md exception**: Updates to `CLAUDE.md` skip the Issue step — commit directly to a branch, open a minimal PR, merge. No issue, no RC branch, no ceremony.
+- **CLAUDE.md & memory files — NO separate workflow**: Changes that ONLY touch `CLAUDE.md` or `~/.claude/` memory files MUST NOT get their own issue, branch, or PR. Bundle them into the next phase's PR, or commit directly to the working branch. See global CLAUDE.md for full rule.
 - CI triggers only on PRs targeting `main` — RC→main is where CI runs
 - Ruff format hook auto-fixes imports → always re-stage after first commit attempt
 


### PR DESCRIPTION
## Summary
- Add `.github/dependabot.yml` for automated dependency updates (pip, npm, GitHub Actions)
- Add `dependency-review-action` to CI for vulnerability scanning on PRs
- Bundle CLAUDE.md update (memory file binding rule)

**Phase**: 3c of [#212](https://github.com/arthurfantaci/requirements-graphrag-api/issues/212)
**Plan**: `~/Projects/graphrag-api-db/docs/best-practices-plan.md` §Phase 3c

## Changes
### `.github/dependabot.yml` (new)
- **pip** ecosystem: scans `backend/` weekly for Python dependency updates
- **npm** ecosystem: scans `frontend/` weekly for JavaScript dependency updates
- **github-actions** ecosystem: scans workflows weekly for action version updates
- Conventional commit prefixes (`chore(deps):`, `ci(deps):`)
- Labels for easy filtering (`dependencies`, `python`/`javascript`/`ci`)

### `.github/workflows/ci.yml` (modified)
- New `dependency-review` job that runs only on PRs (`if: github.event_name == 'pull_request'`)
- Uses `actions/dependency-review-action@v4` to flag newly-introduced vulnerable dependencies

### `CLAUDE.md` (modified)
- Updated CLAUDE.md exception rule to match global binding rule for memory files

## Test plan
- [x] 813 tests passing locally
- [x] Ruff lint + format clean
- [ ] CI pipeline passes on this PR
- [ ] Dependabot starts opening PRs after merge (verify within 1 week)

🤖 Generated with [Claude Code](https://claude.com/claude-code)