### PR TITLE
feat: API hardening — response models, data quality fixes, FastAPI bump (Phase 4)

### DIFF
--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 
 dependencies = [
     # Web framework
-    "fastapi>=0.115.0",
+    "fastapi>=0.130.0,<1.0.0",
     "uvicorn[standard]>=0.32.0",
     "sse-starlette>=2.0.0",
     # Neo4j

--- a/backend/src/requirements_graphrag_api/api.py
+++ b/backend/src/requirements_graphrag_api/api.py
@@ -27,6 +27,7 @@ from typing import TYPE_CHECKING
 import structlog
 from fastapi import FastAPI, Security
 from fastapi.middleware.cors import CORSMiddleware
+from pydantic import BaseModel, ConfigDict
 from slowapi.errors import RateLimitExceeded
 
 from requirements_graphrag_api.auth import (
@@ -322,7 +323,18 @@ app.include_router(
 )
 
 
-@app.get("/")
+class RootResponse(BaseModel):
+    """Response from root endpoint."""
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str
+    version: str
+    docs: str
+    health: str
+
+
+@app.get("/", response_model=RootResponse)
 async def root() -> dict[str, str]:
     """Root endpoint with API information."""
     return {

--- a/backend/src/requirements_graphrag_api/core/retrieval.py
+++ b/backend/src/requirements_graphrag_api/core/retrieval.py
@@ -39,6 +39,28 @@ if TYPE_CHECKING:
 
 logger = structlog.get_logger()
 
+# Minimum meaningful content length for chunk filtering (Issue #202)
+_MIN_CONTENT_LENGTH = 20
+
+
+def _is_meaningful_content(content: str) -> bool:
+    """Check if chunk content has enough non-whitespace text to be useful.
+
+    Filters degenerate chunks like bare markdown headings ("#### Traceable")
+    that score highly in vector search but contain no information.
+
+    Args:
+        content: Chunk text content.
+
+    Returns:
+        True if content has enough meaningful text.
+    """
+    stripped = content.strip()
+    # Remove markdown heading markers
+    if stripped.startswith("#"):
+        stripped = stripped.lstrip("#").strip()
+    return len(stripped) >= _MIN_CONTENT_LENGTH
+
 
 @dataclass(frozen=True, slots=True)
 class GraphEnrichmentOptions:
@@ -213,6 +235,9 @@ async def vector_search(
             }
         )
 
+    # Filter degenerate chunks (bare headings without content — Issue #202)
+    formatted = [r for r in formatted if _is_meaningful_content(r["content"])]
+
     logger.info("Vector search returned %d results", len(formatted))
     return formatted
 
@@ -289,6 +314,9 @@ async def hybrid_search(
             return []
 
     keyword_results = await asyncio.to_thread(_keyword_search)
+
+    # Filter degenerate chunks from keyword results (Issue #202)
+    keyword_results = [r for r in keyword_results if _is_meaningful_content(r.get("content", ""))]
 
     # Merge and deduplicate results
     seen_ids = set()
@@ -483,8 +511,7 @@ def _enrich_with_semantic_relationships(
             f"""
             MATCH (entity)-[:MENTIONED_IN]->(c:Chunk)
             WHERE elementId(c) IN $chunk_ids
-            OPTIONAL MATCH (entity)-[r:{rel_pattern}]->(related)
-            WHERE related IS NOT NULL
+            MATCH (entity)-[r:{rel_pattern}]->(related)
             WITH elementId(c) AS chunk_id,
                  collect(DISTINCT {{
                      from_entity: entity.display_name,
@@ -726,12 +753,15 @@ def _enrich_with_definitions(
 def _assemble_enriched_result(
     result: dict[str, Any],
     enrichment_data: dict[str, dict[str, Any]],
+    seen_relationships: set[tuple[str, str, str]] | None = None,
 ) -> dict[str, Any]:
     """Assemble enrichment data into a single result dictionary.
 
     Args:
         result: Base search result with content, score, metadata.
         enrichment_data: Dictionary containing all enrichment lookups.
+        seen_relationships: Optional set tracking relationship keys across results
+            for deduplication (Issue #202). Mutated in-place.
 
     Returns:
         Enriched result with all graph context attached.
@@ -747,9 +777,23 @@ def _assemble_enriched_result(
     # Level 2: Entities with properties
     result["entities"] = enrichment_data["entities"].get(chunk_id, [])
 
-    # Level 3: Semantic relationships
+    # Level 3: Semantic relationships (deduplicate across results — Issue #202)
     if chunk_id in enrichment_data["relationships"]:
-        result["semantic_relationships"] = enrichment_data["relationships"][chunk_id]
+        rels = enrichment_data["relationships"][chunk_id]
+        if seen_relationships is not None:
+            deduped = []
+            for rel in rels:
+                key = (
+                    rel.get("from_entity", ""),
+                    rel.get("relationship", ""),
+                    rel.get("to_entity", ""),
+                )
+                if key not in seen_relationships:
+                    seen_relationships.add(key)
+                    deduped.append(rel)
+            rels = deduped
+        if rels:
+            result["semantic_relationships"] = rels
 
     # Level 4: Domain context
     if chunk_id in enrichment_data["industry"]:
@@ -901,7 +945,11 @@ async def graph_enriched_search(
         "definitions": definitions_by_chunk,
     }
 
-    enriched = [_assemble_enriched_result(result, enrichment_data) for result in base_results]
+    # Track seen relationships across results for deduplication (Issue #202)
+    seen_rels: set[tuple[str, str, str]] = set()
+    enriched = [
+        _assemble_enriched_result(result, enrichment_data, seen_rels) for result in base_results
+    ]
 
     # Log enrichment summary
     enrichment_stats = {

--- a/backend/src/requirements_graphrag_api/routes/chat.py
+++ b/backend/src/requirements_graphrag_api/routes/chat.py
@@ -16,7 +16,7 @@ from typing import TYPE_CHECKING, Any
 import structlog
 from fastapi import APIRouter, Request, Security
 from fastapi.responses import StreamingResponse
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 from slowapi.util import get_remote_address
 
 from requirements_graphrag_api.auth import UNAUTHORIZED_RESPONSE, api_key_security
@@ -530,7 +530,28 @@ async def chat_endpoint(
     )
 
 
-@router.get("/chat/routing-guide")
+class QueryTypeInfo(BaseModel):
+    """Information about a query type for routing guidance."""
+
+    type: str
+    intent: str
+    description: str
+    examples: list[str]
+    keywords: list[str]
+
+
+class RoutingGuideResponse(BaseModel):
+    """Response from routing guide endpoint."""
+
+    model_config = ConfigDict(extra="allow")
+
+    title: str
+    description: str
+    query_types: list[QueryTypeInfo]
+    tips: list[str]
+
+
+@router.get("/chat/routing-guide", response_model=RoutingGuideResponse)
 async def routing_guide_endpoint() -> dict[str, Any]:
     """Get user-facing documentation for query routing.
 

--- a/backend/src/requirements_graphrag_api/routes/definitions.py
+++ b/backend/src/requirements_graphrag_api/routes/definitions.py
@@ -10,6 +10,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, HTTPException, Query, Request
+from pydantic import BaseModel, ConfigDict
 
 from requirements_graphrag_api.core import list_all_terms, lookup_term, search_terms
 
@@ -19,7 +20,41 @@ if TYPE_CHECKING:
 router = APIRouter()
 
 
-@router.get("/definitions/{term}")
+class TermResponse(BaseModel):
+    """Response from single term lookup."""
+
+    model_config = ConfigDict(extra="allow")
+
+    term: str
+    definition: str
+    acronym: str | None = None
+    url: str | None = None
+    term_id: str | None = None
+    score: float
+
+
+class TermSummary(BaseModel):
+    """Summary of a definition term."""
+
+    model_config = ConfigDict(extra="allow")
+
+    term: str
+    definition: str
+    acronym: str | None = None
+    url: str | None = None
+    score: float | None = None
+
+
+class TermListResponse(BaseModel):
+    """Response from term listing/search."""
+
+    model_config = ConfigDict(extra="allow")
+
+    terms: list[TermSummary]
+    total: int
+
+
+@router.get("/definitions/{term}", response_model=TermResponse)
 async def get_term(
     request: Request,
     term: str,
@@ -45,7 +80,7 @@ async def get_term(
     return result
 
 
-@router.get("/definitions")
+@router.get("/definitions", response_model=TermListResponse)
 async def list_definitions(
     request: Request,
     q: str | None = Query(default=None, description="Search query"),

--- a/backend/src/requirements_graphrag_api/routes/health.py
+++ b/backend/src/requirements_graphrag_api/routes/health.py
@@ -10,6 +10,7 @@ import asyncio
 from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, Request
+from pydantic import BaseModel, ConfigDict
 
 if TYPE_CHECKING:
     from neo4j import Driver
@@ -17,7 +18,17 @@ if TYPE_CHECKING:
 router = APIRouter()
 
 
-@router.get("/health")
+class HealthResponse(BaseModel):
+    """Response from health check endpoint."""
+
+    model_config = ConfigDict(extra="allow")
+
+    status: str
+    neo4j: str
+    version: str
+
+
+@router.get("/health", response_model=HealthResponse)
 async def health_check(request: Request) -> dict[str, Any]:
     """Check the health of the API and its dependencies.
 

--- a/backend/src/requirements_graphrag_api/routes/schema.py
+++ b/backend/src/requirements_graphrag_api/routes/schema.py
@@ -10,6 +10,7 @@ import asyncio
 from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, Request
+from pydantic import BaseModel, ConfigDict
 
 from requirements_graphrag_api.core import explore_entity
 
@@ -19,7 +20,61 @@ if TYPE_CHECKING:
 router = APIRouter()
 
 
-@router.get("/schema")
+class NodeLabelCount(BaseModel):
+    """Node label with instance count."""
+
+    label: str
+    count: int
+
+
+class RelationshipTypeCount(BaseModel):
+    """Relationship type with instance count."""
+
+    type: str
+    count: int
+
+
+class SchemaResponse(BaseModel):
+    """Response from schema endpoint."""
+
+    model_config = ConfigDict(extra="allow")
+
+    node_labels: list[NodeLabelCount]
+    relationship_types: list[RelationshipTypeCount]
+
+
+class RelatedEntity(BaseModel):
+    """Entity related to a explored entity."""
+
+    name: str | None = None
+    display_name: str | None = None
+    relationship: str | None = None
+    labels: list[str] = []
+
+
+class ArticleMention(BaseModel):
+    """Article where an entity is mentioned."""
+
+    article: str | None = None
+    url: str | None = None
+
+
+class EntityDetailResponse(BaseModel):
+    """Response from entity detail endpoint."""
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str
+    found: bool
+    display_name: str | None = None
+    labels: list[str] = []
+    properties: dict[str, Any] = {}
+    related: list[RelatedEntity] = []
+    mentioned_in: list[ArticleMention] = []
+    message: str | None = None
+
+
+@router.get("/schema", response_model=SchemaResponse)
 async def get_schema(request: Request) -> dict[str, Any]:
     """Get the knowledge graph schema.
 
@@ -66,7 +121,7 @@ async def get_schema(request: Request) -> dict[str, Any]:
     }
 
 
-@router.get("/schema/entity/{name}")
+@router.get("/schema/entity/{name}", response_model=EntityDetailResponse)
 async def get_entity(
     request: Request,
     name: str,

--- a/backend/src/requirements_graphrag_api/routes/search.py
+++ b/backend/src/requirements_graphrag_api/routes/search.py
@@ -12,7 +12,7 @@ from typing import TYPE_CHECKING, Any
 
 import structlog
 from fastapi import APIRouter, HTTPException, Request
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, ConfigDict, Field
 
 from requirements_graphrag_api.core import (
     graph_enriched_search,
@@ -78,7 +78,7 @@ class HybridSearchRequest(SearchRequest):
 class EntityInfo(BaseModel):
     """Entity information from graph enrichment."""
 
-    name: str | None = None
+    name: str
     type: str | None = None
     definition: str | None = None
     benefit: str | None = None
@@ -96,11 +96,41 @@ class GlossaryDefinition(BaseModel):
 class SemanticRelationship(BaseModel):
     """Semantic relationship between entities."""
 
-    from_entity: str | None = None
-    relationship: str | None = None
+    from_entity: str
+    relationship: str
     to_entity: str | None = None
     to_type: str | None = None
     to_definition: str | None = None
+
+
+class ChunkMetadata(BaseModel):
+    """Metadata for a search result chunk."""
+
+    model_config = ConfigDict(extra="allow")
+
+    title: str | None = None
+    url: str | None = None
+    article_id: str | None = None
+    chapter: str | None = None
+    chunk_id: str | None = None
+    chunk_index: int | None = None
+
+
+class RelatedArticle(BaseModel):
+    """Cross-referenced article from graph enrichment."""
+
+    title: str | None = None
+    url: str | None = None
+    chapter: str | None = None
+
+
+class IndustryStandardInfo(BaseModel):
+    """Industry standard information from graph enrichment."""
+
+    industry: str | None = None
+    standard: str | None = None
+    organization: str | None = None
+    standard_definition: str | None = None
 
 
 class ContextWindow(BaseModel):
@@ -146,7 +176,7 @@ class SearchResult(BaseModel):
 
     content: str
     score: float
-    metadata: dict[str, Any]
+    metadata: ChunkMetadata
     # Level 1: Window context
     context_window: ContextWindow | None = None
     # Level 2: Entities with properties
@@ -154,9 +184,9 @@ class SearchResult(BaseModel):
     # Level 3: Semantic relationships
     semantic_relationships: list[SemanticRelationship] = []
     # Level 4: Domain context
-    industry_standards: list[dict[str, Any]] = []
+    industry_standards: list[IndustryStandardInfo] = []
     media: MediaContent | None = None
-    related_articles: list[dict[str, Any]] = []
+    related_articles: list[RelatedArticle] = []
     glossary_definitions: list[GlossaryDefinition] = []
 
 

--- a/backend/src/requirements_graphrag_api/routes/standards.py
+++ b/backend/src/requirements_graphrag_api/routes/standards.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, HTTPException, Query, Request
+from pydantic import BaseModel, ConfigDict
 
 from requirements_graphrag_api.core import (
     get_standards_by_industry,
@@ -23,7 +24,67 @@ if TYPE_CHECKING:
 router = APIRouter()
 
 
-@router.get("/standards/{name}")
+class StandardRelatedEntity(BaseModel):
+    """Entity related to a standard."""
+
+    name: str | None = None
+    display_name: str | None = None
+    relationship: str | None = None
+    labels: list[str] = []
+
+
+class StandardMention(BaseModel):
+    """Article that mentions a standard."""
+
+    title: str | None = None
+    url: str | None = None
+
+
+class StandardDetailResponse(BaseModel):
+    """Response from single standard lookup."""
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str
+    display_name: str | None = None
+    organization: str | None = None
+    domain: str | None = None
+    labels: list[str] = []
+    related: list[StandardRelatedEntity] = []
+    mentioned_in: list[StandardMention] = []
+
+
+class StandardSummary(BaseModel):
+    """Summary of a standard."""
+
+    model_config = ConfigDict(extra="allow")
+
+    name: str
+    display_name: str | None = None
+    organization: str | None = None
+    domain: str | None = None
+
+
+class StandardListResponse(BaseModel):
+    """Response from standard listing/search."""
+
+    model_config = ConfigDict(extra="allow")
+
+    standards: list[StandardSummary]
+    total: int
+
+
+class IndustryStandardsResponse(BaseModel):
+    """Response from industry-specific standards lookup."""
+
+    model_config = ConfigDict(extra="allow")
+
+    industry: str
+    standards: list[StandardSummary]
+    total: int
+
+
+@router.get("/standards/{name}", response_model=StandardDetailResponse)
 async def get_standard(
     request: Request,
     name: str,
@@ -49,7 +110,7 @@ async def get_standard(
     return result
 
 
-@router.get("/standards")
+@router.get("/standards", response_model=StandardListResponse)
 async def list_standards(
     request: Request,
     q: str | None = Query(default=None, description="Search query"),
@@ -85,7 +146,7 @@ async def list_standards(
     }
 
 
-@router.get("/standards/industry/{industry}")
+@router.get("/standards/industry/{industry}", response_model=IndustryStandardsResponse)
 async def get_by_industry(
     request: Request,
     industry: str,

--- a/backend/uv.lock
+++ b/backend/uv.lock
@@ -572,17 +572,18 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.128.0"
+version = "0.131.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
     { name = "pydantic" },
     { name = "starlette" },
     { name = "typing-extensions" },
+    { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/52/08/8c8508db6c7b9aae8f7175046af41baad690771c9bcde676419965e338c7/fastapi-0.128.0.tar.gz", hash = "sha256:1cc179e1cef10a6be60ffe429f79b829dce99d8de32d7acb7e6c8dfdf7f2645a", size = 365682, upload-time = "2025-12-27T15:21:13.714Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/91/32/158cbf685b7d5a26f87131069da286bf10fc9fbf7fc968d169d48a45d689/fastapi-0.131.0.tar.gz", hash = "sha256:6531155e52bee2899a932c746c9a8250f210e3c3303a5f7b9f8a808bfe0548ff", size = 369612, upload-time = "2026-02-22T16:38:11.252Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/5c/05/5cbb59154b093548acd0f4c7c474a118eda06da25aa75c616b72d8fcd92a/fastapi-0.128.0-py3-none-any.whl", hash = "sha256:aebd93f9716ee3b4f4fcfe13ffb7cf308d99c9f3ab5622d8877441072561582d", size = 103094, upload-time = "2025-12-27T15:21:12.154Z" },
+    { url = "https://files.pythonhosted.org/packages/ff/94/b58ec24c321acc2ad1327f69b033cadc005e0f26df9a73828c9e9c7db7ce/fastapi-0.131.0-py3-none-any.whl", hash = "sha256:ed0e53decccf4459de78837ce1b867cd04fa9ce4579497b842579755d20b405a", size = 103854, upload-time = "2026-02-22T16:38:09.814Z" },
 ]
 
 [[package]]
@@ -2571,7 +2572,7 @@ requires-dist = [
     { name = "asyncpg", specifier = ">=0.31.0" },
     { name = "better-profanity", specifier = ">=0.7.0" },
     { name = "better-profanity", marker = "extra == 'guardrails'", specifier = ">=0.7.0" },
-    { name = "fastapi", specifier = ">=0.115.0" },
+    { name = "fastapi", specifier = ">=0.130.0,<1.0.0" },
     { name = "httpx", specifier = ">=0.27.0" },
     { name = "langchain-core", specifier = ">=0.3.0" },
     { name = "langchain-openai", specifier = ">=0.2.0" },


### PR DESCRIPTION
## Summary

Phase 4 of the [best-practices plan](https://github.com/arthurfantaci/graphrag-api-db/blob/main/docs/best-practices-plan.md) — API hardening with three sub-steps:

- **4a — Issue #202 data quality fixes**: Fix ghost null relationships in enrichment queries (`OPTIONAL MATCH` → `MATCH`), filter degenerate chunks (<20 chars), deduplicate redundant relationships across graph-enriched results, tighten `EntityInfo`/`SemanticRelationship` models, and type `SearchResult.metadata`/`.related_articles`/`.industry_standards`
- **4b — FastAPI version bump**: `>=0.130.0,<1.0.0` (resolves to 0.131.0)
- **4c — Pydantic response models**: Add typed `response_model` to all 10 untyped endpoints (`/`, `/health`, `/definitions/*`, `/schema/*`, `/standards/*`, `/chat/routing-guide`) with `ConfigDict(extra="allow")` for safe initial rollout

## Test plan

- [x] `uv run ruff check .` — all checks passed
- [x] `uv run ruff format --check .` — 133 files formatted
- [x] `uv run pytest --tb=short` — 813 tests passing (no modifications needed)
- [x] `uv run ty check` — advisory only (continue-on-error)
- [ ] Verify OpenAPI docs (`/docs`) show typed schemas for all endpoints
- [ ] Verify frontend integration — no silently dropped fields (extra="allow" ensures safety)

Closes #202
Ref #212 (Phase 4)

🤖 Generated with [Claude Code](https://claude.com/claude-code)