### PR TITLE
fix(api): Phase 4 — LangSmith user-text feedback capture

### DIFF
--- a/backend/src/requirements_graphrag_api/routes/feedback.py
+++ b/backend/src/requirements_graphrag_api/routes/feedback.py
@@ -186,37 +186,29 @@ async def submit_feedback(
             body.category if body.category else ("positive" if body.score >= 0.5 else "negative")
         )
 
-        # Build comment string with all metadata for human review
-        comment_parts: list[str] = []
-        if safe_comment:
-            comment_parts.append(safe_comment)
+        # System metadata goes in `extra` so it's queryable separately from the user's comment.
+        # `comment` is the user's free-text feedback only (PII-redacted) — clean, scannable in
+        # the LangSmith UI, and matchable in analytics queries without metadata bleed.
+        extra_metadata: dict[str, str] = {}
         if body.category:
-            comment_parts.append(f"Category: {body.category}")
-        if safe_correction:
-            comment_parts.append(f"Correction: {safe_correction}")
+            extra_metadata["category"] = body.category
         if body.message_id:
-            comment_parts.append(f"Message ID: {body.message_id}")
+            extra_metadata["message_id"] = body.message_id
         if body.conversation_id:
-            comment_parts.append(f"Conversation ID: {body.conversation_id}")
+            extra_metadata["conversation_id"] = body.conversation_id
         if body.intent:
-            comment_parts.append(f"Intent: {body.intent}")
+            extra_metadata["intent"] = body.intent
         if body.trace_id:
-            comment_parts.append(f"Trace ID: {body.trace_id}")
+            extra_metadata["trace_id"] = body.trace_id
 
-        comment = " | ".join(comment_parts) if comment_parts else None
-
-        # Create feedback in LangSmith
-        # - score: numeric value (0.0-1.0) for quantitative metrics
-        # - value: simple string for categorical filtering in charts
-        # - comment: detailed metadata for human review
-        # - correction: structured correction dict (if provided)
         feedback = client.create_feedback(
             run_id=body.run_id,
             key="user-feedback",
             score=body.score,
-            comment=comment,
+            comment=safe_comment,
             value=feedback_value,
             correction={"text": safe_correction} if safe_correction else None,
+            extra=extra_metadata if extra_metadata else None,
         )
 
         feedback_id = str(feedback.id) if feedback else None
@@ -237,13 +229,16 @@ async def submit_feedback(
                         exc_info=True,
                     )
 
-        # Log for monitoring
-        feedback_type = "positive" if body.score >= 0.5 else "negative"
         logger.info(
-            "User feedback submitted: run_id=%s, type=%s, category=%s",
+            "feedback submitted run_id=%s score=%s "
+            "comment_present=%s has_correction=%s "
+            "category=%s intent=%s",
             body.run_id,
-            feedback_type,
+            body.score,
+            bool(safe_comment),
+            bool(safe_correction),
             body.category,
+            body.intent,
         )
 
         # Route negative feedback to intent-specific annotation queues

--- a/backend/tests/test_routes/test_feedback.py
+++ b/backend/tests/test_routes/test_feedback.py
@@ -370,3 +370,142 @@ class TestRubricScores:
         # Endpoint still succeeds despite rubric failure
         assert response.status_code == 200
         assert response.json()["status"] == "received"
