### PR TITLE
fix: revert @eslint/js 10 bump (Vercel ERESOLVE)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,7 +18,7 @@
         "react-markdown": "^10.1.0"
       },
       "devDependencies": {
-        "@eslint/js": "^10.0.1",
+        "@eslint/js": "^9.39.1",
         "@sentry/vite-plugin": "^4.9.1",
         "@types/react": "^19.2.14",
         "@types/react-dom": "^19.2.3",
@@ -850,24 +850,16 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "10.0.1",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-10.0.1.tgz",
-      "integrity": "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA==",
+      "version": "9.39.4",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
+      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": "^20.19.0 || ^22.13.0 || >=24"
+        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       },
       "funding": {
         "url": "https://eslint.org/donate"
-      },
-      "peerDependencies": {
-        "eslint": "^10.0.0"
-      },
-      "peerDependenciesMeta": {
-        "eslint": {
-          "optional": true
-        }
       }
     },
     "node_modules/@eslint/object-schema": {
@@ -2949,19 +2941,6 @@
       },
       "funding": {
         "url": "https://opencollective.com/eslint"
-      }
-    },
-    "node_modules/eslint/node_modules/@eslint/js": {
-      "version": "9.39.4",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.39.4.tgz",
-      "integrity": "sha512-nE7DEIchvtiFTwBw4Lfbu59PG+kCofhjsKaCWzxTpt4lfRjRMqG6uMBzKXuEcyXhOHoUp9riAm7/aWYGhXZ9cw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
-      },
-      "funding": {
-        "url": "https://eslint.org/donate"
       }
     },
     "node_modules/espree": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -20,7 +20,7 @@
     "react-markdown": "^10.1.0"
   },
   "devDependencies": {
-    "@eslint/js": "^10.0.1",
+    "@eslint/js": "^9.39.1",
     "@sentry/vite-plugin": "^4.9.1",
     "@types/react": "^19.2.14",
     "@types/react-dom": "^19.2.3",


### PR DESCRIPTION
## Summary

Reverts the `@eslint/js` 9.39.2 → 10.0.1 bump from #254. The new major declares `peerOptional eslint ^10.0.0`, but the project pins `eslint@^9.39.4`. Vercel's `npm install` fails with ERESOLVE; all frontend deploys since 22a7eda have been broken.

The chatbot UI is unaffected because Vercel keeps serving the last successful deploy until a new build succeeds.

## Why revert vs. forward fix

A proper eslint v9 → v10 migration should be its own scoped PR (config review, plugin compatibility check, lint-rule changes). Reverting now is the precise inverse of the cause and restores known-good state.

## Test plan

- [x] `npm run build` succeeds locally on this branch (verified pre-revert; the revert restores the prior package.json)
- [ ] CI Lint & Format Check passes
- [ ] CI Test passes
- [ ] Vercel preview build succeeds (this is the actual signal)

Closes #311

🤖 Generated with [Claude Code](https://claude.com/claude-code)