### PR TITLE
chore(ci): group vite + @vitejs/plugin-* majors in Dependabot (closes #327)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -30,6 +30,18 @@ updates:
       prefix: "chore(deps):"
     open-pull-requests-limit: 5
     groups:
+      # Pair vite with its plugins (peer-dep coupled). Must come before the
+      # broader minor-and-patch group so first-match-wins routes these packages
+      # here for all update types. See issue #327 for the ERESOLVE rationale.
+      vite-ecosystem:
+        applies-to: version-updates
+        patterns:
+          - "vite"
+          - "@vitejs/plugin-*"
+        update-types:
+          - "major"
+          - "minor"
+          - "patch"
       npm-minor-and-patch:
         applies-to: version-updates
         update-types:


### PR DESCRIPTION
## Summary
- Adds a `vite-ecosystem` group to `.github/dependabot.yml` that pairs `vite` with `@vitejs/plugin-*` packages so Dependabot bundles their major/minor/patch updates into a single PR. Without this, peer-dep coupling between the two causes a bidirectional **ERESOLVE** deadlock on Vercel — demonstrated today by closed PRs #317 + #318.
- Group ordering is deliberate: `vite-ecosystem` comes **before** `npm-minor-and-patch` because Dependabot resolves group conflicts by first-match-wins per file order. Without that ordering, minor/patch updates of vite/plugin-* would be claimed by the broader catch-all group and the pairing would only apply to majors.
- The `"@vitejs/plugin-*"` wildcard future-proofs against new sibling plugins (`plugin-vue`, `plugin-legacy`, etc.) being added later — they'd auto-join the group with zero further config.

## Why now
Today's `/loop` queue triage closed PRs #317 (`@vitejs/plugin-react` 5→6) and #318 (`vite` 7→8) because both failed Vercel preview builds with `ERESOLVE`. Build logs from those closed PRs:
- #318: `peer vite@"^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" from @vitejs/plugin-react@5.1.4` (vite 8 alone won't resolve against pinned plugin-react 5)
- #317: `peer vite@"^8.0.0" from @vitejs/plugin-react@6.0.2` (plugin-react 6 alone won't resolve against pinned vite 7)

Under the current config, next month's Dependabot run would reopen the same two PRs separately and they'd fail with identical ERESOLVE errors. This fix routes them into a single grouped PR on the next cycle — Dependabot will regenerate the lockfile with both new peers in lockstep, satisfying npm's resolver and Vercel's `npm install`.

## Test plan
- [ ] `Lint & Format Check` passes
- [ ] `Test` passes
- [ ] `check yaml` pre-commit hook passes (already verified locally — passed on commit)
- [ ] Vercel preview build for this PR completes successfully
- [ ] After merge, on the next monthly Dependabot npm run (≈2026-06-09), verify a single grouped PR is opened for any pending vite/plugin-* updates rather than separate per-package PRs

## Risk
Minimal — config-only change. No code paths touched, no runtime behavior changed. Reversible by reverting the 12-line addition. The `vite-ecosystem` group only changes how Dependabot batches future PRs; it has no effect on the application or CI until Dependabot's next cycle.

Closes #327

🤖 Generated with [Claude Code](https://claude.com/claude-code)