### PR TITLE
chore(ci): disable auto-opened npm major-version PRs in Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -29,6 +29,16 @@ updates:
     commit-message:
       prefix: "chore(deps):"
     open-pull-requests-limit: 5
+    # Disable auto-opened major-version PRs for npm. Peer-dep coupled majors
+    # (vite/plugin-react, eslint/@eslint/js, etc.) hit Vercel ERESOLVE when
+    # opened as separate PRs — three incidents (PRs #254, #317/#318, #329/#332/
+    # #333) confirmed this is the recurring failure mode for this project.
+    # Security advisories (GHSA) still fire regardless of ignore rules.
+    # Minor + patch updates continue to flow and auto-merge via #321 infra.
+    # Major bumps are now human-initiated when needed.
+    ignore:
+      - dependency-name: "*"
+        update-types: ["version-update:semver-major"]
     groups:
       # Pair vite with its plugins (peer-dep coupled). Must come before the
       # broader minor-and-patch group so first-match-wins routes these packages


### PR DESCRIPTION
## Summary

Closes the recurring ERESOLVE failure mode by telling Dependabot to **stop opening major-version PRs** for the npm ecosystem. Three incidents this cycle (PR #254 → revert #312; #317/#318; #329/#332/#333) confirmed peer-dep-coupled majors as separate PRs cannot resolve on Vercel.

## What changes

```yaml
ignore:
  - dependency-name: "*"
    update-types: ["version-update:semver-major"]
```

10 lines added to `.github/dependabot.yml` under the npm block.

## What still works

- **Minor + patch PRs continue** → `npm-minor-and-patch` group + `automerge:candidate` label → auto-merge. PR #331 today proved the full round-trip works for safe updates.
- **Security advisories** (GHSA) bypass `ignore` rules and still fire on schedule.
- **pip (backend)** and **github-actions** ecosystems unaffected — no coupling failures observed.

## What changes for the human

Major version bumps are now opt-in. When needed:

```bash
cd frontend && npm install <pkg>@<major>   # plus any coupled peers
git checkout -b chore/deps/<pkg>-<major>
git add frontend/package.json frontend/package-lock.json
git commit -m "chore(deps): bump <pkg> to <major>"
gh pr create && gh pr merge --squash --delete-branch
```

5 minutes of focused work, vs. the perpetual Tetris.

## Test plan
- [ ] Lint & Format Check passes
- [ ] Test passes
- [ ] Vercel preview build completes successfully
- [ ] check yaml pre-commit hook passes (already verified locally)
- [ ] After merge: next monthly Dependabot npm run opens only minor/patch (no majors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)