### PR TITLE
fix(api): route feedback metadata via source_info, not extra

### DIFF
--- a/backend/src/requirements_graphrag_api/routes/feedback.py
+++ b/backend/src/requirements_graphrag_api/routes/feedback.py
@@ -186,20 +186,21 @@ async def submit_feedback(
             body.category if body.category else ("positive" if body.score >= 0.5 else "negative")
         )
 
-        # System metadata goes in `extra` so it's queryable separately from the user's comment.
-        # `comment` is the user's free-text feedback only (PII-redacted) — clean, scannable in
-        # the LangSmith UI, and matchable in analytics queries without metadata bleed.
-        extra_metadata: dict[str, str] = {}
+        # System metadata goes in `feedback_source.metadata` via the `source_info` kwarg,
+        # not `extra` — LangSmith silently drops `extra` on `create_feedback` (every stored
+        # record shows `extra: {"error": false}` regardless of what's passed). `source_info`
+        # lands the dict on `feedback_source.metadata`, which IS persisted and queryable.
+        source_metadata: dict[str, str] = {}
         if body.category:
-            extra_metadata["category"] = body.category
+            source_metadata["category"] = body.category
         if body.message_id:
-            extra_metadata["message_id"] = body.message_id
+            source_metadata["message_id"] = body.message_id
         if body.conversation_id:
-            extra_metadata["conversation_id"] = body.conversation_id
+            source_metadata["conversation_id"] = body.conversation_id
         if body.intent:
-            extra_metadata["intent"] = body.intent
+            source_metadata["intent"] = body.intent
         if body.trace_id:
