### PR TITLE
fix(ux): include conversation_id in feedback POST

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -33,7 +33,7 @@ function GitHubIcon() {
 }
 
 function App() {
-  const { messages, isLoading, sendMessage, clearMessages } = useSSEChat()
+  const { messages, isLoading, sendMessage, clearMessages, conversationId } = useSSEChat()
   const [sidebarOpen, setSidebarOpen] = useState(true)
 
   const toggleSidebar = () => setSidebarOpen((prev) => !prev)
@@ -126,7 +126,7 @@ function App() {
             {messages.length === 0 ? (
               <WelcomeScreen onQuickStart={sendMessage} />
             ) : (
-              <MessageList messages={messages} />
+              <MessageList messages={messages} conversationId={conversationId} />
             )}
           </main>
 

--- a/frontend/src/components/chat/AssistantMessage.jsx
+++ b/frontend/src/components/chat/AssistantMessage.jsx
@@ -22,7 +22,7 @@ const LOADING_LABELS = {
  *
  * Handles explanatory (RAG), structured (Cypher), and conversational response types
  */
-export function AssistantMessage({ message }) {
+export function AssistantMessage({ message, conversationId }) {
   const {
     id,
     content,
@@ -134,7 +134,7 @@ export function AssistantMessage({ message }) {
 
       {/* Response actions - show when complete */}
       {status === 'complete' && (
-        <ResponseActions content={content} runId={runId} messageId={id} traceId={traceId} intent={intent} />
+        <ResponseActions content={content} runId={runId} messageId={id} traceId={traceId} intent={intent} conversationId={conversationId} />
       )}
     </div>
   )

--- a/frontend/src/components/chat/MessageList.jsx
+++ b/frontend/src/components/chat/MessageList.jsx
@@ -16,7 +16,7 @@ function UserMessage({ content }) {
 /**
  * Message list component that renders all messages
  */
-export function MessageList({ messages }) {
+export function MessageList({ messages, conversationId }) {
   return (
     <>
       {messages.map((message) => (
@@ -24,7 +24,7 @@ export function MessageList({ messages }) {
           {message.role === 'user' ? (
             <UserMessage content={message.content} />
           ) : (
-            <AssistantMessage message={message} />
+            <AssistantMessage message={message} conversationId={conversationId} />
           )}
         </div>
       ))}

--- a/frontend/src/components/feedback/ResponseActions.jsx
+++ b/frontend/src/components/feedback/ResponseActions.jsx
@@ -33,7 +33,7 @@ function ThumbsDownIcon() {
  * Response action bar with Copy, Thumbs Up, Thumbs Down
  * Styled similar to Claude Desktop
  */
-export function ResponseActions({ content, runId, messageId, traceId, intent }) {
+export function ResponseActions({ content, runId, messageId, traceId, intent, conversationId }) {
   const [copied, setCopied] = useState(false)
   const [feedbackGiven, setFeedbackGiven] = useState(null) // 'positive' | 'negative' | null
   const [feedbackWarning, setFeedbackWarning] = useState(null)
@@ -95,6 +95,7 @@ export function ResponseActions({ content, runId, messageId, traceId, intent }) 
           category: isPositive ? 'positive' : 'negative',
           ...(traceId && { trace_id: traceId }),
           ...(intent && { intent }),
+          ...(conversationId && { conversation_id: conversationId }),
           ...(rubricScores && Object.keys(rubricScores).length > 0 && { rubric_scores: rubricScores }),
         }),
       })

--- a/frontend/src/hooks/useSSEChat.js
+++ b/frontend/src/hooks/useSSEChat.js
@@ -279,5 +279,6 @@ export function useSSEChat() {
     isLoading,
     sendMessage,
     clearMessages,
+    conversationId,
   }
 }


### PR DESCRIPTION
Closes #351.

## What & why

The backend already accepts `body.conversation_id` and routes it into `feedback_source.metadata` (post-#350). The frontend wasn't sending it. Production confirmation (`langsmith.Client.list_feedback`, three most recent records 2026-05-22): `feedback_source.metadata` had `{category, intent, trace_id, message_id}` but no `conversation_id`. Without it, session-level analytics across multiple turns in a single conversation is impossible.

## Implementation

Prop-drill from `useSSEChat` (session state, regenerated by `clearMessages()` on "New chat" click) down to the feedback POST.

| File | Change |
|---|---|
| `useSSEChat.js` | Expose `conversationId` in hook return |
| `App.jsx` | Destructure + pass to `<MessageList>` |
| `MessageList.jsx` | Accept prop, forward to `<AssistantMessage>` |
| `AssistantMessage.jsx` | Accept prop, forward to `<ResponseActions>` |
| `ResponseActions.jsx` | Accept prop, add `conversation_id: conversationId` to POST body via the existing conditional-spread pattern |

Total: 5 files, +9/-7. No backend change (model already accepts the field). No new tests (backend route coverage already exists; this is purely about whether the field reaches the route).

## Verification

```
./node_modules/.bin/eslint <changed files>   # clean (exit 0)
./node_modules/.bin/vite build               # clean (629.06 KB, exit 0)
```

## Post-merge production check (after Railway + Vercel redeploys)

Submit a new feedback record from the UI, then:

```python
from langsmith import Client
fb = next(iter(Client().list_feedback(feedback_key=['user-feedback'], limit=1)))
print(fb.feedback_source.metadata)
# Expected: {'category': ..., 'intent': ..., 'trace_id': ..., 'message_id': ..., 'conversation_id': '<UUID>'}
```

The `conversation_id` should be a UUID v4 string (per `useSSEChat.generateConversationId`) and should change when "New chat" is clicked.

## Notes

- Railway will return "No deployment needed - watched paths not modified" (frontend-only PR). Expected, not a failure.
- Type Check (Advisory) failure is expected per project convention; mergeable per branch ruleset.