### PR TITLE
fix(context): preserve Concept node label when glossary enriches an entity

### DIFF
--- a/backend/src/requirements_graphrag_api/core/context.py
+++ b/backend/src/requirements_graphrag_api/core/context.py
@@ -250,7 +250,6 @@ def format_context(
                     all_entities[term] = {"definition": definition, "label": "Definition"}
                 elif definition and not all_entities[term].get("definition"):
                     all_entities[term]["definition"] = definition
-                    all_entities[term]["label"] = "Definition"
                 # Collect for KG section
                 if term not in seen_glossary and definition:
                     seen_glossary[term] = definition

--- a/backend/tests/test_core/test_context.py
+++ b/backend/tests/test_core/test_context.py
@@ -284,6 +284,34 @@ class TestFormatContext:
         assert "AEC" in result.entities_by_name
         assert result.entities_by_name["AEC"]["definition"] == "Arch, Eng & Constr"
 
+    def test_concept_label_preserved_when_glossary_definition_matches(self) -> None:
+        """Regression for #359: a Concept entity must not be demoted to "Definition"
+        when a matching glossary_definitions entry augments its tooltip text.
+        """
+        docs = [
+            NormalizedDocument(
+                content="Chunk discussing bi-directional traceability.",
+                source="Traceability Article",
+                entities=[
+                    {"name": "Bi-directional Traceability", "type": "Concept", "definition": None},
+                ],
+                glossary_definitions=[
+                    {
+                        "term": "Bi-directional Traceability",
+                        "definition": (
+                            "Traceability that works forwards and backwards across the "
+                            "requirements lifecycle."
+                        ),
+                    },
+                ],
+            ),
+        ]
+        result = format_context(docs)
+        assert result.entities_by_name["Bi-directional Traceability"]["label"] == "Concept"
+        assert result.entities_by_name["Bi-directional Traceability"]["definition"] == (
+            "Traceability that works forwards and backwards across the requirements lifecycle."
+        )
+
     def test_deduplicates_relationships(self) -> None:
         """Same relationship from two chunks appears once in KG section."""
         rel = {


### PR DESCRIPTION
## Summary

Single-line production fix in `core/context.py` that stops silently demoting `:Concept` (and other specific Neo4j labels: Standard, Bestpractice, Challenge, Methodology, etc.) to "Definition" whenever the glossary_definitions enrichment path happens to match the entity name. Adds one regression test guarding against re-introduction.

Resolves the long-standing UI symptom where purple Concept badges never appear in the Concepts accordion of explanatory LLM responses despite the frontend supporting them via `EntityBadges.jsx:50-115`.

## Root cause

`format_context()` in `backend/src/requirements_graphrag_api/core/context.py:251-253` had an asymmetric label-handling rule. The per-chunk entity-path's elif (lines 237-238) was first-wins on label (never updates existing). The glossary_definitions path's elif (lines 251-253) was first-wins on definition BUT explicitly overwrote the label to "Definition" anyway. The mismatched rule was the bug.

## Data probe (production Neo4j) confirming impact

- 3,076 `:Concept` nodes in the graph, all mentioned in chunks
- 196 (~6%) have own `.definition` property; 2,880 (~94%) do not
- `_enrich_with_definitions` Cypher uses permissive substring matching (`CONTAINS`), so nearly every Concept name matches at least one `:Definition` node
- Net effect: virtually every Concept retrieved was being demoted to Definition

## Fix

Drop line 253 (the `all_entities[term]["label"] = "Definition"` overwrite). Keep line 252 so a Concept that has a matching Definition still surfaces the Definition's text on hover — the badge stays purple while the tooltip stays informative.

## Test

New regression test `test_concept_label_preserved_when_glossary_definition_matches` in `backend/tests/test_core/test_context.py`. Constructs a `NormalizedDocument` with a Concept entity (no own definition) and a matching glossary definition; asserts the label stays "Concept" and the definition text is correctly carried over from the glossary path.

Suite count: **853 -> 854 passing.**

## Out of scope (filed as #360)

Reviewer flagged two residual triggers of the same bug class via different mechanisms (pre-loop `definitions` parameter path + cross-chunk first-wins ordering). Both are different code paths from the one fixed here, and the orchestrator currently doesn't pass `definitions` to format_context in the chat flow, so they're not firing in production today. Tracked in #360 for future work.

## Frontend

No frontend changes. `EntityBadges.jsx` already correctly maps `Concept -> purple`, `Definition -> blue`, `Entity -> teal`, etc. The fix is entirely backend.

## Test plan

- [x] Backend: full pytest suite 853 -> 854 passing (one net new regression test). ruff check + ruff format clean. (verified locally)
- [x] Independent code review via `pr-review-toolkit:code-reviewer` subagent: APPROVED, no blocking findings.
- [ ] CI: Lint & Format Check + Test must pass.
- [ ] Post-merge production verification: after Railway auto-deploys, user submits an explanatory query at https://graphrag.norfolkaibi.com/ and confirms purple Concept badges now appear in the Concepts accordion (alongside the existing blue Definition badges and teal Entity badges).

## HITL gate sequence

Backend-only PR — Vercel Preview verification is structurally unavailable (preview frontend points at production Railway via `VITE_API_URL`). Pre-merge confidence = CI green + 854 tests passing + independent code review APPROVED. Post-merge HITL = user manually exercises production after Railway redeploys.

## Workflow note

This PR was implemented via subagent-driven development:
- Implementation: `general-purpose` subagent with self-contained brief
- Review: `pr-review-toolkit:code-reviewer` subagent independent review
- Orchestration (issue, branch, push, PR, monitor, surface HITL): main session

Closes #359
Refs #360

🤖 Generated with [Claude Code](https://claude.com/claude-code)