### PR TITLE
ci: add Dependabot auto-merge for minor/patch updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,28 @@
+# Auto-merge Dependabot PRs for minor and patch updates
+name: Dependabot Auto-Merge
+
+on: pull_request_target
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    runs-on: ubuntu-latest
+    if: github.actor == 'dependabot[bot]'
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Auto-approve and enable auto-merge
+        if: steps.metadata.outputs.update-type != 'version-update:semver-major'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr review "$PR_URL" --approve --body "Auto-approved: Dependabot ${{ steps.metadata.outputs.update-type }}"
+          gh pr merge "$PR_URL" --auto --merge


### PR DESCRIPTION
## Summary
- Auto-approves and enables auto-merge for Dependabot PRs with minor or patch version bumps
- Major version bumps (like the eslint 9→10 case) still require manual review
- Uses `pull_request_target` with `dependabot/fetch-metadata` to detect update type
- Eliminates the need to manually approve + merge each Dependabot PR

## Test plan
- [ ] CI passes
- [ ] Next Dependabot minor/patch PR auto-merges after CI passes
- [ ] Major version bump PR is left for manual review

🤖 Generated with [Claude Code](https://claude.com/claude-code)