### PR TITLE
fix(synthesis): renumber inline [Source N] markers to match citations footer

### DIFF
--- a/backend/src/requirements_graphrag_api/core/agentic/subgraphs/synthesis.py
+++ b/backend/src/requirements_graphrag_api/core/agentic/subgraphs/synthesis.py
@@ -16,6 +16,7 @@ State:
 from __future__ import annotations
 
 import json
+import re
 from typing import TYPE_CHECKING, Any, Literal
 
 import structlog
@@ -274,12 +275,35 @@ Focus on improving completeness and addressing the gaps identified above."""
         """
         draft = state.get("draft_answer", "")
         citations = state.get("citations", [])
+        context = state.get("context", "")
         critique = state.get("critique")
 
         logger.info("Formatting final output")
 
-        # Build final answer with citation footer
-        final = draft
+        # The synthesis LLM embeds [Source N] markers using the *input* numbering
+        # from `context` (typically Sources 1..10), but `citations` is a filtered
+        # subset returned in arbitrary order. Below we renumber inline markers in
+        # `draft` to match the position of each cited title in `citations`, so the
+        # body's references align with the "Sources:" footer rendered below.
+        # Markers whose source isn't in `citations` are dropped (LLM cited an
+        # input source it didn't include in its citations list).
+        ctx_titles = {
+            n: title.strip()
+            for n, title in re.findall(r"\[Source (\d+):\s*([^\]]+)\]", context)
+        }
+        cit_index = {title.strip(): i + 1 for i, title in enumerate(citations)}
+
+        def _remap(match: re.Match[str]) -> str:
+            n = match.group(1)
+            title = ctx_titles.get(n, "")
+            new_idx = cit_index.get(title)
+            return f"[Source {new_idx}]" if new_idx else ""
+
+        final = re.sub(r"\[Source (\d+)\]", _remap, draft)
+        # Collapse whitespace left by any dropped markers (e.g. " ." -> ".").
+        final = re.sub(r"\s+([,.;:])", r"\1", final)
+        final = re.sub(r" {2,}", " ", final).strip()
+
         if citations:
             citation_text = "\n\n**Sources:**\n"
             for i, source in enumerate(citations, 1):

