### PR TITLE
feat: unify source attribution — accordion numbering + hover excerpts

### DIFF
--- a/backend/src/requirements_graphrag_api/core/agentic/subgraphs/synthesis.py
+++ b/backend/src/requirements_graphrag_api/core/agentic/subgraphs/synthesis.py
@@ -273,18 +273,11 @@ Focus on improving completeness and addressing the gaps identified above."""
         adding citation references and metadata.
         """
         draft = state.get("draft_answer", "")
-        citations = state.get("citations", [])
         critique = state.get("critique")
 
         logger.info("Formatting final output")
 
-        # Build final answer with citation footer
         final = draft
-        if citations:
-            citation_text = "\n\n**Sources:**\n"
-            for i, source in enumerate(citations, 1):
-                citation_text += f"- [{i}] {source}\n"
-            final += citation_text
 
         # Add confidence indicator if low
         if critique and critique.confidence < CONFIDENCE_THRESHOLD:

--- a/backend/tests/test_core/test_agentic/test_subgraphs.py
+++ b/backend/tests/test_core/test_agentic/test_subgraphs.py
@@ -266,6 +266,34 @@ class TestSynthesisSubgraph:
         )
         assert critique.completeness == "insufficient"
 
+    def test_synthesis_module_has_no_sources_footer(self):
+        """Regression guard: synthesis must not emit a '**Sources:**' citation footer.
+
+        Issue #357 / docs/superpowers/specs/2026-05-23-unified-source-attribution-design.md.
+        The accordion at the bottom of the response is the canonical numbered source list;
+        a duplicated markdown footer creates a divergent third numbering scheme (LLM-judged
+        citations) that conflicts with the inline [Source N] markers (retrieval order).
+
+        This is a source-inspection regression rather than a runtime assertion because
+        format_output is a closure inside create_synthesis_subgraph and is not reachable
+        through a stable public API without elaborate LLM mocking through the full graph.
+        Source-inspection is a strictly stronger invariant: if the offending string is
+        absent from the module source, the runtime output cannot produce it.
+        """
+        import inspect
+
+        from requirements_graphrag_api.core.agentic.subgraphs import synthesis
+
+        source = inspect.getsource(synthesis)
+        assert "**Sources:**" not in source, (
+            "synthesis.py must not contain a '**Sources:**' footer marker; "
+            "see docs/superpowers/specs/2026-05-23-unified-source-attribution-design.md"
+        )
+        assert "citation_text" not in source, (
+            "The citation_text variable was part of the now-removed '**Sources:**' "
+            "footer logic; see the spec above for the rationale."
+        )
+
 
 # =============================================================================
 # STATE TYPE TESTS

