### PR TITLE
chore(ci): skip Claude Code Review on Dependabot PRs

### DIFF
--- a/.github/workflows/claude-code-review.yml
+++ b/.github/workflows/claude-code-review.yml
@@ -12,11 +12,11 @@ on:
 
 jobs:
   claude-review:
-    # Optional: Filter by PR author
-    # if: |
-    #   github.event.pull_request.user.login == 'external-contributor' ||
-    #   github.event.pull_request.user.login == 'new-developer' ||
-    #   github.event.pull_request.author_association == 'FIRST_TIME_CONTRIBUTOR'
+    # Skip Dependabot PRs — the upstream action refuses to run on bot-authored
+    # PRs (prompt-injection guardrail) and produces a red X on every Dependabot
+    # PR. Dependabot bumps do not need AI review here; dependency-review-action
+    # already CVE-checks them.
+    if: github.actor != 'dependabot[bot]'
 
     runs-on: ubuntu-latest
     permissions:
@@ -41,4 +41,3 @@ jobs:
           prompt: '/code-review:code-review ${{ github.repository }}/pull/${{ github.event.pull_request.number }}'
           # See https://github.com/anthropics/claude-code-action/blob/main/docs/usage.md
           # or https://code.claude.com/docs/en/cli-reference for available options
-


### PR DESCRIPTION
## Summary
- The upstream `anthropics/claude-code-action@v1` ships with a default prompt-injection guardrail that **refuses to run on bot-authored PRs**, exiting with: *"Workflow initiated by non-human actor: dependabot (type: Bot)."* The action never reaches the actual review step on Dependabot PRs but still emits a red X.
- Add an actor-filter `if:` condition to the `claude-review` job so it skips entirely on PRs opened by `dependabot[bot]`. Result: the check **does not appear at all** on Dependabot PRs (no red X), and continues to run normally on human-authored PRs.
- Aligns with the project's existing pattern (`dependabot-auto-merge.yml` and `dependabot-review-routing.yml` both use `if:` on actor for symmetric reasons).

## Why skip rather than allow

Could fix by adding `allowed_bots: '*'` to the action's `with:` block, but for this repo that means spending API tokens on AI review of routine version-string changes from Dependabot — most of those diffs are noise that `dependency-review-action` already covers (CVE checks). Skipping is the lower-noise, lower-cost choice.

## Test plan
- [ ] `Lint & Format Check` passes (no Python/JS touched)
- [ ] `Test` passes (no code touched)
- [ ] Vercel preview builds successfully
- [ ] After merge: the next Dependabot-opened PR shows **no claude-review check** in its CI rollup (vs. the current red X on every one)
- [ ] Future human-authored PR still shows claude-review running normally

🤖 Generated with [Claude Code](https://claude.com/claude-code)