### PR TITLE
chore(deps): monthly + grouped Dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,31 +4,51 @@ updates:
   - package-ecosystem: "pip"
     directory: "/backend"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels:
       - "dependencies"
       - "python"
     commit-message:
       prefix: "chore(deps):"
+    open-pull-requests-limit: 5
+    groups:
+      python-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
 
   # npm dependencies (frontend)
   - package-ecosystem: "npm"
     directory: "/frontend"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels:
       - "dependencies"
       - "javascript"
     commit-message:
       prefix: "chore(deps):"
+    open-pull-requests-limit: 5
+    groups:
+      npm-minor-and-patch:
+        applies-to: version-updates
+        update-types:
+          - "minor"
+          - "patch"
 
   # GitHub Actions
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "weekly"
+      interval: "monthly"
     labels:
       - "dependencies"
       - "ci"
     commit-message:
       prefix: "ci(deps):"
+    open-pull-requests-limit: 5
+    groups:
+      actions-all:
+        applies-to: version-updates
+        patterns:
+          - "*"


### PR DESCRIPTION
## Summary

- Switches all three Dependabot ecosystems (pip, npm, github-actions) from `weekly` to `monthly` scheduling
- Adds `groups` so minor + patch bumps bundle into a single PR per ecosystem per cycle
- Keeps **major bumps individual** for pip/npm (langchain-core, vite, etc. still get individual review)
- Groups **all** GitHub Actions bumps (low-risk to batch)
- Adds `open-pull-requests-limit: 5` defensively

## Behavior

| Update type | Before | After |
|---|---|---|
| pip / npm minor + patch | 1 PR per dep per week | 1 grouped PR per ecosystem per month |
| pip / npm major | 1 PR per dep per week | 1 PR per dep per month |
| github-actions any | 1 PR per dep per week | 1 grouped PR per month |
| Security updates | Immediate | Immediate (unchanged) |

## Test plan

- [ ] CI lint + test pass (YAML changes only; should be a no-op for backend/frontend code)
- [ ] Dependabot GitHub validates the config (auto-validated when this PR merges — invalid configs surface as a check-run failure)
- [ ] No regression in the Dependabot Auto-Merge workflow (grouped PRs are auto-merge-eligible same as individual PRs)

Closes #313

🤖 Generated with [Claude Code](https://claude.com/claude-code)