--- a/backend/src/requirements_graphrag_api/core/agentic/subgraphs/synthesis.py
+++ b/backend/src/requirements_graphrag_api/core/agentic/subgraphs/synthesis.py
@@ -288,8 +288,7 @@ Focus on improving completeness and addressing the gaps identified above."""
         # Markers whose source isn't in `citations` are dropped (LLM cited an
         # input source it didn't include in its citations list).
         ctx_titles = {
-            n: title.strip()
-            for n, title in re.findall(r"\[Source (\d+):\s*([^\]]+)\]", context)
+            n: title.strip() for n, title in re.findall(r"\[Source (\d+):\s*([^\]]+)\]", context)
         }
         cit_index = {title.strip(): i + 1 for i, title in enumerate(citations)}
 

--- a/backend/tests/test_core/test_agentic/test_subgraphs.py
+++ b/backend/tests/test_core/test_agentic/test_subgraphs.py
@@ -266,6 +266,112 @@ class TestSynthesisSubgraph:
         )
         assert critique.completeness == "insufficient"
 
+    @pytest.mark.asyncio
+    async def test_format_output_renumbers_inline_markers(self, mock_config: AppConfig):
+        """`[Source N]` markers (input numbering) are renumbered to match the
+        filtered `citations` list (output numbering) so the body and footer
+        agree."""
+        # Draft references input sources 3 and 1; citations list keeps C and A
+        # (in that order), so [Source 3] -> [Source 1] and [Source 1] -> [Source 2].
+        draft_payload = json.dumps(
+            {
+                "answer": "Foo [Source 3] bar [Source 1]",
+                "critique": {
+                    "confidence": 0.9,
+                    "completeness": "complete",
+                    "missing_aspects": [],
+                },
+                "citations": ["C", "A"],
+            }
+        )
+
+        mock_chain = MagicMock()
+        mock_chain.ainvoke = AsyncMock(return_value=create_ai_message_mock(draft_payload))
+        mock_prompt_template = MagicMock()
+        mock_prompt_template.__or__ = MagicMock(return_value=mock_chain)
+        mock_llm = MagicMock()
+
+        with (
+            patch(
+                "requirements_graphrag_api.core.agentic.subgraphs.synthesis.get_prompt",
+                new_callable=AsyncMock,
+                return_value=mock_prompt_template,
+            ),
+            patch(
+                "requirements_graphrag_api.core.agentic.subgraphs.synthesis.ChatOpenAI",
+                return_value=mock_llm,
+            ),
+        ):
+            graph = create_synthesis_subgraph(mock_config)
+            result = await graph.ainvoke(
+                {
+                    "query": "q",
+                    "context": "[Source 1: A]\n[Source 2: B]\n[Source 3: C]",
+                }
+            )
+
+        final = result["final_answer"]
+        # Body uses footer-aligned numbering: C is [Source 1], A is [Source 2].
+        assert "Foo [Source 1] bar [Source 2]" in final
+        # Footer matches.
+        assert "- [1] C" in final
+        assert "- [2] A" in final
+        # No leftover input-numbered marker for the dropped index.
+        assert "[Source 3]" not in final
+
+    @pytest.mark.asyncio
+    async def test_format_output_drops_orphan_markers(self, mock_config: AppConfig):
+        """When the LLM cites an input source it didn't include in `citations`,
+        the inline marker is dropped (rather than dangling against the footer)."""
+        # Body cites Source 2 (B), but citations only includes A and C -> B is
+        # an "orphan" and that inline marker must be removed.
+        draft_payload = json.dumps(
+            {
+                "answer": "Alpha [Source 1] beta [Source 2] gamma [Source 3].",
+                "critique": {
+                    "confidence": 0.9,
+                    "completeness": "complete",
+                    "missing_aspects": [],
+                },
+                "citations": ["A", "C"],
+            }
+        )
+
+        mock_chain = MagicMock()
+        mock_chain.ainvoke = AsyncMock(return_value=create_ai_message_mock(draft_payload))
+        mock_prompt_template = MagicMock()
+        mock_prompt_template.__or__ = MagicMock(return_value=mock_chain)
+        mock_llm = MagicMock()
+
+        with (
+            patch(
+                "requirements_graphrag_api.core.agentic.subgraphs.synthesis.get_prompt",
+                new_callable=AsyncMock,
+                return_value=mock_prompt_template,
+            ),
+            patch(
+                "requirements_graphrag_api.core.agentic.subgraphs.synthesis.ChatOpenAI",
+                return_value=mock_llm,
+            ),
+        ):
+            graph = create_synthesis_subgraph(mock_config)
+            result = await graph.ainvoke(
+                {
+                    "query": "q",
+                    "context": "[Source 1: A]\n[Source 2: B]\n[Source 3: C]",
+                }
+            )
+
+        final = result["final_answer"]
+        # A -> [Source 1] (first in citations), C -> [Source 2] (second).
+        assert "[Source 1]" in final  # for A
+        assert "[Source 2]" in final  # for C
+        # The orphan reference to B (input Source 2) must be gone.
+        # After dropping, the body should have exactly two markers remaining.
+        assert final.count("[Source ") == 2
+        assert "- [1] A" in final
+        assert "- [2] C" in final
+
 
 # =============================================================================
 # STATE TYPE TESTS


### PR DESCRIPTION
Closes #353.

## Origin: LangSmith Issues Agent

This PR carries a substantive bug fix originally authored by the **LangSmith Issues Agent** on branch `issues-agent/ee2be412-a807-476f-a564-0c1864640f19` (commit `1bb8885`, 2026-05-22). The agent appears to have authored this fix in response to production user feedback record `019e50b5-…`:

> "There's a clear disconnect between the default four Sources included in the LLM's response and the contents of the 'Sources' expandable section…"

The agent's commit is preserved as-is in this branch. The only additional change is one format fix-up commit (`f63eb06`) collapsing a two-line dict comprehension onto one line per project ruff format style — required for the Lint & Format Check CI gate. No functional behavior change.

## Bug

`backend/src/requirements_graphrag_api/core/agentic/subgraphs/synthesis.py` — the synthesis LLM embeds `[Source N]` markers using **input** source numbering from `context`, but `citations` is a filtered subset returned in arbitrary order. Result: body's inline `[Source N]` references and the "Sources:" footer disagree.

## Fix

Renumber inline markers in `draft` to match the position of each cited title in `citations`. Drop markers for sources not in `citations`. Collapse whitespace from dropped markers.

```python
ctx_titles = {n: title.strip() for n, title in re.findall(r"\[Source (\d+):\s*([^\]]+)\]", context)}
cit_index = {title.strip(): i + 1 for i, title in enumerate(citations)}

def _remap(match):
    n = match.group(1)
    title = ctx_titles.get(n, "")
    new_idx = cit_index.get(title)
    return f"[Source {new_idx}]" if new_idx else ""

final = re.sub(r"\[Source (\d+)\]", _remap, draft)
final = re.sub(r"\s+([,.;:])", r"\1", final)
final = re.sub(r" {2,}", " ", final).strip()
```

## Tests

Agent added `test_format_output_renumbers_inline_markers` in `tests/test_core/test_agentic/test_subgraphs.py` covering:
- Reorder mapping (input Source 3 → output Source 1, input Source 1 → output Source 2)
- Dropped-marker whitespace cleanup

Local verification:
```
uv run pytest tests/test_core/test_agentic/test_subgraphs.py::TestSynthesisSubgraph -v   # 8 passed
uv run pytest --tb=short                                                                   # 854 passed (was 852)
uv run ruff check src/requirements_graphrag_api/core/agentic/subgraphs/synthesis.py        # clean
uv run ruff format --check src/requirements_graphrag_api/core/agentic/subgraphs/synthesis.py  # clean (after format fix-up)
```

## Co-Authored-By

The substantive logic is the agent's work; format fix-up is mine. Squash-merge commit message will preserve credit.

## Provenance / cleanup

After this PR merges, the original `issues-agent/ee2be412-a807-476f-a564-0c1864640f19` branch will be deleted as obsolete (the fix will be on main).

## References

- Triggering feedback: LangSmith record `019e50b5-428e-76f3-860d-fd66d88324e0` (2026-05-22 16:55 UTC)
- Autonomous agent triage docs: `memory/project_autonomous-agents.md`