### PR TITLE
feat: HybridRetriever integration — Phase 5a

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,6 +27,13 @@
 - Structured data as keyword args (`logger.warning("msg", key=value)`) — NOT `extra={}`
 - Test log capture: `structlog.testing.capture_logs()` (not `caplog`) for all modules
 
+## Response Models (Phase 4)
+- All 15 endpoints have typed Pydantic `response_model` — do NOT add untyped endpoints
+- New response models use `ConfigDict(extra="allow")` — tighten later
+- Search models: `EntityInfo.name` required, `SemanticRelationship.from_entity`/`.relationship` required
+- Typed sub-models: `ChunkMetadata`, `RelatedArticle`, `IndustryStandardInfo` (not `dict[str, Any]`)
+- Degenerate chunk filtering: `_is_meaningful_content()` in `core/retrieval.py` (≥20 non-whitespace chars)
+
 ## Testing
 - 813+ tests, run with `uv run pytest --tb=short` from `backend/`
 - Autouse fixtures (conftest.py): `_disable_langsmith_tracing`, `_reset_cost_tracker`, `_clear_singleton_caches`, `_reset_structlog`

--- a/backend/src/requirements_graphrag_api/api.py
+++ b/backend/src/requirements_graphrag_api/api.py
@@ -39,7 +39,10 @@ from requirements_graphrag_api.auth import (
     configure_audit_logging,
 )
 from requirements_graphrag_api.config import get_auth_config, get_config, get_guardrail_config
-from requirements_graphrag_api.core.retrieval import create_vector_retriever
+from requirements_graphrag_api.core.retrieval import (
+    create_hybrid_retriever,
+    create_vector_retriever,
+)
 from requirements_graphrag_api.middleware import (
     SizeLimitMiddleware,
     TraceCorrelationMiddleware,
@@ -150,6 +153,14 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     retriever = create_vector_retriever(driver, config)
     logger.info("VectorRetriever initialized with index: %s", config.vector_index_name)
 
+    # Create HybridRetriever (Phase 5a — combines vector + fulltext search)
+    hybrid_retriever = create_hybrid_retriever(driver, config)
+    logger.info(
+        "HybridRetriever initialized with indexes: %s + %s",
+        config.vector_index_name,
+        config.fulltext_index_name,
+    )
+
     # Initialize guardrails
     guardrail_config = get_guardrail_config()
     limiter = get_rate_limiter()
@@ -179,6 +190,7 @@ async def lifespan(app: FastAPI) -> AsyncIterator[None]:
     app.state.config = config
     app.state.driver = driver
     app.state.retriever = retriever
+    app.state.hybrid_retriever = hybrid_retriever
     app.state.guardrail_config = guardrail_config
     app.state.limiter = limiter
     app.state.auth_config = auth_config

--- a/backend/src/requirements_graphrag_api/config.py
+++ b/backend/src/requirements_graphrag_api/config.py
@@ -129,6 +129,9 @@ class AppConfig:
     prompt_hub_enabled: bool = True
     # Conversational model (lightweight, for meta-conversation queries)
     conversational_model: str = "gpt-4o-mini"
+    # HybridRetriever settings (Phase 5a)
+    fulltext_index_name: str = "chunk_text_fulltext"
+    use_legacy_hybrid_search: bool = False
 
     def __post_init__(self) -> None:
         """Validate configuration after initialization."""
@@ -398,4 +401,7 @@ def get_config() -> AppConfig:
         prompt_cache_ttl=int(os.getenv("PROMPT_CACHE_TTL", "300")),
         prompt_hub_enabled=prompt_hub_enabled,
         conversational_model=os.getenv("CONVERSATIONAL_MODEL", "gpt-4o-mini"),
+        fulltext_index_name=os.getenv("FULLTEXT_INDEX_NAME", "chunk_text_fulltext"),
+        use_legacy_hybrid_search=os.getenv("USE_LEGACY_HYBRID_SEARCH", "false").lower()
+        in ("true", "1", "yes"),
     )