--- a/docs/superpowers/plans/2026-05-23-unified-source-attribution.md
+++ b/docs/superpowers/plans/2026-05-23-unified-source-attribution.md
@@ -1,0 +1,685 @@
+# Unified Source Attribution Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace three-way source-attribution numbering inconsistency with a single canonical scheme — inline `[Source N]` chips in the body, matched 1:1 by numbered `[N]` chips in the accordion below, with hover tooltips on accordion rows surfacing the retrieved chunk text.
+
+**Architecture:** Three coordinated changes — one backend deletion (~6 lines), two frontend additions (~70 lines) — in a single bundled PR on branch `feat/unified-source-attribution` (already created, with the spec doc already committed). Backend removes the redundant `**Sources:**` markdown footer that synthesis post-processing currently appends. Frontend numbers accordion rows with the same emerald-pill styling already used for inline citation chips, and wraps row titles in the existing shared `<Tooltip>` widget so hovering surfaces a smart-truncated excerpt of the retrieved chunk text. No payload-schema changes; all needed fields already flow through the SSE stream.
+
+**Tech Stack:** Backend — Python 3.13, FastAPI, LangGraph, structlog, pytest (run via `uv`); Frontend — React 19, Vite, Tailwind CSS v4, ReactMarkdown.
+
+**Spec:** `docs/superpowers/specs/2026-05-23-unified-source-attribution-design.md` (read this first for the design rationale, non-goals, error-handling matrix, and HITL gate sequence).
+
+**Tracking issue:** [#357](https://github.com/arthurfantaci/requirements-graphrag-api/issues/357)
+
+**Branch:** `feat/unified-source-attribution` (verify with `git branch --show-current` before starting; the spec doc commits are already on this branch).
+
+---
+
+## Task 1: Backend — Remove the redundant Sources footer (TDD)
+
+**Files:**
+
+- Modify: `backend/src/requirements_graphrag_api/core/agentic/subgraphs/synthesis.py:281-287`
+- Test: `backend/tests/test_core/test_agentic/test_subgraphs.py` (add one test method to `TestSynthesisSubgraph` class, around line 268)
+
+**Why source-inspection over runtime assertion:** the spec's intended runtime assertion (`final_answer` does not contain `**Sources:**`) would require setting up LLM mocking infrastructure that does not currently exist for synthesis tests (only `test_synthesis_no_context` exercises the graph, and it uses the no-context early-exit to avoid the LLM). Source-inspection is a stronger invariant — if the source string is absent, the runtime output cannot produce it — and avoids introducing a new test-infrastructure dependency for a one-shot regression guard.
+
+- [ ] **Step 1: Verify you are on the right branch with the spec already present**
+
+Run:
+
+```bash
+cd /Users/arthurfantaci/Projects/requirements-graphrag-api
+git branch --show-current
+ls docs/superpowers/specs/2026-05-23-unified-source-attribution-design.md
+```
+
+Expected: branch is `feat/unified-source-attribution`; spec file exists. If not on the branch, stop and fix before continuing.
+
+- [ ] **Step 2: Read the existing test patterns for context**
+
+Open `backend/tests/test_core/test_agentic/test_subgraphs.py` and skim the `TestSynthesisSubgraph` class (lines ~188-267). Note that no existing test invokes `format_output` directly or asserts on the `**Sources:**` rendering — we are adding one new test, not modifying any existing test.
+
+- [ ] **Step 3: Write the failing regression test**
+
+Open `backend/tests/test_core/test_agentic/test_subgraphs.py`. Add the following test method as the LAST method inside the `TestSynthesisSubgraph` class (after `test_needs_revision_insufficient_completeness`, before the `# STATE TYPE TESTS` section comment around line 270):
+
+```python
+    def test_synthesis_module_has_no_sources_footer(self):
+        """Regression guard: synthesis must not emit a '**Sources:**' citation footer.
+
+        Issue #357 / docs/superpowers/specs/2026-05-23-unified-source-attribution-design.md.
+        The accordion at the bottom of the response is the canonical numbered source list;
+        a duplicated markdown footer creates a divergent third numbering scheme (LLM-judged
+        citations) that conflicts with the inline [Source N] markers (retrieval order).
+
+        This is a source-inspection regression rather than a runtime assertion because
+        format_output is a closure inside create_synthesis_subgraph and is not reachable
+        through a stable public API without elaborate LLM mocking through the full graph.
+        Source-inspection is a strictly stronger invariant: if the offending string is
+        absent from the module source, the runtime output cannot produce it.
+        """
+        import inspect
+
+        from requirements_graphrag_api.core.agentic.subgraphs import synthesis
+
+        source = inspect.getsource(synthesis)
+        assert "**Sources:**" not in source, (
+            "synthesis.py must not contain a '**Sources:**' footer marker; "
+            "see docs/superpowers/specs/2026-05-23-unified-source-attribution-design.md"
+        )
+        assert "citation_text" not in source, (
+            "The citation_text variable was part of the now-removed '**Sources:**' "
+            "footer logic; see the spec above for the rationale."
+        )
+```
+
+- [ ] **Step 4: Run the new test to verify it FAILS (TDD red)**
+
+Run:
+
+```bash
+cd backend
+uv run pytest tests/test_core/test_agentic/test_subgraphs.py::TestSynthesisSubgraph::test_synthesis_module_has_no_sources_footer -v
+```
+
+Expected: 1 failed. The failure message should be the first assertion (`'**Sources:**' not in source`). This is correct — the footer code is still present at this stage.
+
+If the test PASSES at this point, stop. Something is wrong (either the footer is already removed, or the test imports the wrong module). Investigate before continuing.
+
+- [ ] **Step 5: Delete the footer code in synthesis.py**
+
+Open `backend/src/requirements_graphrag_api/core/agentic/subgraphs/synthesis.py`. Find the `format_output` function (around line 269). The current code at lines 281-287:
+
+```python
+        logger.info("Formatting final output")
+
+        # Build final answer with citation footer
+        final = draft
+        if citations:
+            citation_text = "\n\n**Sources:**\n"
+            for i, source in enumerate(citations, 1):
+                citation_text += f"- [{i}] {source}\n"
+            final += citation_text
+
+        # Add confidence indicator if low
+```
+
+Delete line 281 (the section comment, now misleading) and lines 283-287 (the `if citations:` block and its body). Line 282 (`final = draft`) MUST be retained — it initializes the variable that the confidence-indicator block at lines 290-294 still appends to.
+
+Result after edit (lines 279-289 in the new file):
+
+```python
+        logger.info("Formatting final output")
+
+        final = draft
+
+        # Add confidence indicator if low
+        if critique and critique.confidence < CONFIDENCE_THRESHOLD:
+            final += (
+                "\n\n*Note: This answer is based on limited context. "
+                "Consider asking follow-up questions for more detail.*"
+            )
+```
+
+The `citations = state.get("citations", [])` extraction at line 276 stays unchanged — only the rendering append is removed, so `citations` remains in `SynthesisState` for downstream consumers (e.g., LangSmith telemetry).
+
+- [ ] **Step 6: Run the new test to verify it PASSES (TDD green)**
+
+Run:
+
+```bash
+cd backend
+uv run pytest tests/test_core/test_agentic/test_subgraphs.py::TestSynthesisSubgraph::test_synthesis_module_has_no_sources_footer -v
+```
+
+Expected: 1 passed.
+
+- [ ] **Step 7: Run the full backend suite to confirm no regressions**
+
+Run:
+
+```bash
+cd backend
+uv run pytest --tb=short
+```
+
+Expected: 853 passed (was 852; one net new test added). If any pre-existing tests fail, the deletion broke something — most likely a test in `test_orchestrator.py` or `test_integration.py` that asserts on a substring of `final_answer`. Investigate and either fix the test (if its assertion was checking the footer pattern) or revert and reassess.
+
+- [ ] **Step 8: Run lint and format checks**
+
+Run:
+
+```bash
+cd backend
+uv run ruff check .
+uv run ruff format --check .
+```
+
+Expected: both pass (no output, exit 0). If ruff format flags changes, run `uv run ruff format .` and re-stage.
+
+- [ ] **Step 9: Commit**
+
+Run:
+
+```bash
+cd /Users/arthurfantaci/Projects/requirements-graphrag-api
+git add backend/src/requirements_graphrag_api/core/agentic/subgraphs/synthesis.py \
+        backend/tests/test_core/test_agentic/test_subgraphs.py
+git commit -m "$(cat <<'EOF'
+refactor(synthesis): remove redundant Sources footer from final answer
+
+The format_output node was appending a markdown '**Sources:**' footer
+to every explanatory answer, built from the LLM-judged `citations` field.
+This created a third numbering scheme (LLM-judged) that conflicted with
+the inline [Source N] markers (retrieval-order) and the unnumbered
+accordion (retrieval-order). The accordion is the canonical source list;
+the footer was redundant and divergently numbered.
+
+The `citations` field is retained in SynthesisState since downstream
+consumers (LangSmith telemetry) may read it; only the rendering append
+is removed.
+
+Adds a source-inspection regression test to prevent the footer pattern
+from being reintroduced.
+
+Refs: #357
+See docs/superpowers/specs/2026-05-23-unified-source-attribution-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: pre-commit hooks pass; commit lands on `feat/unified-source-attribution`. If ruff format hook re-formats files, follow the project convention — re-stage the formatted files and re-commit.
+
+---
+
+## Task 2: Frontend — Number accordion rows with citation-style chips
+
+**Files:**
+
+- Modify: `frontend/src/components/metadata/SourcesPanel.jsx` (modify `SourceItem` signature + render structure; modify `SourcesPanel` map call)
+
+No tests — frontend has no test framework per project posture. Verification is local dev-server inspection at this stage; full Vercel Preview HITL comes in Task 4.
+
+- [ ] **Step 1: Modify `SourceItem` to accept `sourceNumber` and render the chip**
+
+Open `frontend/src/components/metadata/SourcesPanel.jsx`. Find the `SourceItem` function (lines 76-98). Replace the entire function with:
+
+```jsx
+function SourceItem({ source, sourceNumber }) {
+  const { title, url, relevance_score } = source
+
+  return (
+    <div className="flex items-start justify-between gap-2 py-2 border-b border-black/5 last:border-b-0">
+      <div className="flex-1 min-w-0 flex items-start gap-2">
+        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-emerald-50 text-emerald-700 border border-emerald-200 flex-shrink-0 mt-0.5">
+          {sourceNumber}
+        </span>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm text-charcoal-light truncate">{title || 'Untitled Source'}</p>
+          <RelevanceBar score={relevance_score} />
+        </div>
+      </div>
+      {url && (
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex-shrink-0 p-1 text-charcoal-muted hover:text-emerald-600 transition-colors"
+          title="Open source"
+        >
+          <LinkIcon />
+        </a>
+      )}
+    </div>
+  )
+}
+```
+
+What changed:
+
+- Function now accepts a `sourceNumber` prop.
+- The `<div className="flex-1 min-w-0">` that previously held title + relevance bar is now nested inside a new `<div className="flex-1 min-w-0 flex items-start gap-2">` that hosts the chip + the title/relevance block.
+- New `<span>` chip is added BEFORE the title/relevance block; its class string matches `SourceCitationRenderer.jsx:30` exactly except for: `mr-2` is omitted (parent gap handles spacing via `gap-2`); `flex-shrink-0` is added so the chip never compresses when the title is long; `mt-0.5` is added so the chip vertically aligns with the title text baseline.
+- Inner title/relevance block is unchanged.
+- External-link icon block is unchanged.
+
+- [ ] **Step 2: Update the map call in `SourcesPanel` to pass `sourceNumber`**
+
+In the same file, find lines 133-137 (inside the `SourcesPanel` function's expandable content block). Change:
+
+```jsx
+          {sources.map((source, index) => (
+            <SourceItem key={`source-${index}`} source={source} />
+          ))}
+```
+
+To:
+
+```jsx
+          {sources.map((source, index) => (
+            <SourceItem key={`source-${index}`} source={source} sourceNumber={index + 1} />
+          ))}
+```
+
+- [ ] **Step 3: Run the dev server and verify chips render**
+
+Run:
+
+```bash
+cd frontend
+npm run dev
+```
+
+Expected: server starts on the configured local port (typically 5173). Open the browser. Submit any explanatory query that returns multiple sources (e.g., "What is requirements traceability?"). Wait for the response.
+
+Verify:
+
+- The Sources accordion header still shows `Sources (N)` with the correct count.
+- Clicking the header expands the accordion.
+- Each row now has an emerald `[N]` chip prefix (1, 2, 3, …) styled identically to the inline `[Source N]` chips in the response body — same emerald background, same border, same text color.
+- Hovering an inline `[Source N]` chip in the body and visually scanning to the matching accordion row N — they should clearly be the same source (same title).
+- External-link icon on each row still works (opens source URL in new tab).
+- Relevance bar still renders correctly below each title.
+
+If any of these fail, stop and debug before committing. Common causes: missing `sourceNumber` prop (chip will show "undefined"), broken flex layout (chip and title misaligned), or the class string typo.
+
+Stop the dev server with Ctrl-C when verification is complete.
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+```bash
+cd /Users/arthurfantaci/Projects/requirements-graphrag-api
+git add frontend/src/components/metadata/SourcesPanel.jsx
+git commit -m "$(cat <<'EOF'
+feat(ui): number Sources accordion rows with citation-style chips
+
+Prefix each accordion row with an emerald [N] chip matching the
+inline [Source N] citation chip styling (same Tailwind class string
+as SourceCitationRenderer.jsx:30, minus the inline-context margins).
+
+Row N now visibly corresponds 1:1 to inline citation N — the
+alignment was already correct in the data layer (both derive from
+the same retrieval-order sources[] array in core/context.py), but
+was invisible to users until the rows were numbered.
+
+Refs: #357
+See docs/superpowers/specs/2026-05-23-unified-source-attribution-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+Expected: commit lands on `feat/unified-source-attribution`. No pre-commit hooks should fire for `.jsx` files (the project's hooks are Python-focused).
+
+---
+
+## Task 3: Frontend — Add chunk-excerpt tooltip on row title hover
+
+**Files:**
+
+- Modify: `frontend/src/components/metadata/SourcesPanel.jsx` (add module-top constants + `buildExcerpt` helper; wrap title `<p>` in `<Tooltip>`)
+
+No tests — same posture as Task 2.
+
+- [ ] **Step 1: Add the truncation helper at the top of `SourcesPanel.jsx`**
+
+Open `frontend/src/components/metadata/SourcesPanel.jsx`. Find the import block at the top (lines 1-2):
+
+```jsx
+import { useState } from 'react'
+import { Tooltip } from '../ui/Tooltip'
+```
+
+Immediately AFTER the imports (with one blank line between the last import and the new code), add:
+
+```jsx
+
+const EXCERPT_MAX_CHARS = 280
+const BOUNDARY_FLOOR = 100
+
+function buildExcerpt(content) {
+  if (!content) return null
+  const normalized = content.trim().replace(/\s+/g, ' ')
+  if (!normalized) return null
+  if (normalized.length <= EXCERPT_MAX_CHARS) return normalized
+
+  const window = normalized.slice(0, EXCERPT_MAX_CHARS)
+
+  // Prefer the last sentence boundary within the window
+  const sentenceMatches = [...window.matchAll(/[.?!]\s/g)]
+  const lastSentence = sentenceMatches[sentenceMatches.length - 1]
+  if (lastSentence && lastSentence.index >= BOUNDARY_FLOOR) {
+    return normalized.slice(0, lastSentence.index + 1) + ' …'
+  }
+
+  // Fall back to the last word boundary
+  const wordBoundary = window.lastIndexOf(' ')
+  if (wordBoundary >= BOUNDARY_FLOOR) {
+    return normalized.slice(0, wordBoundary) + ' …'
+  }
+
+  // Pathological: no whitespace in first 280 chars — hard cut
+  return window + '…'
+}
+```
+
+The `…` characters MUST be the single Unicode codepoint U+2026 (`…`), NOT three ASCII periods.
+
+- [ ] **Step 2: Wrap the title `<p>` in `<Tooltip>` and destructure `content` from source**
+
+Find the `SourceItem` function (now starting around line 27 after Task 2's changes, but verify by searching for `function SourceItem`). Replace the whole function with:
+
+```jsx
+function SourceItem({ source, sourceNumber }) {
+  const { title, url, content, relevance_score } = source
+  const excerpt = buildExcerpt(content)
+
+  return (
+    <div className="flex items-start justify-between gap-2 py-2 border-b border-black/5 last:border-b-0">
+      <div className="flex-1 min-w-0 flex items-start gap-2">
+        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-emerald-50 text-emerald-700 border border-emerald-200 flex-shrink-0 mt-0.5">
+          {sourceNumber}
+        </span>
+        <div className="flex-1 min-w-0">
+          <Tooltip
+            title={title || `Source ${sourceNumber}`}
+            description={excerpt || 'No excerpt available.'}
+            color="emerald"
+            position="top"
+          >
+            <p className="text-sm text-charcoal-light truncate">
+              {title || 'Untitled Source'}
+            </p>
+          </Tooltip>
+          <RelevanceBar score={relevance_score} />
+        </div>
+      </div>
+      {url && (
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex-shrink-0 p-1 text-charcoal-muted hover:text-emerald-600 transition-colors"
+          title="Open source"
+        >
+          <LinkIcon />
+        </a>
+      )}
+    </div>
+  )
+}
+```
+
+What changed from Task 2's version:
+
+- Destructure now includes `content` (previously omitted; backend already returns it).
+- Compute `excerpt = buildExcerpt(content)` at the top of the function body.
+- Wrap the title `<p>` in `<Tooltip>` with `title`, `description`, `color="emerald"`, and `position="top"` props. The `Tooltip` import is already present from Task 2 / the original file.
+- Everything else is identical to Task 2's version.
+
+- [ ] **Step 3: Run the dev server and verify tooltips render**
+
+Run:
+
+```bash
+cd frontend
+npm run dev
+```
+
+Submit an explanatory query that returns multiple sources. Expand the accordion. Verify:
+
+- Hover the title text of row 1. A dark tooltip appears with the source title (bold) and a body paragraph showing the chunk text excerpt.
+- The excerpt is readable (clean text, no awkward gaps from preserved newlines).
+- If the row's `source.content` is more than ~280 characters, the excerpt ends with `…` and the cut is at a clean sentence or word boundary.
+- If the row's `source.content` is shorter than ~280 characters, the full text shows with no ellipsis.
+- Mouse off; the tooltip disappears.
+- Hover another row — same behavior, different content.
+- The chip prefix from Task 2 is unaffected; the external-link icon still works.
+
+Edge cases to spot-check:
+
+- Hover a row near the bottom of the viewport — the tooltip should flip to render below the row if there's not enough space above.
+- Hover a row near the very top of the viewport — tooltip should render below the row (existing widget flip logic).
+- On a mobile-width browser (resize to ~400px), the tooltip should remain within the viewport bounds, not overflow horizontally.
+
+If you cannot find a row whose `content` is empty (which would trigger the "No excerpt available." fallback), this is fine to leave unverified at the dev-server stage — the fallback is exercised by the code path regardless and will be verified during Vercel Preview HITL.
+
+Stop the dev server with Ctrl-C when verification is complete.
+
+- [ ] **Step 4: Commit**
+
+Run:
+
+```bash
+cd /Users/arthurfantaci/Projects/requirements-graphrag-api
+git add frontend/src/components/metadata/SourcesPanel.jsx
+git commit -m "$(cat <<'EOF'
+feat(ui): show retrieved chunk excerpt on Sources row hover
+
+Wrap each accordion row title in the shared <Tooltip> widget. The
+tooltip surfaces the retrieved chunk text (source.content, already
+returned by the backend on the SSE stream) as a smart-truncated
+excerpt — preferring sentence boundaries up to ~280 chars, falling
+back to word boundaries, then to a hard cut at the limit.
+
+Whitespace runs (including embedded newlines from source HTML) are
+collapsed so the rendered excerpt flows cleanly inside the tooltip's
+single <p> body. Empty or missing content shows "No excerpt available."
+for a consistent affordance across all rows.
+
+No XSS surface introduced — React text rendering escapes by default,
+and the excerpt is passed as a plain string prop to TooltipContent.
+
+Refs: #357
+See docs/superpowers/specs/2026-05-23-unified-source-attribution-design.md
+
+Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>
+EOF
+)"
+```
+
+---
+
+## Task 4: Push branch + open PR + Vercel Preview HITL gate
+
+**Files:** none (orchestration only).
+
+- [ ] **Step 1: Verify the branch state before push**
+
+Run:
+
+```bash
+cd /Users/arthurfantaci/Projects/requirements-graphrag-api
+git status
+git log main..HEAD --oneline
+```
+
+Expected: working tree clean. The branch should have FIVE commits ahead of `main`:
+
+1. `docs(spec): unified source attribution design`
+2. `docs(spec): fix markdownlint diagnostics on unified source attribution spec`
+3. `refactor(synthesis): remove redundant Sources footer from final answer`
+4. `feat(ui): number Sources accordion rows with citation-style chips`
+5. `feat(ui): show retrieved chunk excerpt on Sources row hover`
+
+If the commit list looks wrong, stop and reconcile before pushing.
+
+- [ ] **Step 2: Push the branch with upstream tracking**
+
+Run:
+
+```bash
+git push -u origin feat/unified-source-attribution
+```
+
+Expected: branch is published to origin and upstream tracking is set.
+
+- [ ] **Step 3: Open the PR via `gh pr create`**
+
+Run:
+
+```bash
+gh pr create --base main --head feat/unified-source-attribution --title "feat: unify source attribution — accordion numbering + hover excerpts" --body "$(cat <<'EOF'
+## Summary
+
+- Remove redundant `**Sources:**` footer from synthesis output (`refactor(synthesis)`).
+- Number Sources accordion rows with citation-style emerald chips matching the inline `[Source N]` chip styling (`feat(ui)`).
+- Show retrieved chunk text excerpt on Sources row title hover (`feat(ui)`).
+
+Resolves the three-way numbering inconsistency described in #357. Inline `[Source N]` chips and accordion rows now visibly correspond 1:1 (alignment was already correct in the data layer; this PR makes it visible). The third footer-numbering scheme is removed.
+
+## Spec
+
+`docs/superpowers/specs/2026-05-23-unified-source-attribution-design.md`
+
+## Test plan
+
+- [ ] Backend: full pytest suite goes 852 → 853 passing (one net new regression test added — `test_synthesis_module_has_no_sources_footer`).
+- [ ] Frontend: no test framework per project posture; HITL manual verification on the Vercel Preview deployment.
+
+### Vercel Preview HITL checklist (gate before merge)
+
+- [ ] LLM response body shows no `**Sources:**` block at the bottom.
+- [ ] Accordion header still shows `Sources (N)`.
+- [ ] Expanding the accordion reveals `[1]`, `[2]`, … emerald chips at row start, matching inline-chip styling.
+- [ ] Hovering an accordion row title shows a dark tooltip with the chunk text excerpt.
+- [ ] Long chunks truncate with `…`; short chunks display fully; empty `content` shows "No excerpt available."
+- [ ] External-link icon on each row still opens the source URL in a new tab.
+- [ ] All pre-existing accordion behavior preserved (expand/collapse, info icon tooltip, relevance bar).
+
+### Post-merge production HITL (after merge to main)
+
+- [ ] After Railway auto-deploy completes, run an explanatory query against production and confirm: (a) `**Sources:**` block gone, (b) accordion numbering visible, (c) hover tooltip working.
+
+Closes #357
+
+🤖 Generated with [Claude Code](https://claude.com/claude-code)
+EOF
+)"
+```
+
+Expected: PR URL is returned. Capture it.
+
+- [ ] **Step 4: Monitor CI and Vercel Preview status**
+
+Run (in a loop or via Monitor):
+
+```bash
+gh pr checks $(gh pr view --json number --jq .number) --watch
+```
+
+Wait for:
+
+- Lint & Format Check: pass
+- Test: pass
+- Vercel — Preview: ready (preview URL listed in PR comments)
+
+If any check fails, investigate the failure, push a fix on the branch, and re-monitor. Do not proceed to Step 5 until all checks are green AND the Vercel Preview is Ready.
+
+- [ ] **Step 5: Surface the Vercel Preview URL to the user for manual HITL**
+
+Per `feedback_hitl-before-production.md`, STOP before proposing merge. Post a message to the user that contains:
+
+1. The Vercel Preview URL (from the PR's `vercel[bot]` comment or `gh pr view --comments`).
+2. The seven-check HITL checklist verbatim (see PR body above).
+3. An explicit "please exercise the preview manually and approve merge when ready" prompt.
+
+Do NOT merge. Wait for the user's explicit approval. The act-on-authorized-tasks memory does NOT authorize self-merge of product-surface PRs.
+
+---
+
+## Task 5: Squash-merge after user approval + Railway production HITL
+
+**Files:** none (orchestration only).
+
+Pre-condition: the user has explicitly approved the merge after exercising the Vercel Preview per Task 4 Step 5.
+
+- [ ] **Step 1: Squash-merge with branch deletion**
+
+Run:
+
+```bash
+gh pr merge $(gh pr view --json number --jq .number) --squash --delete-branch
+```
+
+Expected: PR is squash-merged into `main`, the remote feature branch is deleted, the local branch is detached.
+
+- [ ] **Step 2: Sync local main**
+
+Run:
+
+```bash
+cd /Users/arthurfantaci/Projects/requirements-graphrag-api
+git checkout main
+git pull --ff-only origin main
+git log -1 --format='%h %s'
+```
+
+Expected: local `main` is at the squash-merge commit.
+
+- [ ] **Step 3: Wait for Railway auto-deploy to complete**
+
+Railway watches `main` and auto-deploys when backend files change. Use the Monitor tool with a Railway API or status check, or wait ~3-5 minutes for typical deploy duration. Then probe production:
+
+```bash
+curl -s -o /dev/null -w "%{http_code}\n" https://api-production-f1cf.up.railway.app/health
+```
+
+Expected: `200`.
+
+If Railway shows a failed deploy, halt and investigate before proceeding to production HITL.
+
+- [ ] **Step 4: Surface production HITL prompt to the user**
+
+Per `feedback_hitl-before-production.md` post-merge clause, prompt the user to run an explanatory query against production at https://graphrag.norfolkaibi.com/ and confirm in one sentence:
+
+- `**Sources:**` block is gone from the response body.
+- Accordion rows show `[N]` chips matching inline citation chip styling.
+- Hovering a row title shows the chunk excerpt tooltip.
+
+Wait for the user's confirmation. If they report any regression, halt and discuss rollback options.
+
+- [ ] **Step 5: Close out memory + tracking**
+
+After user confirms production is healthy:
+
+- Update `~/.claude/projects/-Users-arthurfantaci-Projects-requirements-graphrag-api/memory/MEMORY.md` "Recent decisions" with a one-row entry describing the PR shipped, the commit hash, the test count change, and any production-verification notes.
+- Verify issue #357 was auto-closed by the `Closes #357` trailer in the PR body. If not, close manually with a brief outcome comment.
+
+This step is bundled into the implementation branch's outcome per the global "no separate workflow for CLAUDE.md / memory" rule — memory updates do not need their own commit or PR.
+
+---
+
+## Self-Review
+
+After writing this plan, I checked it against the spec with fresh eyes:
+
+**Spec coverage check** — every section in `2026-05-23-unified-source-attribution-design.md` maps to a task:
+
+- Problem → context for the implementer (header summary + spec reference).
+- Goals → goal statement at the top.
+- Non-goals → not separately tasked; implementer reads spec for context. The "out of scope" items (Tooltip widget tuning, SourceBadge extraction, etc.) are not touched in any task.
+- Approach — Backend change → Task 1.
+- Approach — Frontend changes (row numbering + tooltip + map pass-through) → Tasks 2 and 3.
+- Approach — Excerpt truncation helper → Task 3 Step 1.
+- Data flow → no task needed (no schema changes).
+- Error handling → covered by Task 3's `'No excerpt available.'` fallback and the existing `Tooltip` widget's viewport-clamp behavior.
+- Testing — backend → Task 1.
+- Testing — frontend → Task 2 Step 3, Task 3 Step 3, Task 4 Step 5 (HITL).
+- HITL gate sequence → Task 4 Step 5 (pre-merge), Task 5 Steps 3-4 (post-merge).
+- Branch / PR shape → Task 4 Step 3 (PR creation), Task 5 Step 1 (squash-merge with delete-branch).
+
+**Placeholder scan** — no "TBD", "TODO", "implement later", "appropriate error handling", or similar vague language. Every step has either concrete code blocks or concrete shell commands.
+
+**Type consistency check** — `sourceNumber` prop name is used identically in Task 2 (introduced) and Task 3 (extended). `buildExcerpt` function name is defined and called consistently. The class string for the chip is identical across the spec and Tasks 2 & 3.
+
+**Spec deviation noted** — Task 1 uses source-inspection rather than the spec's runtime assertion for the regression test. Rationale is documented in the task header. This is a stricter invariant than the spec's intent, so it satisfies the spec's goal.
+
+No remediation needed; plan is internally consistent.

--- a/docs/superpowers/plans/2026-05-23-unified-source-attribution.md
+++ b/docs/superpowers/plans/2026-05-23-unified-source-attribution.md
@@ -501,13 +501,15 @@ git status
 git log main..HEAD --oneline
 ```
 
-Expected: working tree clean. The branch should have FIVE commits ahead of `main`:
+Expected: working tree clean. The branch should have SEVEN commits ahead of `main`:
 
 1. `docs(spec): unified source attribution design`
 2. `docs(spec): fix markdownlint diagnostics on unified source attribution spec`
-3. `refactor(synthesis): remove redundant Sources footer from final answer`
-4. `feat(ui): number Sources accordion rows with citation-style chips`
-5. `feat(ui): show retrieved chunk excerpt on Sources row hover`
+3. `docs(plan): unified source attribution implementation plan`
+4. `docs(plan): fix expected commit count in Task 4 Step 1`
+5. `refactor(synthesis): remove redundant Sources footer from final answer`
+6. `feat(ui): number Sources accordion rows with citation-style chips`
+7. `feat(ui): show retrieved chunk excerpt on Sources row hover`
 
 If the commit list looks wrong, stop and reconcile before pushing.
 

--- a/docs/superpowers/specs/2026-05-23-unified-source-attribution-design.md
+++ b/docs/superpowers/specs/2026-05-23-unified-source-attribution-design.md
@@ -141,13 +141,13 @@ No payload-schema changes. The backend SSE stream already publishes `sources: li
 ## Error handling
 
 | Condition | Behavior |
-|---|---|
+| --- | --- |
 | `source.content` missing / empty / whitespace-only | Tooltip renders with `description="No excerpt available."` — consistent affordance across all rows, no conditional hiding. |
 | `source.content` very long (>2000 chars) | Same truncation path; ellipsis at the boundary. No special case. |
 | `source.content` contains HTML or markdown syntax | React's text rendering escapes by default. The excerpt renders inside `<p>{description}</p>` in `TooltipContent` (`Tooltip.jsx:135`) — pure React text rendering, no raw-HTML injection paths involved. **No XSS surface introduced.** |
 | Tooltip near viewport top edge | Existing widget's flip-to-bottom logic (`Tooltip.jsx:33-51`) applies. May be off by ~40px due to `tooltipHeight = 80` constant (actual excerpt height ~120-160px); viewport-clamp prevents off-screen render. Acceptable cosmetic. |
 | Mobile viewport | Widget clamps to `w-64 max-w-xs` (256-320px) and adjusts horizontally within bounds (`Tooltip.jsx:24-27`). No new behavior. |
-| `sources` empty array | Existing early-return at `SourcesPanel.jsx:108` (`if (!sources || sources.length === 0) return null`) handles. No new code. |
+| `sources` empty array | Existing early-return at `SourcesPanel.jsx:108` (`if (!sources \|\| sources.length === 0) return null`) handles. No new code. |
 
 ## Testing
 
@@ -164,6 +164,7 @@ uv run pytest --tb=short
 Tests live in `backend/tests/test_core/test_agentic/test_subgraphs.py`, class `TestSynthesisSubgraph`. The class currently has seven tests; none of them invoke `format_output` directly or assert on the `**Sources:**` rendering — so there is nothing existing to UPDATE. We are ADDING one new regression test:
 
 **New test — `test_format_output_no_sources_footer`** (or similar name): construct a `SynthesisState` with `draft_answer` and `citations` populated, invoke the compiled subgraph (or call the `format_output` node directly via the same pattern as the existing tests), and assert all of:
+
 - `final_answer` does NOT contain `"**Sources:**"`.
 - `final_answer` does NOT contain `"\n- ["` (the citation-list marker pattern).
 - The returned state (or the input state, depending on test scope) still carries `citations` so downstream consumers (LangSmith telemetry) are not broken by the rendering removal.

--- a/docs/superpowers/specs/2026-05-23-unified-source-attribution-design.md
+++ b/docs/superpowers/specs/2026-05-23-unified-source-attribution-design.md
@@ -1,0 +1,214 @@
+# Unified Source Attribution — Design Spec
+
+**Date**: 2026-05-23
+**Status**: Approved (brainstorming complete; awaiting implementation plan)
+**Branch**: `feat/unified-source-attribution`
+**Tracking issue**: [#357](https://github.com/arthurfantaci/requirements-graphrag-api/issues/357)
+**Produced via**: `superpowers:brainstorming` skill workflow
+
+## Problem
+
+Source attribution in explanatory LLM responses currently uses three different and incompatible numbering schemes that the user cannot reconcile:
+
+1. **Inline citation chips** `[Source N]` in the response body. Numbers derive from retrieval order, built in `backend/src/requirements_graphrag_api/core/context.py:291` (`[Source {i}: {title}]` markers fed into the synthesis prompt).
+2. **Static `**Sources:**` footer** appended to every explanatory answer in `backend/src/requirements_graphrag_api/core/agentic/subgraphs/synthesis.py:283-287`. Numbers derive from the LLM-judged `citations` field parsed out of the synthesis JSON output (`synthesis.py:107, 222`). LLM-judged order can and does diverge from retrieval order.
+3. **Sources accordion** at the bottom of the response (`frontend/src/components/metadata/SourcesPanel.jsx`). Renders the SSE `sources[]` array in retrieval order — the same order as (1) — but accordion rows have no visible numbers, so users cannot visually link inline chips to accordion rows.
+
+End-users see all three at once. The divergence between (1) and (2) makes the existing inline chips appear "wrong" relative to the prominent static list. PR #354 (LangSmith Issues Agent) attempted to reconcile by forcing (1) to follow (2)'s numbering — which inverted the data direction (LLM-judged → deterministic retrieval) and made the symptom worse. That PR was rolled back as `fe3c6b7`.
+
+## Goals
+
+- Eliminate the divergent third numbering scheme by removing the static `**Sources:**` footer.
+- Make the existing alignment between inline `[Source N]` chips and accordion rows visually unmistakable by numbering accordion rows with chip styling identical to inline citations.
+- Surface the retrieved chunk text on demand via row-title hover tooltip, so users can audit *why* a row was cited without leaving the response.
+
+## Non-goals
+
+- **Backfilling historical responses.** Forward-only.
+- **Tuning the shared Tooltip widget's `tooltipHeight = 80` position-flip constant** (`frontend/src/components/ui/Tooltip.jsx:20`). Pre-existing limitation; tuning it touches a widget shared across components and is a separate concern.
+- **Extracting a shared `SourceBadge` component.** The emerald chip class string is one line of Tailwind. The two usages — inline chip (anchor + tooltip + click-to-open) vs. accordion-row prefix (plain span, non-interactive) — have meaningfully different surrounding structure. An abstraction would have to parameterize both, and the parameterization cost exceeds the duplication cost.
+- **Removing the upstream `citations` extraction** at `synthesis.py:107, 222`. The field stays in `SynthesisState` in case downstream consumers (e.g., LangSmith telemetry) read it. Only the *rendering append* in `format_output` is removed.
+- **Changing the inline `[Source N]` chip tooltip** in `SourceCitationRenderer.jsx:36-48`. It stays lean (title + relevance + click hint). The accordion-row tooltip provides progressive disclosure — chip identifies, row investigates.
+- **Cypher / structured-response surfaces.** This PR touches the explanatory (RAG) response only.
+
+## Approach
+
+Three coordinated changes; two files of production code plus one test file; ~80-line net diff; single bundled PR.
+
+### Backend change (1 file)
+
+`backend/src/requirements_graphrag_api/core/agentic/subgraphs/synthesis.py`, function `format_output`:
+
+Delete line 281 (the now-misleading section comment) and lines 283-287 (the `if citations:` block and its body):
+
+```python
+# Build final answer with citation footer         ← line 281, delete
+final = draft                                       ← line 282, KEEP
+if citations:                                       ← line 283, delete
+    citation_text = "\n\n**Sources:**\n"           ← line 284, delete
+    for i, source in enumerate(citations, 1):      ← line 285, delete
+        citation_text += f"- [{i}] {source}\n"     ← line 286, delete
+    final += citation_text                          ← line 287, delete
+```
+
+Line 282 (`final = draft`) MUST be retained — it is the initialization that the confidence-indicator block at lines 290-294 still appends to. The `citations = state.get("citations", [])` extraction at line 276 also stays — only the rendering append is removed, so `citations` remains available in `SynthesisState` for downstream consumers (e.g., LangSmith telemetry).
+
+### Frontend changes (1 file)
+
+`frontend/src/components/metadata/SourcesPanel.jsx`:
+
+**1. Row numbering chip.** Prefix each `SourceItem` with a `[N]` span using the exact class string from `SourceCitationRenderer.jsx:30`, adjusted for the row-prefix context:
+
+```jsx
+<span className="inline-flex items-center px-1.5 py-0.5 mr-2 rounded text-xs font-medium bg-emerald-50 text-emerald-700 border border-emerald-200 flex-shrink-0">
+  {sourceNumber}
+</span>
+```
+
+`mr-2` replaces the original `mx-0.5` — the row-prefix context wants right-margin spacing only, not symmetric. `flex-shrink-0` is added so the chip never shrinks when the title is long. The chip is non-interactive (no anchor wrapper, no hover state) because the row already exposes click affordance via the existing external-link icon.
+
+**2. Row-title hover tooltip.** Wrap the title `<p>` in the shared `<Tooltip>` wrapper from `frontend/src/components/ui/Tooltip.jsx:159-185`:
+
+```jsx
+<Tooltip
+  title={title || `Source ${sourceNumber}`}
+  description={excerpt || 'No excerpt available.'}
+  color="emerald"
+  position="top"
+>
+  <p className="text-sm text-charcoal-light truncate">
+    {title || 'Untitled Source'}
+  </p>
+</Tooltip>
+```
+
+The `<Tooltip>` wrapper already supplies `cursor-help` on its trigger span. `excerpt` is computed via the local helper described below. The underlying `<p>` keeps its existing `truncate` class for visual handling of long titles within the row.
+
+**3. Pass row number through.** At `SourcesPanel.jsx:134`, change the map call to pass the 1-indexed number:
+
+```jsx
+{sources.map((source, index) => (
+  <SourceItem key={`source-${index}`} source={source} sourceNumber={index + 1} />
+))}
+```
+
+### Excerpt truncation helper (frontend)
+
+Module-private function at the top of `SourcesPanel.jsx`. Inline rather than a separate file — small, single-use, no test framework on the frontend to share with.
+
+```javascript
+const EXCERPT_MAX_CHARS = 280
+const BOUNDARY_FLOOR = 100
+
+function buildExcerpt(content) {
+  if (!content) return null
+  const normalized = content.trim().replace(/\s+/g, ' ')
+  if (!normalized) return null
+  if (normalized.length <= EXCERPT_MAX_CHARS) return normalized
+
+  const window = normalized.slice(0, EXCERPT_MAX_CHARS)
+
+  // Prefer the last sentence boundary within the window
+  const sentenceMatches = [...window.matchAll(/[.?!]\s/g)]
+  const lastSentence = sentenceMatches[sentenceMatches.length - 1]
+  if (lastSentence && lastSentence.index >= BOUNDARY_FLOOR) {
+    return normalized.slice(0, lastSentence.index + 1) + ' …'
+  }
+
+  // Fall back to the last word boundary
+  const wordBoundary = window.lastIndexOf(' ')
+  if (wordBoundary >= BOUNDARY_FLOOR) {
+    return normalized.slice(0, wordBoundary) + ' …'
+  }
+
+  // Pathological: no whitespace in first 280 chars — hard cut
+  return window + '…'
+}
+```
+
+Key choices:
+
+- **`EXCERPT_MAX_CHARS = 280`**: ~3-4 lines at the tooltip's `text-xs leading-relaxed` styling. Readable without dominating the viewport.
+- **`BOUNDARY_FLOOR = 100`**: prevents pathological cases like "Hi. <very long sentence>" from truncating to "Hi." — if the only sentence terminator is too close to the start, fall through to word boundary.
+- **Whitespace normalization** (`replace(/\s+/g, ' ')`): chunks carry embedded `\n` from source HTML; `<p>` does not honor newlines as breaks, so normalizing prevents awkward gap rendering.
+- **`…` (U+2026)** not `...`: single codepoint, correct typography.
+- Returns `null` when there is no usable content — caller renders the fallback string `'No excerpt available.'`.
+
+## Data flow
+
+No payload-schema changes. The backend SSE stream already publishes `sources: list[dict]` where each entry includes `{title, content, url, chunk_id, relevance_score}` (`core/context.py:297-304`). The frontend `SourcesPanel` already iterates this array in retrieval order — the *same* order used to build `[Source i: {title}]` markers in `core/context.py:291`. The design surfaces this existing alignment; it does not change the underlying data.
+
+## Error handling
+
+| Condition | Behavior |
+|---|---|
+| `source.content` missing / empty / whitespace-only | Tooltip renders with `description="No excerpt available."` — consistent affordance across all rows, no conditional hiding. |
+| `source.content` very long (>2000 chars) | Same truncation path; ellipsis at the boundary. No special case. |
+| `source.content` contains HTML or markdown syntax | React's text rendering escapes by default. The excerpt renders inside `<p>{description}</p>` in `TooltipContent` (`Tooltip.jsx:135`) — pure React text rendering, no raw-HTML injection paths involved. **No XSS surface introduced.** |
+| Tooltip near viewport top edge | Existing widget's flip-to-bottom logic (`Tooltip.jsx:33-51`) applies. May be off by ~40px due to `tooltipHeight = 80` constant (actual excerpt height ~120-160px); viewport-clamp prevents off-screen render. Acceptable cosmetic. |
+| Mobile viewport | Widget clamps to `w-64 max-w-xs` (256-320px) and adjusts horizontally within bounds (`Tooltip.jsx:24-27`). No new behavior. |
+| `sources` empty array | Existing early-return at `SourcesPanel.jsx:108` (`if (!sources || sources.length === 0) return null`) handles. No new code. |
+
+## Testing
+
+### Backend
+
+Run from `backend/`:
+
+```bash
+uv run ruff check .
+uv run ruff format --check .
+uv run pytest --tb=short
+```
+
+Tests live in `backend/tests/test_core/test_agentic/test_subgraphs.py`, class `TestSynthesisSubgraph`. The class currently has seven tests; none of them invoke `format_output` directly or assert on the `**Sources:**` rendering — so there is nothing existing to UPDATE. We are ADDING one new regression test:
+
+**New test — `test_format_output_no_sources_footer`** (or similar name): construct a `SynthesisState` with `draft_answer` and `citations` populated, invoke the compiled subgraph (or call the `format_output` node directly via the same pattern as the existing tests), and assert all of:
+- `final_answer` does NOT contain `"**Sources:**"`.
+- `final_answer` does NOT contain `"\n- ["` (the citation-list marker pattern).
+- The returned state (or the input state, depending on test scope) still carries `citations` so downstream consumers (LangSmith telemetry) are not broken by the rendering removal.
+
+Expected suite count: 852 → 853 (one net new test added; no existing tests changed).
+
+### Frontend
+
+No test framework per project posture. Verification path:
+
+1. **Local**: `npm run dev` from `frontend/`. Exercise with an explanatory query that returns 3+ sources (e.g., "What is requirements traceability?"). Verify the seven checks listed below.
+2. **Vercel Preview**: after push, the Preview deployment URL gets the same seven checks, exercised by the user per `feedback_hitl-before-production.md`.
+
+Seven checks (these form the HITL prompt the user will receive when the preview is ready):
+
+1. LLM response body shows no `**Sources:**` block at the bottom.
+2. Accordion header still shows `Sources (N)`.
+3. Expanding the accordion reveals `[1]`, `[2]`, … emerald chips at row start, matching inline-chip styling.
+4. Hovering an accordion row title shows a dark tooltip with the chunk text excerpt.
+5. Long chunks truncate with `…`; short chunks display fully; rows where `content` is empty show "No excerpt available."
+6. External-link icon on each row still opens the source URL in a new tab.
+7. All pre-existing accordion behavior preserved (expand/collapse, info icon tooltip, relevance bar).
+
+## HITL gate sequence
+
+Per `~/.claude/projects/-Users-arthurfantaci-Projects-requirements-graphrag-api/memory/feedback_hitl-before-production.md`:
+
+1. **Pre-merge** — once CI green AND Vercel Preview Ready, surface the preview URL with the seven-check list above. User exercises manually. User approves merge.
+2. **Post-merge** — backend change ships to Railway via auto-deploy (no preview environment for backend in this stack; Vercel preview frontend points at production Railway via `VITE_API_URL`). Prompt the user to run an explanatory query against production after Railway deploy completes, with one-line confirmation that (a) `**Sources:**` block is gone, (b) accordion numbering is visible, (c) hover tooltip is working.
+
+## Branch / PR shape
+
+- **Tracking issue**: [#357](https://github.com/arthurfantaci/requirements-graphrag-api/issues/357).
+- **Branch**: `feat/unified-source-attribution`.
+- **Commits** (three logical, squashed at merge):
+  1. `refactor(synthesis): remove redundant Sources footer from final answer`
+  2. `feat(ui): number Sources accordion rows with citation-style chips`
+  3. `feat(ui): show retrieved chunk excerpt on Sources row hover`
+- **Spec doc** (this file): commits with the implementation branch per project CLAUDE.md (this spec is code-adjacent and drives the implementation plan — NOT a docs-only branch/PR).
+- **PR**: squash-merge with `--delete-branch` per standard workflow. PR description references this spec by path.
+
+## Open questions
+
+None remaining after Gates 1 and 2 of the brainstorming workflow. All design choices captured above.
+
+## Next step
+
+Invoke `superpowers:writing-plans` skill to produce the implementation plan that breaks this spec into ordered, executable tasks. The plan will be a separate file (also on this branch) that the implementation session works from.

--- a/frontend/src/components/metadata/SourcesPanel.jsx
+++ b/frontend/src/components/metadata/SourcesPanel.jsx
@@ -1,6 +1,34 @@
 import { useState } from 'react'
 import { Tooltip } from '../ui/Tooltip'
 
+const EXCERPT_MAX_CHARS = 280
+const BOUNDARY_FLOOR = 100
+
+function buildExcerpt(content) {
+  if (!content) return null
+  const normalized = content.trim().replace(/\s+/g, ' ')
+  if (!normalized) return null
+  if (normalized.length <= EXCERPT_MAX_CHARS) return normalized
+
+  const window = normalized.slice(0, EXCERPT_MAX_CHARS)
+
+  // Prefer the last sentence boundary within the window
+  const sentenceMatches = [...window.matchAll(/[.?!]\s/g)]
+  const lastSentence = sentenceMatches[sentenceMatches.length - 1]
+  if (lastSentence && lastSentence.index >= BOUNDARY_FLOOR) {
+    return normalized.slice(0, lastSentence.index + 1) + ' …'
+  }
+
+  // Fall back to the last word boundary
+  const wordBoundary = window.lastIndexOf(' ')
+  if (wordBoundary >= BOUNDARY_FLOOR) {
+    return normalized.slice(0, wordBoundary) + ' …'
+  }
+
+  // Pathological: no whitespace in first 280 chars — hard cut
+  return window + '…'
+}
+
 /**
  * Info icon for tooltip trigger
  */
@@ -74,7 +102,8 @@ function RelevanceBar({ score }) {
  * Single source item
  */
 function SourceItem({ source, sourceNumber }) {
-  const { title, url, relevance_score } = source
+  const { title, url, content, relevance_score } = source
+  const excerpt = buildExcerpt(content)
 
   return (
     <div className="flex items-start justify-between gap-2 py-2 border-b border-black/5 last:border-b-0">
@@ -83,7 +112,16 @@ function SourceItem({ source, sourceNumber }) {
           {sourceNumber}
         </span>
         <div className="flex-1 min-w-0">
-          <p className="text-sm text-charcoal-light truncate">{title || 'Untitled Source'}</p>
+          <Tooltip
+            title={title || `Source ${sourceNumber}`}
+            description={excerpt || 'No excerpt available.'}
+            color="emerald"
+            position="top"
+          >
+            <p className="text-sm text-charcoal-light truncate">
+              {title || 'Untitled Source'}
+            </p>
+          </Tooltip>
           <RelevanceBar score={relevance_score} />
         </div>
       </div>

--- a/frontend/src/components/metadata/SourcesPanel.jsx
+++ b/frontend/src/components/metadata/SourcesPanel.jsx
@@ -73,14 +73,19 @@ function RelevanceBar({ score }) {
 /**
  * Single source item
  */
-function SourceItem({ source }) {
+function SourceItem({ source, sourceNumber }) {
   const { title, url, relevance_score } = source
 
   return (
     <div className="flex items-start justify-between gap-2 py-2 border-b border-black/5 last:border-b-0">
-      <div className="flex-1 min-w-0">
-        <p className="text-sm text-charcoal-light truncate">{title || 'Untitled Source'}</p>
-        <RelevanceBar score={relevance_score} />
+      <div className="flex-1 min-w-0 flex items-start gap-2">
+        <span className="inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium bg-emerald-50 text-emerald-700 border border-emerald-200 flex-shrink-0 mt-0.5">
+          {sourceNumber}
+        </span>
+        <div className="flex-1 min-w-0">
+          <p className="text-sm text-charcoal-light truncate">{title || 'Untitled Source'}</p>
+          <RelevanceBar score={relevance_score} />
+        </div>
       </div>
       {url && (
         <a
@@ -132,7 +137,7 @@ export function SourcesPanel({ sources }) {
       {isOpen && (
         <div className="px-3 pb-2 border-t border-emerald-100 bg-ivory-light">
           {sources.map((source, index) => (
-            <SourceItem key={`source-${index}`} source={source} />
+            <SourceItem key={`source-${index}`} source={source} sourceNumber={index + 1} />
           ))}
         </div>
       )}


### PR DESCRIPTION
## Summary

- Remove redundant `**Sources:**` footer from synthesis output (`refactor(synthesis)`).
- Number Sources accordion rows with citation-style emerald chips matching the inline `[Source N]` chip styling (`feat(ui)`).
- Show retrieved chunk text excerpt on Sources row title hover (`feat(ui)`).

Resolves the three-way numbering inconsistency described in #357. Inline `[Source N]` chips and accordion rows now visibly correspond 1:1 (alignment was already correct in the data layer; this PR makes it visible). The third footer-numbering scheme is removed.

## Spec

`docs/superpowers/specs/2026-05-23-unified-source-attribution-design.md`

## Plan

`docs/superpowers/plans/2026-05-23-unified-source-attribution.md`

## Test plan

- [x] Backend: full pytest suite goes 852 → 853 passing (one net new regression test added — `test_synthesis_module_has_no_sources_footer`, a source-inspection guard that asserts the `**Sources:**` marker is absent from the synthesis module).
- [x] Frontend: ESLint clean on `SourcesPanel.jsx`; `vite build` succeeds with the modified bundle.
- [ ] Frontend HITL: manual verification on the Vercel Preview deployment (see checklist below).

### Vercel Preview HITL checklist (gate before merge)

- [ ] LLM response body shows no `**Sources:**` block at the bottom.
- [ ] Accordion header still shows `Sources (N)`.
- [ ] Expanding the accordion reveals `[1]`, `[2]`, … emerald chips at row start, matching inline-chip styling.
- [ ] Hovering an accordion row title shows a dark tooltip with the chunk text excerpt.
- [ ] Long chunks truncate with `…`; short chunks display fully; empty `content` shows "No excerpt available."
- [ ] External-link icon on each row still opens the source URL in a new tab.
- [ ] All pre-existing accordion behavior preserved (expand/collapse, info icon tooltip, relevance bar).

### Post-merge production HITL (after merge to main)

- [ ] After Railway auto-deploy completes, run an explanatory query against production and confirm: (a) `**Sources:**` block gone, (b) accordion numbering visible, (c) hover tooltip working.

Closes #357

🤖 Generated with [Claude Code](https://claude.com/claude-code)