### PR TITLE
fix(api): support CORS_ORIGIN_REGEX env var for Vercel preview origins

### DIFF
--- a/backend/src/requirements_graphrag_api/api.py
+++ b/backend/src/requirements_graphrag_api/api.py
@@ -278,10 +278,14 @@ _cors_origins = (
     if _cors_origins_env
     else ["http://localhost:3000", "http://localhost:5173"]
 )
+# Optional regex for dynamic origins (Vercel preview branches use per-deploy URLs
+# that can't be enumerated in CORS_ORIGINS).
+_cors_origin_regex = os.getenv("CORS_ORIGIN_REGEX") or None
 
 app.add_middleware(
     CORSMiddleware,
     allow_origins=_cors_origins,
+    allow_origin_regex=_cors_origin_regex,
     allow_credentials=True,
     allow_methods=["*"],
     allow_headers=["*"],

--- a/backend/tests/test_middleware/test_cors.py
+++ b/backend/tests/test_middleware/test_cors.py
@@ -1,0 +1,132 @@
+"""Tests for CORS configuration — exact-list + regex pattern matching.
+
+Covers the dual-source CORS origin allowlist used in api.py: `CORS_ORIGINS`
+(comma-separated exact-match list) and `CORS_ORIGIN_REGEX` (regex pattern
+for dynamic origins like Vercel preview branches). FastAPI's CORSMiddleware
+applies the two with OR semantics — either source can authorize a request.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi import FastAPI
+from fastapi.middleware.cors import CORSMiddleware
+from starlette.testclient import TestClient
+
+
+@pytest.fixture
+def app_with_cors():
+    """Build a FastAPI app mirroring api.py's CORS wiring."""
+    app = FastAPI()
+    app.add_middleware(
+        CORSMiddleware,
+        allow_origins=["https://graphrag.norfolkaibi.com"],
+        allow_origin_regex=r"^https://frontend-[a-zA-Z0-9-]+-norfolk-ai-bi\.vercel\.app$",
+        allow_credentials=True,
+        allow_methods=["*"],
+        allow_headers=["*"],
+    )
+
+    @app.get("/ping")
+    async def ping():
+        return {"ok": True}
+
+    return app
+
+
+@pytest.fixture
+def client(app_with_cors):
+    return TestClient(app_with_cors)
+
+
+class TestCORSOriginAllowlist:
+    """Verify exact-match list and regex pattern both authorize origins."""
+
+    def test_exact_match_origin_allowed(self, client):
+        """Origin in `allow_origins` list passes preflight."""
+        response = client.options(
+            "/ping",
+            headers={
+                "Origin": "https://graphrag.norfolkaibi.com",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert response.status_code == 200
+        assert response.headers["access-control-allow-origin"] == "https://graphrag.norfolkaibi.com"
+
+    def test_regex_match_vercel_preview_branch_alias(self, client):
+        """Vercel branch-alias preview URL matches the regex."""
+        origin = "https://frontend-git-feat-sidebar-ux-persistence-norfolk-ai-bi.vercel.app"
+        response = client.options(
+            "/ping",
+            headers={
+                "Origin": origin,
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert response.status_code == 200
+        assert response.headers["access-control-allow-origin"] == origin
+
+    def test_regex_match_vercel_deployment_url(self, client):
+        """Vercel per-deployment URL (no `git-` prefix) matches the regex."""
+        origin = "https://frontend-325st6mmx-norfolk-ai-bi.vercel.app"
+        response = client.options(
+            "/ping",
+            headers={
+                "Origin": origin,
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert response.status_code == 200
+        assert response.headers["access-control-allow-origin"] == origin
+
+    def test_unknown_origin_rejected(self, client):
+        """Origin matching neither list nor regex receives no CORS headers."""
+        response = client.options(
+            "/ping",
+            headers={
+                "Origin": "https://evil.example.com",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert "access-control-allow-origin" not in response.headers
+
+    def test_different_org_vercel_url_rejected(self, client):
+        """Vercel URL outside the `norfolk-ai-bi` org is not matched by the regex."""
+        response = client.options(
+            "/ping",
+            headers={
+                "Origin": "https://frontend-abc123-other-org.vercel.app",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert "access-control-allow-origin" not in response.headers
+
+
+class TestCORSRegexUnsetDefault:
+    """When CORS_ORIGIN_REGEX is unset, middleware falls back to exact-list only."""
+
+    def test_no_regex_means_only_exact_list_allowed(self):
+        app = FastAPI()
+        app.add_middleware(
+            CORSMiddleware,
+            allow_origins=["https://graphrag.norfolkaibi.com"],
+            allow_origin_regex=None,
+            allow_credentials=True,
+            allow_methods=["*"],
+            allow_headers=["*"],
+        )
+
+        @app.get("/ping")
+        async def ping():
+            return {"ok": True}
+
+        client = TestClient(app)
+        response = client.options(
+            "/ping",
+            headers={
+                "Origin": "https://frontend-git-test-norfolk-ai-bi.vercel.app",
+                "Access-Control-Request-Method": "GET",
+            },
+        )
+        assert "access-control-allow-origin" not in response.headers


### PR DESCRIPTION
## Summary

Adds an optional `CORS_ORIGIN_REGEX` env var that's passed through to FastAPI's `CORSMiddleware` as `allow_origin_regex=`. The existing `CORS_ORIGINS` exact-match list stays untouched; the regex is a fallback for dynamic origins (specifically Vercel preview branches, whose URLs can't be enumerated in advance).

Discovered during PR #340 verification: Vercel preview deployments return `HTTP/2 400 "Disallowed CORS origin"` from Railway because the preview URLs are dynamic and don't match the production allowlist. Direct preflight confirms it:

\`\`\`bash
curl -i -X OPTIONS https://api-production-f1cf.up.railway.app/chat \\
  -H 'Origin: https://frontend-git-feat-sidebar-ux-persistence-norfolk-ai-bi.vercel.app' \\
  -H 'Access-Control-Request-Method: POST'
# HTTP/2 400  "Disallowed CORS origin"
\`\`\`

## Changes

**`backend/src/requirements_graphrag_api/api.py`** — 5 added lines:
- Read \`CORS_ORIGIN_REGEX\` from env (default \`None\`)
- Pass to \`CORSMiddleware\` as \`allow_origin_regex=\`

**\`backend/tests/test_middleware/test_cors.py\`** — 6 new tests:
- Exact-list origin accepted
- Vercel branch-alias URL matched by regex
- Vercel deployment-id URL matched by regex
- Unknown origin rejected
- Off-org Vercel URL rejected
- Regex=None (env unset) falls back to exact-list-only

## Safety

| Concern | Mitigation |
|---|---|
| Production breakage | Existing \`CORS_ORIGINS\` list is untouched. \`graphrag.norfolkaibi.com\` stays in the exact-match path. |
| Default-behavior drift | When \`CORS_ORIGIN_REGEX\` env var is unset, \`allow_origin_regex=None\` → middleware behaves identically to today. |
| Overly permissive regex | The regex pattern is org-scoped (\`norfolk-ai-bi\`) — Vercel projects in other orgs can't accidentally inherit. Test \`test_different_org_vercel_url_rejected\` enforces this. |
| Dev environment | Default \`CORS_ORIGINS\` fallback (\`localhost:3000\`, \`localhost:5173\`) is unchanged. |

## Verification

Local test run:
\`\`\`
$ uv run pytest --tb=short
846 passed in 14.08s
\`\`\`

After merge → Railway redeploy → set \`CORS_ORIGIN_REGEX\` env var on Railway:
\`\`\`
^https://frontend-[a-zA-Z0-9-]+-norfolk-ai-bi\\.vercel\\.app$
\`\`\`

→ Verify preflight from a preview origin returns 200 with \`access-control-allow-origin\` echo:
\`\`\`bash
curl -i -X OPTIONS https://api-production-f1cf.up.railway.app/chat \\
  -H 'Origin: https://frontend-git-fix-cors-preview-regex-norfolk-ai-bi.vercel.app' \\
  -H 'Access-Control-Request-Method: POST'
# Expect: HTTP/2 200, access-control-allow-origin echoed
\`\`\`

→ Then PR #340 preview chat requests should succeed end-to-end (sidebar persistence + chat round-trip).

## References

- Closes #341
- Unblocks end-to-end verification of #339 (PR #340) and all future preview PRs across the UX implementation plan (#338).