+
+
+# =========================================================================
+# E. Comment / Extra Separation (Phase 4 — LangSmith feedback capture fix)
+# =========================================================================
+
+
+class TestCommentAndExtra:
+    """User free-text comment is passed AS-IS; system metadata lives in `extra`."""
+
+    def test_user_comment_passes_through_unchanged(
+        self, client: TestClient, mock_langsmith_client: MagicMock
+    ) -> None:
+        """The user's comment text reaches LangSmith's `comment` kwarg unchanged."""
+        user_text = "Sources panel disagreed with the citation list in the response."
+        response = client.post(
+            "/feedback",
+            json={"run_id": "run-1", "score": 0.0, "comment": user_text},
+        )
+
+        assert response.status_code == 200
+        call = mock_langsmith_client.create_feedback.call_args
+        assert call.kwargs["comment"] == user_text
+        # No metadata bleed
+        assert "|" not in (call.kwargs["comment"] or "")
+        assert "Category:" not in (call.kwargs["comment"] or "")
+        assert "Intent:" not in (call.kwargs["comment"] or "")
+
+    def test_metadata_goes_to_extra_not_comment(
+        self, client: TestClient, mock_langsmith_client: MagicMock
+    ) -> None:
+        """category/intent/message_id/conversation_id/trace_id land in `extra`, not `comment`."""
+        response = client.post(
+            "/feedback",
+            json={
+                "run_id": "run-1",
+                "score": 0.0,
+                "comment": "Free text only",
+                "category": "incorrect",
+                "intent": "explanatory",
+                "message_id": "msg-abc",
+                "conversation_id": "conv-xyz",
+                "trace_id": "trace-123",
+            },
+        )
+
+        assert response.status_code == 200
+        call = mock_langsmith_client.create_feedback.call_args
+        assert call.kwargs["comment"] == "Free text only"
+        assert call.kwargs["extra"] == {
+            "category": "incorrect",
+            "intent": "explanatory",
+            "message_id": "msg-abc",
+            "conversation_id": "conv-xyz",
+            "trace_id": "trace-123",
+        }
+
+    def test_empty_comment_with_metadata_yields_none_comment(
+        self, client: TestClient, mock_langsmith_client: MagicMock
+    ) -> None:
+        """No user text + metadata → `comment=None`, metadata still flows via `extra`."""
+        response = client.post(
+            "/feedback",
+            json={
+                "run_id": "run-1",
+                "score": 0.0,
+                "category": "incorrect",
+                "intent": "structured",
+            },
+        )
+
+        assert response.status_code == 200
+        call = mock_langsmith_client.create_feedback.call_args
+        assert call.kwargs["comment"] is None
+        assert call.kwargs["extra"] == {"category": "incorrect", "intent": "structured"}
+
+    def test_no_metadata_no_extra(
+        self, client: TestClient, mock_langsmith_client: MagicMock
+    ) -> None:
+        """Comment-only submission produces `extra=None` (not an empty dict)."""
+        response = client.post(
+            "/feedback",
+            json={"run_id": "run-1", "score": 1.0, "comment": "Great response"},
+        )
+
+        assert response.status_code == 200
+        call = mock_langsmith_client.create_feedback.call_args
+        assert call.kwargs["comment"] == "Great response"
+        assert call.kwargs["extra"] is None
+
+    def test_correction_remains_structured(
+        self, client: TestClient, mock_langsmith_client: MagicMock
+    ) -> None:
+        """Correction text stays in the structured `correction` kwarg, not folded into comment."""
+        response = client.post(
+            "/feedback",
+            json={
+                "run_id": "run-1",
+                "score": 0.0,
+                "comment": "Wrong answer",
+                "correction": "The correct answer is X",
+            },
+        )
+
+        assert response.status_code == 200
+        call = mock_langsmith_client.create_feedback.call_args
+        assert call.kwargs["comment"] == "Wrong answer"
+        assert call.kwargs["correction"] == {"text": "The correct answer is X"}
+        # Correction must NOT leak into comment
+        assert "The correct answer is X" not in call.kwargs["comment"]
+
+    def test_pii_redacted_comment_is_what_reaches_langsmith(
+        self, mock_app: FastAPI, mock_langsmith_client: MagicMock
+    ) -> None:
+        """When PII is detected, the anonymized text (not the raw comment) is sent to LangSmith."""
+        raw_comment = "Email me at user@example.com about this."
+        redacted_comment = "Email me at <EMAIL> about this."
+
+        with (
+            patch.dict("os.environ", {"LANGSMITH_API_KEY": "test-key"}),
+            patch("requirements_graphrag_api.routes.feedback.detect_and_redact_pii") as mock_pii,
+            patch("langsmith.Client", return_value=mock_langsmith_client),
+        ):
+            pii_result = MagicMock()
+            pii_result.contains_pii = True
+            pii_result.anonymized_text = redacted_comment
+            pii_result.entity_count = 1
+            mock_pii.return_value = pii_result
+
+            test_client = TestClient(mock_app)
+            response = test_client.post(
+                "/feedback",
+                json={"run_id": "run-1", "score": 0.0, "comment": raw_comment},
+            )
+
+        assert response.status_code == 200
+        call = mock_langsmith_client.create_feedback.call_args
+        assert call.kwargs["comment"] == redacted_comment
+        assert raw_comment not in (call.kwargs["comment"] or "")


### PR DESCRIPTION
Closes #347. Final phase of #338 (Phase 4 of the phased UX implementation).

## Problem (production-confirmed)