--- a/backend/src/requirements_graphrag_api/core/__init__.py
+++ b/backend/src/requirements_graphrag_api/core/__init__.py
@@ -33,6 +33,7 @@ from requirements_graphrag_api.core.definitions import (
 from requirements_graphrag_api.core.retrieval import (
     DEFAULT_ENRICHMENT_OPTIONS,
     GraphEnrichmentOptions,
+    create_hybrid_retriever,
     create_vector_retriever,
     explore_entity,
     get_entities_from_chunks,
@@ -64,6 +65,7 @@ __all__ = [
     "StreamEvent",
     "StreamEventType",
     "classify_intent",
+    "create_hybrid_retriever",
     "create_vector_retriever",
     "explore_entity",
     "format_context",

--- a/backend/src/requirements_graphrag_api/core/agentic/orchestrator.py
+++ b/backend/src/requirements_graphrag_api/core/agentic/orchestrator.py
@@ -46,7 +46,7 @@ from requirements_graphrag_api.core.context import (
 if TYPE_CHECKING:
     from langgraph.checkpoint.postgres.aio import AsyncPostgresSaver
     from neo4j import Driver
-    from neo4j_graphrag.retrievers import VectorRetriever
+    from neo4j_graphrag.retrievers import HybridRetriever, VectorRetriever
 
     from requirements_graphrag_api.config import AppConfig
 
@@ -59,6 +59,7 @@ def create_orchestrator_graph(
     retriever: VectorRetriever,
     *,
     checkpointer: AsyncPostgresSaver | None = None,
+    hybrid_retriever: HybridRetriever | None = None,
 ) -> StateGraph:
     """Create the main orchestrator graph composing all subgraphs.
 
@@ -67,12 +68,13 @@ def create_orchestrator_graph(
         driver: Neo4j driver instance.
         retriever: Vector retriever instance.
         checkpointer: Optional PostgresSaver for conversation persistence.
+        hybrid_retriever: Optional hybrid retriever for combined vector+keyword search.
 
     Returns:
         Compiled orchestrator graph.
     """
     # Create subgraphs
-    rag_subgraph = create_rag_subgraph(config, driver, retriever)
+    rag_subgraph = create_rag_subgraph(config, driver, retriever, hybrid_retriever)
     synthesis_subgraph = create_synthesis_subgraph(config)
 
     # -------------------------------------------------------------------------

--- a/backend/src/requirements_graphrag_api/core/agentic/subgraphs/rag.py
+++ b/backend/src/requirements_graphrag_api/core/agentic/subgraphs/rag.py
@@ -32,7 +32,7 @@ from requirements_graphrag_api.prompts import PromptName, get_prompt
 
 if TYPE_CHECKING:
     from neo4j import Driver
-    from neo4j_graphrag.retrievers import VectorRetriever
+    from neo4j_graphrag.retrievers import HybridRetriever, VectorRetriever
 
     from requirements_graphrag_api.config import AppConfig
 
@@ -48,6 +48,7 @@ def create_rag_subgraph(
     config: AppConfig,
     driver: Driver,
     retriever: VectorRetriever,
+    hybrid_retriever: HybridRetriever | None = None,
 ) -> StateGraph:
     """Create the RAG retrieval subgraph.
 
@@ -55,6 +56,7 @@ def create_rag_subgraph(
         config: Application configuration.
         driver: Neo4j driver instance.
         retriever: Vector retriever instance.
+        hybrid_retriever: Optional hybrid retriever for combined vector+keyword search.
 
     Returns:
         Compiled RAG subgraph.
@@ -138,6 +140,8 @@ def create_rag_subgraph(
                     driver=driver,
                     query=q,
                     limit=MAX_RESULTS_PER_QUERY,
+                    hybrid_retriever=hybrid_retriever,
+                    use_legacy=config.use_legacy_hybrid_search,
                 )
                 # Tag results with source query
                 for r in results:

--- a/backend/src/requirements_graphrag_api/core/retrieval.py
+++ b/backend/src/requirements_graphrag_api/core/retrieval.py
@@ -32,8 +32,9 @@ import structlog
 from requirements_graphrag_api.observability import traceable_safe
 
 if TYPE_CHECKING:
+    import neo4j
     from neo4j import Driver
-    from neo4j_graphrag.retrievers import VectorRetriever
+    from neo4j_graphrag.retrievers import HybridRetriever, VectorRetriever
 
     from requirements_graphrag_api.config import AppConfig
 
@@ -126,6 +127,72 @@ def create_vector_retriever(
         index_name=config.vector_index_name,
         embedder=embedder,
         return_properties=["text", "index"],
+    )
+
+
+def _hybrid_result_formatter(record: neo4j.Record) -> Any:
+    """Format HybridRetriever results with element ID and clean text content.
+
+    The default neo4j-graphrag formatter loses the element ID needed for
+    article metadata joins. This custom formatter extracts it from the
+    record's top-level ``elementId`` key.
+
+    Args:
+        record: Neo4j record from HybridRetriever's internal Cypher query.
+
+    Returns:
+        RetrieverResultItem with text content and metadata including element ID.
+    """
+    from neo4j_graphrag.types import RetrieverResultItem
+
+    node = record.get("node")
+    text = node.get("text", "") if isinstance(node, dict) else ""
+    index = node.get("index") if isinstance(node, dict) else None
+
+    return RetrieverResultItem(
+        content=text,
+        metadata={
+            "score": record.get("score", 0.0),
+            "id": record.get("elementId"),
+            "index": index,
+        },
+    )
+
+
+def create_hybrid_retriever(
+    driver: Driver,
+    config: AppConfig,
+) -> HybridRetriever:
+    """Create a HybridRetriever for combined vector + keyword search.
+
+    Uses the neo4j-graphrag library's HybridRetriever with a custom result
+    formatter that preserves element IDs for article metadata joins.
+
+    Args:
+        driver: Neo4j driver instance.
+        config: Application configuration.
+
+    Returns:
+        Configured HybridRetriever instance.
+    """
+    from neo4j_graphrag.retrievers import HybridRetriever
+
+    from requirements_graphrag_api.core.embeddings import VoyageAIEmbeddings
+
+    embedder = VoyageAIEmbeddings(
+        model=config.embedding_model,
+        input_type="query",
+        dimensions=config.embedding_dimensions,
+        api_key=config.voyage_api_key,
+    )
+
+    return HybridRetriever(
+        driver=driver,
+        vector_index_name=config.vector_index_name,
+        fulltext_index_name=config.fulltext_index_name,
+        embedder=embedder,
+        return_properties=["text", "index"],
+        result_formatter=_hybrid_result_formatter,
     )
 
 
@@ -242,8 +309,7 @@ async def vector_search(
     return formatted
 
 
-@traceable_safe(name="hybrid_search", run_type="retriever")
-async def hybrid_search(
+async def _legacy_hybrid_search(
     retriever: VectorRetriever,
     driver: Driver,
     query: str,
@@ -251,23 +317,16 @@ async def hybrid_search(
     limit: int = 6,
     keyword_weight: float = 0.3,
 ) -> list[dict[str, Any]]:
-    """Perform hybrid search combining vector similarity and keyword matching.
+    """Legacy hybrid search using manual Cypher queries.
 
-    Combines semantic understanding (vectors) with exact term matching (keywords)
-    for improved recall on queries with specific technical terms.
+    Preserved behind ``use_legacy_hybrid_search`` config flag for rollback.
+    Will be removed after one release cycle.
 
-    Args:
-        retriever: Configured VectorRetriever instance.
-        driver: Neo4j driver for keyword search.
-        query: Natural language search query.
-        limit: Maximum number of results to return.
-        keyword_weight: Weight for keyword results (0-1). Vector weight = 1 - keyword_weight.
-
-    Returns:
-        List of results with content, score, source, and metadata.
+    Note: The keyword leg uses 'chunk_fulltext' (indexed on non-existent
+    ``heading`` property), so it effectively returns vector-only results.
     """
     logger.info(
-        "Hybrid search: query='%s', limit=%d, keyword_weight=%.2f",
+        "Legacy hybrid search: query='%s', limit=%d, keyword_weight=%.2f",
         query,
         limit,
         keyword_weight,
@@ -359,8 +418,141 @@ async def hybrid_search(
     merged.sort(key=lambda x: x["score"], reverse=True)
     results = merged[:limit]
 
-    logger.info("Hybrid search returned %d results", len(results))
+    logger.info("Legacy hybrid search returned %d results", len(results))
     return results
+
+
+@traceable_safe(name="hybrid_search", run_type="retriever")
+async def hybrid_search(
+    retriever: VectorRetriever,
+    driver: Driver,
+    query: str,
+    *,
+    limit: int = 6,
+    keyword_weight: float = 0.3,
+    hybrid_retriever: HybridRetriever | None = None,
+    use_legacy: bool = False,
+) -> list[dict[str, Any]]:
+    """Perform hybrid search combining vector similarity and keyword matching.
+
+    Uses the neo4j-graphrag HybridRetriever with LINEAR ranker when available,
+    falling back to the legacy manual implementation if ``use_legacy`` is True
+    or no ``hybrid_retriever`` is provided.
+
+    The HybridRetriever handles score fusion internally using:
+        ``score = alpha * vector_normalized + (1-alpha) * fulltext_normalized``
+    where ``alpha = 1 - keyword_weight``.
+
+    Post-processing preserves:
+    - Article-level deduplication (HybridRetriever only dedupes at chunk level)
+    - ``source`` provenance field tagging
+    - Article metadata via separate FROM_ARTICLE join
+
+    Args:
+        retriever: Configured VectorRetriever instance (used for legacy path).
+        driver: Neo4j driver for article metadata queries.
+        query: Natural language search query.
+        limit: Maximum number of results to return.
+        keyword_weight: Weight for keyword results (0-1). Maps to alpha = 1 - keyword_weight.
+        hybrid_retriever: Optional HybridRetriever instance for new path.
+        use_legacy: Force legacy implementation (config flag for rollback).
+
+    Returns:
+        List of results with content, score, source, and metadata.
+    """
+    # Dispatch to legacy if requested or no hybrid retriever available
+    if use_legacy or hybrid_retriever is None:
+        return await _legacy_hybrid_search(
+            retriever, driver, query, limit=limit, keyword_weight=keyword_weight
+        )
+
+    alpha = 1 - keyword_weight
+    logger.info(
+        "Hybrid search: query='%s', limit=%d, keyword_weight=%.2f, alpha=%.2f",
+        query,
+        limit,
+        keyword_weight,
+        alpha,
+    )
+
+    # Use HybridRetriever with LINEAR ranker (sync API, offload to thread)
+    # Request extra results for article-level dedup filtering
+    raw_results = await asyncio.to_thread(
+        hybrid_retriever.search,
+        query_text=query,
+        top_k=limit * 2,
+        ranker="linear",
+        alpha=alpha,
+    )
+
+    # Filter degenerate chunks (bare headings without content — Issue #202)
+    items = [item for item in raw_results.items if _is_meaningful_content(item.content or "")]
+
+    # Collect chunk IDs for article metadata join
+    chunk_ids = [item.metadata["id"] for item in items if item.metadata.get("id")]
+
+    # Fetch article metadata for chunks
+    article_context: dict[str, dict[str, Any]] = {}
+    if chunk_ids:
+
+        def _fetch_article_context() -> dict[str, dict[str, Any]]:
+            ctx: dict[str, dict[str, Any]] = {}
+            with driver.session() as session:
+                context_result = session.run(
+                    """
+                    MATCH (c:Chunk)-[:FROM_ARTICLE]->(a:Article)
+                    WHERE elementId(c) IN $chunk_ids
+                    RETURN elementId(c) AS chunk_id,
+                           a.article_title AS title,
+                           a.url AS url,
+                           a.article_id AS article_id,
+                           a.chapter_title AS chapter
+                    """,
+                    chunk_ids=chunk_ids,
+                )
+                for record in context_result:
+                    ctx[record["chunk_id"]] = {
+                        "title": record["title"],
+                        "url": record["url"],
+                        "article_id": record["article_id"],
+                        "chapter": record["chapter"],
+                    }
+            return ctx
+
+        article_context = await asyncio.to_thread(_fetch_article_context)
+
+    # Article-level deduplication + provenance tagging
+    seen_articles: set[str] = set()
+    formatted: list[dict[str, Any]] = []
+
+    for item in items:
+        chunk_id = item.metadata.get("id")
+        score = item.metadata.get("score", 0.0)
+        metadata = article_context.get(chunk_id, {}).copy()
+        metadata["chunk_id"] = chunk_id
+        metadata["chunk_index"] = item.metadata.get("index")
+
+        # Article-level dedup
+        article_id = metadata.get("article_id")
+        if article_id and article_id in seen_articles:
+            continue
+        if article_id:
+            seen_articles.add(article_id)
+
+        formatted.append(
+            {
+                "content": item.content or "",
+                "score": round(float(score), 4),
+                "metadata": metadata,
+                "source": "hybrid",
+            }
+        )
+
+        if len(formatted) >= limit:
+            break
+
+    logger.info("Hybrid search returned %d results", len(formatted))
+    return formatted
 
 
 # =============================================================================
@@ -824,6 +1016,8 @@ async def graph_enriched_search(
     *,
     limit: int = 6,
     options: GraphEnrichmentOptions | None = None,
+    hybrid_retriever: HybridRetriever | None = None,
+    use_legacy: bool = False,
 ) -> list[dict[str, Any]]:
     """Perform hybrid search enriched with multi-level graph context.
 
@@ -849,11 +1043,13 @@ async def graph_enriched_search(
         - Glossary definitions
 
     Args:
-        retriever: Configured VectorRetriever instance.
+        retriever: Configured VectorRetriever instance (used for legacy path).
         driver: Neo4j driver for traversal.
         query: Natural language search query.
         limit: Maximum number of base results.
         options: Configuration for enrichment levels. Uses defaults if None.
+        hybrid_retriever: Optional HybridRetriever for new hybrid search path.
+        use_legacy: Force legacy hybrid search implementation.
 
     Returns:
         List of enriched results with content, score, metadata, and graph context.
@@ -869,7 +1065,14 @@ async def graph_enriched_search(
     )
 
     # Get base results using hybrid search (vector + keyword) for better recall
-    base_results = await hybrid_search(retriever, driver, query, limit=limit)
+    base_results = await hybrid_search(
+        retriever,
+        driver,
+        query,
+        limit=limit,
+        hybrid_retriever=hybrid_retriever,
+        use_legacy=use_legacy,
+    )
 
     # Collect all chunk IDs for batch queries
     chunk_ids = [

--- a/backend/src/requirements_graphrag_api/graph.py
+++ b/backend/src/requirements_graphrag_api/graph.py
@@ -16,7 +16,10 @@ from neo4j import GraphDatabase
 
 from requirements_graphrag_api.config import get_config
 from requirements_graphrag_api.core.agentic.orchestrator import create_orchestrator_graph
-from requirements_graphrag_api.core.retrieval import create_vector_retriever
+from requirements_graphrag_api.core.retrieval import (
+    create_hybrid_retriever,
+    create_vector_retriever,
+)
 
 logger = structlog.get_logger()
 
@@ -33,10 +36,11 @@ driver = GraphDatabase.driver(
     max_connection_lifetime=config.neo4j_max_connection_lifetime,
 )
 
-# Initialize VectorRetriever
+# Initialize retrievers
 retriever = create_vector_retriever(driver, config)
+hybrid_retriever = create_hybrid_retriever(driver, config)
 
 # Compile the orchestrator graph (no checkpointer for dev server)
-graph = create_orchestrator_graph(config, driver, retriever)
+graph = create_orchestrator_graph(config, driver, retriever, hybrid_retriever=hybrid_retriever)
 
 logger.info("LangGraph dev server: orchestrator graph compiled")

--- a/backend/src/requirements_graphrag_api/routes/chat.py
+++ b/backend/src/requirements_graphrag_api/routes/chat.py
@@ -53,7 +53,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
     from neo4j import Driver
-    from neo4j_graphrag.retrievers import VectorRetriever
+    from neo4j_graphrag.retrievers import HybridRetriever, VectorRetriever
 
     from requirements_graphrag_api.config import AppConfig, GuardrailConfig
 
@@ -136,6 +136,7 @@ async def _generate_sse_events(
     user_ip: str | None = None,
     request_id: str | None = None,
     trace_id: str | None = None,
+    hybrid_retriever: HybridRetriever | None = None,
 ) -> AsyncIterator[str]:
     """Generate SSE events from streaming chat response with automatic routing.
 
@@ -148,6 +149,7 @@ async def _generate_sse_events(
         user_ip: Client IP address for logging.
         request_id: Unique request identifier.
         trace_id: OTel trace ID for cross-system correlation.
+        hybrid_retriever: Optional HybridRetriever for combined search.
 
     Yields:
         Formatted SSE event strings.
@@ -382,6 +384,7 @@ async def _generate_sse_events(
                 safe_message,
                 guardrail_config=guardrail_config,
                 trace_id=trace_id,
+                hybrid_retriever=hybrid_retriever,
             ):
                 yield event_str
 
@@ -503,6 +506,7 @@ async def chat_endpoint(
     retriever: VectorRetriever = request.app.state.retriever
     driver: Driver = request.app.state.driver
     guardrail_config: GuardrailConfig = request.app.state.guardrail_config
+    hybrid_retriever: HybridRetriever | None = getattr(request.app.state, "hybrid_retriever", None)
 
     # Get client info for logging
     user_ip = get_remote_address(request)
@@ -519,6 +523,7 @@ async def chat_endpoint(
             user_ip=user_ip,
             request_id=request_id,
             trace_id=trace_id,
+            hybrid_retriever=hybrid_retriever,
         ),
         media_type="text/event-stream",
         headers={

--- a/backend/src/requirements_graphrag_api/routes/handlers.py
+++ b/backend/src/requirements_graphrag_api/routes/handlers.py
@@ -43,7 +43,7 @@ if TYPE_CHECKING:
     from collections.abc import AsyncIterator
 
     from neo4j import Driver
-    from neo4j_graphrag.retrievers import VectorRetriever
+    from neo4j_graphrag.retrievers import HybridRetriever, VectorRetriever
 
     from requirements_graphrag_api.config import AppConfig, GuardrailConfig
     from requirements_graphrag_api.routes.chat import ChatMessage, ChatRequest
@@ -298,6 +298,7 @@ async def generate_explanatory_events(
     guardrail_config: GuardrailConfig | None = None,
     *,
     trace_id: str | None = None,
+    hybrid_retriever: HybridRetriever | None = None,
 ) -> AsyncIterator[str]:
     """Generate SSE events for explanatory (RAG) queries using agentic orchestrator.
 
@@ -317,6 +318,7 @@ async def generate_explanatory_events(
         safe_message: Sanitized message with PII redacted.
         guardrail_config: Guardrail configuration for output checks.
         trace_id: OTel trace ID for cross-system correlation.
+        hybrid_retriever: Optional HybridRetriever for combined search.
 
     Yields:
         Formatted SSE event strings.
@@ -330,7 +332,13 @@ async def generate_explanatory_events(
             logger.warning("CHECKPOINT_DATABASE_URL not set — chat memory disabled")
 
         # Create the orchestrator graph with persistence
-        graph = create_orchestrator_graph(config, driver, retriever, checkpointer=checkpointer)
+        graph = create_orchestrator_graph(
+            config,
+            driver,
+            retriever,
+            checkpointer=checkpointer,
+            hybrid_retriever=hybrid_retriever,
+        )
 
         # Refine query for multi-turn context (resolve pronouns, add context)
         refined_query = safe_message

--- a/backend/src/requirements_graphrag_api/routes/search.py
+++ b/backend/src/requirements_graphrag_api/routes/search.py
@@ -390,6 +390,8 @@ async def hybrid_search_endpoint(
         safe_query,
         limit=body.limit,
         keyword_weight=body.keyword_weight,
+        hybrid_retriever=request.app.state.hybrid_retriever,
+        use_legacy=config.use_legacy_hybrid_search,
     )
 
     return {
@@ -431,6 +433,8 @@ async def graph_search_endpoint(
         driver,
         safe_query,
         limit=body.limit,
+        hybrid_retriever=request.app.state.hybrid_retriever,
+        use_legacy=config.use_legacy_hybrid_search,
     )
 
     return {

--- a/backend/tests/test_core/test_retrieval.py
+++ b/backend/tests/test_core/test_retrieval.py
@@ -16,6 +16,8 @@ import pytest
 from requirements_graphrag_api.core.retrieval import (
     GraphEnrichmentOptions,
     _enrich_with_media,
+    _hybrid_result_formatter,
+    create_hybrid_retriever,
     create_vector_retriever,
     explore_entity,
     graph_enriched_search,
@@ -585,3 +587,302 @@ class TestCreateVectorRetriever:
             return_properties=["text", "index"],
         )
         assert result == mock_retriever_cls.return_value
+
+
+# =============================================================================
+# Hybrid Result Formatter Tests
+# =============================================================================
+
+
+class TestHybridResultFormatter:
+    """Tests for _hybrid_result_formatter function."""
+
+    def test_formats_dict_node_correctly(self) -> None:
+        """Test formatting when node is a dict (return_properties set)."""
+        record = MagicMock()
+        record.get = lambda k, d=None: {
+            "node": {"text": "chunk text content", "index": 3},
+            "score": 0.87,
+            "elementId": "4:abc:999",
+        }.get(k, d)
+
+        result = _hybrid_result_formatter(record)
+
+        assert result.content == "chunk text content"
+        assert result.metadata["score"] == 0.87
+        assert result.metadata["id"] == "4:abc:999"
+        assert result.metadata["index"] == 3
+
+    def test_handles_non_dict_node(self) -> None:
+        """Test fallback when node is not a dict."""
+        record = MagicMock()
+        record.get = lambda k, d=None: {
+            "node": "not-a-dict",
+            "score": 0.5,
+            "elementId": "4:abc:111",
+        }.get(k, d)
+
+        result = _hybrid_result_formatter(record)
+
+        assert result.content == ""
+        assert result.metadata["score"] == 0.5
+        assert result.metadata["id"] == "4:abc:111"
+        assert result.metadata["index"] is None
+
+    def test_handles_missing_fields(self) -> None:
+        """Test with missing optional fields."""
+        record = MagicMock()
+        record.get = lambda k, d=None: {"node": {"text": "content"}}.get(k, d)
+
+        result = _hybrid_result_formatter(record)
+
+        assert result.content == "content"
+        assert result.metadata["score"] == 0.0
+        assert result.metadata["id"] is None
+
+
+# =============================================================================
+# Create Hybrid Retriever Tests
+# =============================================================================
+
+
+class TestCreateHybridRetriever:
+    """Tests for create_hybrid_retriever factory function."""
+
+    @patch("requirements_graphrag_api.core.embeddings.VoyageAIEmbeddings")
+    @patch("neo4j_graphrag.retrievers.HybridRetriever")
+    def test_creates_hybrid_retriever_with_correct_params(
+        self, mock_hybrid_cls: MagicMock, mock_voyage_cls: MagicMock, mock_config: MagicMock
+    ) -> None:
+        """Test that HybridRetriever is constructed with correct parameters."""
+        mock_driver = MagicMock()
+        mock_embedder = MagicMock()
+        mock_voyage_cls.return_value = mock_embedder
+
+        result = create_hybrid_retriever(mock_driver, mock_config)
+
+        mock_voyage_cls.assert_called_once_with(
+            model=mock_config.embedding_model,
+            input_type="query",
+            dimensions=mock_config.embedding_dimensions,
+            api_key=mock_config.voyage_api_key,
+        )
+        mock_hybrid_cls.assert_called_once_with(
+            driver=mock_driver,
+            vector_index_name=mock_config.vector_index_name,
+            fulltext_index_name=mock_config.fulltext_index_name,
+            embedder=mock_embedder,
+            return_properties=["text", "index"],
+            result_formatter=_hybrid_result_formatter,
+        )
+        assert result == mock_hybrid_cls.return_value
+
+
+# =============================================================================
+# Hybrid Search with HybridRetriever Tests
+# =============================================================================
+
+
+class TestHybridSearchWithRetriever:
+    """Tests for hybrid_search using the new HybridRetriever path."""
+
+    @pytest.mark.asyncio
+    async def test_uses_hybrid_retriever_when_provided(self) -> None:
+        """Test that new path is used when hybrid_retriever is given."""
+        mock_vector_retriever = MagicMock()
+        mock_hybrid_retriever = MagicMock()
+
+        # Simulate HybridRetriever.search() result
+        item1 = MagicMock()
+        item1.content = "Requirements traceability content"
+        item1.metadata = {"id": "4:abc:100", "score": 0.9, "index": 0}
+
+        mock_result = MagicMock()
+        mock_result.items = [item1]
+        mock_hybrid_retriever.search.return_value = mock_result
+
+        mock_driver = create_mock_driver_with_results(
+            [
+                [
+                    {
+                        "chunk_id": "4:abc:100",
+                        "title": "Test Article",
+                        "url": "https://example.com",
+                        "article_id": "a-1",
+                        "chapter": "Ch1",
+                    }
+                ],
+            ]
+        )
+
+        results = await hybrid_search(
+            mock_vector_retriever,
+            mock_driver,
+            "requirements",
+            hybrid_retriever=mock_hybrid_retriever,
+        )
+
+        assert len(results) == 1
+        assert results[0]["source"] == "hybrid"
+        assert results[0]["content"] == "Requirements traceability content"
+        assert results[0]["metadata"]["title"] == "Test Article"
+        mock_hybrid_retriever.search.assert_called_once()
+        mock_vector_retriever.search.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_alpha_mapping_from_keyword_weight(self) -> None:
+        """Test that keyword_weight is correctly mapped to alpha."""
+        mock_hybrid = MagicMock()
+        mock_result = MagicMock()
+        mock_result.items = []
+        mock_hybrid.search.return_value = mock_result
+
+        mock_driver = MagicMock()
+        mock_driver.session.return_value.__enter__ = MagicMock(return_value=MagicMock())
+        mock_driver.session.return_value.__exit__ = MagicMock(return_value=False)
+
+        await hybrid_search(
+            MagicMock(),
+            mock_driver,
+            "test",
+            keyword_weight=0.3,
+            hybrid_retriever=mock_hybrid,
+        )
+
+        call_kwargs = mock_hybrid.search.call_args
+        assert call_kwargs.kwargs.get("alpha") == pytest.approx(0.7)
+        assert call_kwargs.kwargs.get("ranker") == "linear"
+
+    @pytest.mark.asyncio
+    async def test_article_level_dedup(self) -> None:
+        """Test that results from the same article are deduplicated."""
+        mock_hybrid = MagicMock()
+
+        item1 = MagicMock()
+        item1.content = "Chunk 1 from article A"
+        item1.metadata = {"id": "4:abc:100", "score": 0.9, "index": 0}
+
+        item2 = MagicMock()
+        item2.content = "Chunk 2 from article A"
+        item2.metadata = {"id": "4:abc:101", "score": 0.8, "index": 1}
+
+        mock_result = MagicMock()
+        mock_result.items = [item1, item2]
+        mock_hybrid.search.return_value = mock_result
+
+        # Both chunks from same article_id
+        mock_driver = create_mock_driver_with_results(
+            [
+                [
+                    {
+                        "chunk_id": "4:abc:100",
+                        "title": "Same Article",
+                        "url": "https://example.com/a",
+                        "article_id": "a-1",
+                        "chapter": "Ch1",
+                    },
+                    {
+                        "chunk_id": "4:abc:101",
+                        "title": "Same Article",
+                        "url": "https://example.com/a",
+                        "article_id": "a-1",
+                        "chapter": "Ch1",
+                    },
+                ],
+            ]
+        )
+
+        results = await hybrid_search(
+            MagicMock(),
+            mock_driver,
+            "test",
+            hybrid_retriever=mock_hybrid,
+        )
+
+        assert len(results) == 1
+        assert results[0]["content"] == "Chunk 1 from article A"
+
+    @pytest.mark.asyncio
+    async def test_filters_degenerate_chunks(self) -> None:
+        """Test that degenerate chunks (short/whitespace) are filtered."""
+        mock_hybrid = MagicMock()
+
+        good_item = MagicMock()
+        good_item.content = "This is substantial content about requirements management"
+        good_item.metadata = {"id": "4:abc:100", "score": 0.9, "index": 0}
+
+        degenerate_item = MagicMock()
+        degenerate_item.content = "Heading"
+        degenerate_item.metadata = {"id": "4:abc:101", "score": 0.8, "index": 1}
+
+        mock_result = MagicMock()
+        mock_result.items = [good_item, degenerate_item]
+        mock_hybrid.search.return_value = mock_result
+
+        mock_driver = create_mock_driver_with_results(
+            [
+                [
+                    {
+                        "chunk_id": "4:abc:100",
+                        "title": "Article",
+                        "url": "https://example.com",
+                        "article_id": "a-1",
+                        "chapter": "Ch1",
+                    }
+                ],
+            ]
+        )
+
+        results = await hybrid_search(
+            MagicMock(),
+            mock_driver,
+            "test",
+            hybrid_retriever=mock_hybrid,
+        )
+
+        assert len(results) == 1
+        assert results[0]["content"] == "This is substantial content about requirements management"
+
+
+# =============================================================================
+# Hybrid Search Legacy Fallback Tests
+# =============================================================================
+
+
+class TestHybridSearchLegacyFallback:
+    """Tests for hybrid_search legacy fallback behavior."""
+
+    @pytest.mark.asyncio
+    async def test_uses_legacy_when_use_legacy_true(
+        self, mock_retriever: MagicMock, mock_driver: MagicMock
+    ) -> None:
+        """Test that use_legacy=True forces legacy path even with hybrid_retriever."""
+        mock_hybrid = MagicMock()
+
+        results = await hybrid_search(
+            mock_retriever,
+            mock_driver,
+            "test",
+            hybrid_retriever=mock_hybrid,
+            use_legacy=True,
+        )
+
+        # Legacy path uses VectorRetriever, not HybridRetriever
+        mock_retriever.search.assert_called()
+        mock_hybrid.search.assert_not_called()
+        assert len(results) > 0
+
+    @pytest.mark.asyncio
+    async def test_uses_legacy_when_no_hybrid_retriever(
+        self, mock_retriever: MagicMock, mock_driver: MagicMock
+    ) -> None:
+        """Test that legacy path is used when hybrid_retriever is None."""
+        results = await hybrid_search(
+            mock_retriever,
+            mock_driver,
+            "test",
+            hybrid_retriever=None,
+        )
+
+        mock_retriever.search.assert_called()
+        assert len(results) > 0

--- a/backend/tests/test_routes/test_search.py
+++ b/backend/tests/test_routes/test_search.py
@@ -60,8 +60,10 @@ def client(
     """Create a test client with mocked dependencies."""
     mock_app.state.driver = mock_driver
     mock_app.state.retriever = mock_retriever
+    mock_app.state.hybrid_retriever = None
     mock_app.state.guardrail_config = mock_guardrail_config
     mock_app.state.config = MagicMock()
+    mock_app.state.config.use_legacy_hybrid_search = False
     return TestClient(mock_app)
 
 


### PR DESCRIPTION
## Summary

- Integrates `neo4j-graphrag` **HybridRetriever** with LINEAR ranker for proper vector + keyword score fusion, replacing the manual hybrid search implementation
- Preserves the old implementation as `_legacy_hybrid_search()` behind `USE_LEGACY_HYBRID_SEARCH` config flag for safe rollback
- Threads `hybrid_retriever` through the full call chain: `api.py` lifespan → routes → handlers → orchestrator → RAG subgraph → `graph_enriched_search()` → `hybrid_search()`

### Key implementation details

- **Custom `result_formatter`**: Preserves element IDs from Neo4j records for article metadata joins (default formatter loses them)
- **`create_hybrid_retriever()` factory**: Mirrors `create_vector_retriever()` pattern — uses Voyage AI embedder, `chunk_text_fulltext` index, `return_properties=["text", "index"]`
- **Alpha mapping**: `alpha = 1 - keyword_weight` (0.3 keyword weight → 0.7 alpha → 70% vector / 30% keyword)
- **Article-level dedup**: Preserved as post-processing (HybridRetriever only dedupes at chunk level)
- **Degenerate chunk filtering**: `_is_meaningful_content()` filter applied to new path
- **Source provenance**: All results tagged with `source: "hybrid"`

### Config additions

| Field | Env Var | Default | Purpose |
|-------|---------|---------|---------|
| `fulltext_index_name` | `FULLTEXT_INDEX_NAME` | `chunk_text_fulltext` | Neo4j fulltext index name |
| `use_legacy_hybrid_search` | `USE_LEGACY_HYBRID_SEARCH` | `false` | Rollback flag to legacy implementation |

### Spike findings (Neo4j Aura)

- Fixed vector index dimension mismatch (1536→1024d for Voyage AI)
- Identified broken fulltext index (`chunk_fulltext` on non-existent `heading` property)
- Validated LINEAR ranker, custom formatter, and article-level dedup against 5 reference queries

## Test plan

- [x] 10 new tests: `_hybrid_result_formatter`, `create_hybrid_retriever`, new HybridRetriever path (article-level dedup, alpha mapping, degenerate filtering), legacy fallback
- [x] All 823 tests passing (813 existing + 10 new)
- [x] `ruff check .` — all passed
- [x] `ruff format --check .` — all passed
- [x] `ty check` — advisory only (no new diagnostics)
- [ ] Deploy to staging with `USE_LEGACY_HYBRID_SEARCH=false` and verify search quality
- [ ] Test rollback by setting `USE_LEGACY_HYBRID_SEARCH=true`

Closes Phase 5a of #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)