### PR TITLE
feat(ux): Phase 3 — concept + table polish

### DIFF
--- a/frontend/src/components/metadata/ResultsTable.jsx
+++ b/frontend/src/components/metadata/ResultsTable.jsx
@@ -1,4 +1,48 @@
+import { useState } from 'react'
+
 const MAX_ROWS = 50
+const ARRAY_PREVIEW_COUNT = 2
+
+/**
+ * Inline expandable array cell: shows the first N items + "+M more" toggle.
+ * Mirrors the overflow pattern in EntityBadges.jsx so the affordance reads the same across the UI.
+ */
+function ArrayCell({ items }) {
+  const [expanded, setExpanded] = useState(false)
+
+  if (items.length <= ARRAY_PREVIEW_COUNT) {
+    return items.join(', ')
+  }
+
+  if (expanded) {
+    return (
+      <>
+        {items.join(', ')}
+        <button
+          type="button"
+          onClick={() => setExpanded(false)}
+          className="ml-2 inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-ivory-medium text-charcoal-muted hover:bg-ivory transition-colors"
+        >
+          Show less
+        </button>
+      </>
+    )
+  }
+
+  const hiddenCount = items.length - ARRAY_PREVIEW_COUNT
+  return (
+    <>
+      {items.slice(0, ARRAY_PREVIEW_COUNT).join(', ')}
+      <button
+        type="button"
+        onClick={() => setExpanded(true)}
+        className="ml-2 inline-flex items-center px-2.5 py-1 rounded-md text-xs font-medium bg-ivory-medium text-charcoal-muted hover:bg-ivory transition-colors"
+      >
+        +{hiddenCount} more
+      </button>
+    </>
+  )
+}
 
 /**
  * Format a cell value for display
@@ -8,7 +52,7 @@ function formatCellValue(value) {
     return <span className="text-charcoal-muted italic">null</span>
   }
   if (Array.isArray(value)) {
-    return value.join(', ')
+    return <ArrayCell items={value} />
   }
   if (typeof value === 'object') {
     return JSON.stringify(value)


### PR DESCRIPTION
Closes #345. Part of #338 (Phase 3 of the phased UX implementation).

## What changed

`frontend/src/components/metadata/ResultsTable.jsx` — array-valued cells (e.g., `source_articles` from the webinar Cypher query) now show the first 2 items inline with a clickable `+N more` toggle that expands to the full list, and a `Show less` toggle to collapse. The expand button uses the same Tailwind classes as the overflow button in `EntityBadges.jsx` so the affordance reads the same across the UI. No new dependencies, no new CSS.

## Verification: most of Phase 3 was already done

Phase 3 led with code-level verification per the local plan's "Verify before rebuild" guidance. Two of the three review items needed no code change:

**Issue 2 — ConceptBadge interactivity** (`EntityBadges.jsx`):
- Hover tooltip via `onMouseEnter`/`onMouseLeave` (lines 160–161) ✅
- Tap-to-toggle via `onClick` (line 162) ✅
- `cursor-help` styling (line 159) ✅
- `title` HTML attribute (line 164) ✅
- `?` marker (line 168) is **inside the interactive button**, gated by `entity.definition` truthiness at line 143. Badges without a `definition` fall through to a plain `<span>` (lines 145–151) with no `?`, no hover, no click — eliminating the "false affordance" the review described.
- **No code change.** The remaining gap is data-side (more concept nodes need `definition` populated), explicitly out of Phase 3 scope.

**Issue 3 — Cypher results table layout** (`ResultsTable.jsx`):
- URLs render as `<a target="_blank" rel="noopener noreferrer">` with `truncate block max-w-xs` and `title=` for full URL on hover (lines 20–31) ✅
- Container has `overflow-x-auto` for horizontal scroll (line 70) ✅
- Cells have `whitespace-nowrap` so columns can extend horizontally (line 90) ✅
- Arrays previously rendered via raw `value.join(', ')` (line 11) → **fixed in this PR**.

## Smoke-test (to run on Vercel preview)

- [ ] "What is requirements traceability?" → hover each concept badge → tooltip appears for badges with definitions; badges without a definition show no `?` marker and no hover affordance.
- [ ] "List all webinars about traceability" → table renders → `WEBINAR_URL` opens in new tab on click; horizontal scroll reaches all columns; `source_articles` shows first 2 + `+N more`; clicking `+N more` expands to full list; `Show less` collapses back.

## Out of scope (deferred)

- Issue 3 data quality (thumbnail-slug nodes leaking into webinar results) — Cypher/ingestion concern, not frontend
- Issue 6 (response dedup) — backend prompt tuning
- Issue 7 (thumbnail fallback) — separate fix

## Verification commands run locally

```
./node_modules/.bin/eslint src/components/metadata/ResultsTable.jsx   # clean
./node_modules/.bin/vite build                                         # 503 modules, exit 0
```

## Notes

- No frontend tests added (project has no Vitest setup; manual + Vercel preview is the test posture).
- Railway will return "No deployment needed — watched paths not modified" (frontend-only PR, path filter on `backend/**`). Expected, not a failure.
- Type Check (Advisory) may show failures — `continue-on-error: true` per project convention. Mergeable per branch ruleset.