`POST /feedback` was concatenating the user's free-text feedback with system metadata using ` | ` as a separator, sending the composite string in LangSmith's `comment` field:

```
"my comment text | Category: negative | Message ID: msg-… | Intent: explanatory | Trace ID: …"
```

Pulled 3 recent production `user-feedback` records before opening this PR — **all 3 are affected**. Examples (verbatim from `langsmith.Client.list_feedback`):

> "There's a clear disconnect between the default four Sources included in the LLM's response and the contents of the \"Sources\" expandable section. An Issue should be created in the requirements-graphrag-api repo to address this specific issue. | Category: negative | Message ID: msg-1779468530351-koi9lh0 | Intent: explanatory | Trace ID: ff5f00ab503336b45dcbcac462d5a972"

> "Duplicate webinar record returned for \"Write Better Requirements\" The URLs returned for each record indicate a different link to the same webinar video... | Category: negative | Message ID: msg-1779465879948-a6kdsqt | Intent: structured | Trace ID: 3c2…"

The user's text is technically present but buried; substring searches on `comment` produce false positives from metadata tokens; the dashboard treats the entire string as one opaque blob.

The `extra` field — which is the correct place for system metadata — was unused, carrying only `{"error": false}`.

## Fix

`backend/src/requirements_graphrag_api/routes/feedback.py:189-220` — drop the `comment_parts: list[str]` builder. New behavior:

- **`comment`**: PII-redacted user text only (or `None` if no text was submitted). Clean, scannable, queryable.
- **`extra`**: `dict[str, str]` carrying `category`, `intent`, `message_id`, `conversation_id`, `trace_id` (whichever are set). `None` when no metadata.
- **`correction`**: unchanged — already correctly passed via `correction={"text": safe_correction}` since the route was first written. The bug was specific to `comment`.

Log line restructured to emit a structured, PII-safe record per submission: `run_id`, `score`, `comment_present` (bool, not content), `has_correction` (bool), `category`, `intent`. Operators can verify in Railway logs that comments are flowing without exposure to PII.

## Verification

**Signature check (installed langsmith)**:
```python
>>> inspect.signature(Client.create_feedback).parameters.keys()
['self', 'run_id', 'key', 'score', 'value', 'trace_id', 'correction', 'comment',
 'source_info', 'feedback_source_type', 'source_run_id', 'feedback_id',
 'feedback_config', 'stop_after_attempt', 'project_id', 'comparative_experiment_id',
 'feedback_group_id', 'extra', 'error', 'session_id', 'start_time', 'kwargs']
```
`extra` is supported, accepts a dict.

**Tests added** (`TestCommentAndExtra` class, 6 new tests):
- `test_user_comment_passes_through_unchanged` — exact-match assertion + no `|`/`Category:`/`Intent:` substring
- `test_metadata_goes_to_extra_not_comment` — comment is user text only; `extra` carries the full metadata dict
- `test_empty_comment_with_metadata_yields_none_comment` — `comment=None`, `extra` populated
- `test_no_metadata_no_extra` — pure comment, `extra=None`
- `test_correction_remains_structured` — correction stays in `correction={"text": ...}` kwarg, not folded into comment
- `test_pii_redacted_comment_is_what_reaches_langsmith` — anonymized text (not raw) reaches the client when PII detected

**Counts**: 846 → 852 passing. All existing tests untouched.

**Local verification**:
```
uv run ruff check src/requirements_graphrag_api/routes/feedback.py tests/test_routes/test_feedback.py  # clean
uv run ruff format --check ...                                                                          # clean
uv run pytest --tb=short                                                                                # 852 passed
```

## Production smoke-test (post-merge)

Submit a feedback record with star rating + free text from the UI, then:

```python
from langsmith import Client
c = Client()
[fb for fb in c.list_feedback(feedback_key=["user-feedback"], limit=1)]
```

Expected: `comment` is the user's text only (no ` | Category: …` suffix); `extra` carries `{"category": ..., "intent": ..., "message_id": ..., "trace_id": ...}`.

## Out of scope

- Backfilling prior composite-comment records — historical data is left as-is; the fix is forward-only.
- Other LangSmith integration concerns (run metadata, tracing) — separate scope.

## Notes

- This was the final phase of the #338 UX implementation plan (Phases 1–4 complete).
- Type Check (Advisory) is `continue-on-error: true` per project convention — UNSTABLE merge state with only that failing IS mergeable per branch ruleset.