-            extra_metadata["trace_id"] = body.trace_id
+            source_metadata["trace_id"] = body.trace_id
 
         feedback = client.create_feedback(
             run_id=body.run_id,
@@ -208,7 +209,8 @@ async def submit_feedback(
             comment=safe_comment,
             value=feedback_value,
             correction={"text": safe_correction} if safe_correction else None,
-            extra=extra_metadata if extra_metadata else None,
+            feedback_source_type="api",
+            source_info=source_metadata if source_metadata else None,
         )
 
         feedback_id = str(feedback.id) if feedback else None

--- a/backend/tests/test_routes/test_feedback.py
+++ b/backend/tests/test_routes/test_feedback.py
@@ -373,12 +373,19 @@ class TestRubricScores:
 
 
 # =========================================================================
-# E. Comment / Extra Separation (Phase 4 — LangSmith feedback capture fix)
+# E. Comment / Source-Info Separation (Phase 4 — LangSmith feedback capture)
+#
+# NOTE on test scope: these mocked tests assert what the route passes to
+# `client.create_feedback`. They cannot detect that the LangSmith server
+# silently drops the `extra=` kwarg (it does — confirmed 2026-05-22 via a
+# round-trip probe in production). The metadata must travel via
+# `source_info=` paired with `feedback_source_type="api"`, which lands on
+# `feedback_source.metadata` on the stored Feedback record.
 # =========================================================================
 
 
-class TestCommentAndExtra:
-    """User free-text comment is passed AS-IS; system metadata lives in `extra`."""
+class TestCommentAndSourceInfo:
+    """User free-text comment passes AS-IS; system metadata lives in `source_info`."""
 
     def test_user_comment_passes_through_unchanged(
         self, client: TestClient, mock_langsmith_client: MagicMock
@@ -398,10 +405,10 @@ class TestCommentAndExtra:
         assert "Category:" not in (call.kwargs["comment"] or "")
         assert "Intent:" not in (call.kwargs["comment"] or "")
 
-    def test_metadata_goes_to_extra_not_comment(
+    def test_metadata_goes_to_source_info_not_comment(
         self, client: TestClient, mock_langsmith_client: MagicMock
     ) -> None:
-        """category/intent/message_id/conversation_id/trace_id land in `extra`, not `comment`."""
+        """All system metadata lands in `source_info`, not in `comment`."""
         response = client.post(
             "/feedback",
             json={
@@ -419,7 +426,8 @@ class TestCommentAndExtra:
         assert response.status_code == 200
         call = mock_langsmith_client.create_feedback.call_args
         assert call.kwargs["comment"] == "Free text only"
-        assert call.kwargs["extra"] == {
+        assert call.kwargs["feedback_source_type"] == "api"
+        assert call.kwargs["source_info"] == {
             "category": "incorrect",
             "intent": "explanatory",
             "message_id": "msg-abc",
@@ -430,7 +438,7 @@ class TestCommentAndExtra:
     def test_empty_comment_with_metadata_yields_none_comment(
         self, client: TestClient, mock_langsmith_client: MagicMock
     ) -> None:
-        """No user text + metadata → `comment=None`, metadata still flows via `extra`."""
+        """No user text + metadata → `comment=None`, metadata still flows via `source_info`."""
         response = client.post(
             "/feedback",
             json={
@@ -444,12 +452,12 @@ class TestCommentAndExtra:
         assert response.status_code == 200
         call = mock_langsmith_client.create_feedback.call_args
         assert call.kwargs["comment"] is None
-        assert call.kwargs["extra"] == {"category": "incorrect", "intent": "structured"}
+        assert call.kwargs["source_info"] == {"category": "incorrect", "intent": "structured"}
 
-    def test_no_metadata_no_extra(
+    def test_no_metadata_no_source_info(
         self, client: TestClient, mock_langsmith_client: MagicMock
     ) -> None:
-        """Comment-only submission produces `extra=None` (not an empty dict)."""
+        """Comment-only submission produces `source_info=None` (not an empty dict)."""
         response = client.post(
             "/feedback",
             json={"run_id": "run-1", "score": 1.0, "comment": "Great response"},
@@ -458,7 +466,7 @@ class TestCommentAndExtra:
         assert response.status_code == 200
         call = mock_langsmith_client.create_feedback.call_args
         assert call.kwargs["comment"] == "Great response"
-        assert call.kwargs["extra"] is None
+        assert call.kwargs["source_info"] is None
 
     def test_correction_remains_structured(
         self, client: TestClient, mock_langsmith_client: MagicMock


### PR DESCRIPTION
Closes #349. Follow-up to PR #348.

## Why this is needed

PR #348 (Phase 4) successfully decomposed the LangSmith `comment` field — user free-text is now clean and PII-redacted. But the metadata it routed away from `comment` (`category`, `intent`, `message_id`, `conversation_id`, `trace_id`) was put into `client.create_feedback(extra={...})`, which **LangSmith silently drops server-side**.

Net effect: the most recent production feedback record (`019e50b5-…`, 17:21:56 UTC) has a clean comment but `feedback_source.metadata` is empty — strictly worse for analytics than the pre-fix composite-string version, which at least had the metadata text-searchable in `comment`.

## Evidence (production round-trip)

Two probe records were created against a real run and immediately read back via `client.read_feedback`:

| Channel | What was sent | What was stored |
|---|---|---|
| `extra=` | `{'probe': 'value', 'category': 'negative', 'intent': 'explanatory'}` | `extra={'error': False}` ❌ silently dropped |
| `source_info=` (with `feedback_source_type='api'`) | `{'category': 'negative', 'intent': 'explanatory', 'message_id': 'msg-test-v2'}` | `feedback_source=FeedbackSourceBase(type='api', metadata={'intent': 'explanatory', 'category': 'negative', 'message_id': 'msg-test-v2'})` ✅ persisted |

Both probe records were deleted after the test via `client.delete_feedback`.

## Fix

`feedback.py`:
- Replace `extra=` with `source_info=`
- Add explicit `feedback_source_type="api"` (matches LangSmith default but documents intent)
- Rename local `extra_metadata` → `source_metadata` for accuracy
- Update inline comment to explain the why (server-side drop)

`test_feedback.py`:
- Rename class `TestCommentAndExtra` → `TestCommentAndSourceInfo`
- Retarget 4 assertions from `call.kwargs["extra"]` → `call.kwargs["source_info"]`
- Add an assertion that `feedback_source_type="api"` is passed
- Add a section-comment explaining why mocked unit tests can't catch this class of bug (server silently drops kwargs; only a real round-trip catches it)

## Tests

```
uv run pytest tests/test_routes/test_feedback.py --tb=short  # 20 passed
uv run pytest --tb=short                                      # 852 passed (no count change)
uv run ruff check ...                                         # clean
uv run ruff format --check ...                                # clean
```

No new tests; the 5 existing TestCommentAndSourceInfo tests cover the kwarg structure. Behavior is otherwise unchanged.

## Production smoke-test (post-merge, after Railway redeploys)

```python
from langsmith import Client
fb = next(iter(Client().list_feedback(feedback_key=['user-feedback'], limit=1)))
# Expected:
#   fb.comment         → user's text only (no metadata bleed)
#   fb.feedback_source → FeedbackSourceBase(type='api', metadata={'category': ..., 'intent': ..., ...})
```

## Diagnostic note (separate from the bug)

The UI report that triggered this investigation ("no associated text feedback in the LangSmith traces, thread, or runs") was partially explained by the missing metadata, but the comment text IS reaching LangSmith and IS stored on the correct run (`019e50af-…`, 6 feedback records attached including the `user-feedback` key with the full user comment). The Thread/Turn view's Feedback tab in LangSmith doesn't appear to render free-text comments inline; switching to `runview=traces` or clicking the `user-feedback` aggregate chip should surface them. This is a LangSmith UI behavior, not something this PR addresses.

## References

- Parent tracking: #338
- Phase 4 (introduced this bug): #347 → PR #348 (`868bc3b`)
- Sibling phases: #340 (Phase 1), #344 (Phase 2), #346 (Phase 3)