### PR TITLE
fix(retrieval): filter SimpleKGPipeline scaffolding labels — purple Concept badges (and others) now render in UI

### DIFF
--- a/backend/src/requirements_graphrag_api/core/retrieval.py
+++ b/backend/src/requirements_graphrag_api/core/retrieval.py
@@ -825,7 +825,7 @@ def _enrich_with_entities(
         return_clause = """
             collect(DISTINCT {
                 name: entity.display_name,
-                type: labels(entity)[0],
+                type: [lbl IN labels(entity) WHERE NOT lbl STARTS WITH '__'][0],
                 definition: entity.definition,
                 benefit: entity.benefit,
                 impact: entity.impact
@@ -898,7 +898,7 @@ def _enrich_with_semantic_relationships(
                      from_entity: entity.display_name,
                      relationship: type(r),
                      to_entity: related.display_name,
-                     to_type: labels(related)[0],
+                     to_type: [lbl IN labels(related) WHERE NOT lbl STARTS WITH '__'][0],
                      to_definition: related.definition
                  }})[..$max_related] AS relationships
             WHERE size(relationships) > 0
@@ -1385,7 +1385,9 @@ async def get_entities_from_chunks(
                 """
                 MATCH (entity)-[:MENTIONED_IN]->(c:Chunk)
                 WHERE elementId(c) IN $chunk_ids
-                WITH entity, labels(entity)[0] AS label, count(*) AS mentions
+                WITH entity,
+                     [lbl IN labels(entity) WHERE NOT lbl STARTS WITH '__'][0] AS label,
+                     count(*) AS mentions
                 RETURN label,
                        entity.name AS name,
                        entity.display_name AS display_name,
@@ -1426,7 +1428,7 @@ async def search_entities_by_name(
                        OR n:Outcome)
                       AND (toLower(n.name) CONTAINS toLower($term)
                            OR toLower(n.display_name) CONTAINS toLower($term))
-                WITH n, labels(n)[0] AS label
+                WITH n, [lbl IN labels(n) WHERE NOT lbl STARTS WITH '__'][0] AS label
                 OPTIONAL MATCH (n)-[r]-(related)
                 WITH n, label, count(DISTINCT related) AS connections
                 RETURN label,
@@ -1465,7 +1467,7 @@ async def get_related_entities(
                 MATCH (n {name: $name})-[r]-(related)
                 WHERE NOT related:Chunk AND NOT related:Article
                 WITH type(r) AS rel_type,
-                     labels(related)[0] AS related_label,
+                     [lbl IN labels(related) WHERE NOT lbl STARTS WITH '__'][0] AS related_label,
                      related.name AS related_name,
                      related.display_name AS related_display,
                      startNode(r) = n AS outgoing

--- a/backend/tests/test_core/test_retrieval.py
+++ b/backend/tests/test_core/test_retrieval.py
@@ -1172,3 +1172,30 @@ class TestCommunitySearch:
 
         assert len(results) == 1
         assert results[0]["score"] == 0.0
+
+
+def test_retrieval_filters_scaffolding_labels() -> None:
+    """Regression guard for issue #362: Cypher must filter SimpleKGPipeline scaffolding labels.
+
+    Source-inspection guard against re-introducing the __KGBuilder__/__Entity__ leak.
+    Bare `labels(X)[0]` returns the first scaffolding label on typed entity nodes built
+    by neo4j-graphrag's SimpleKGPipeline; the filtered form skips '__'-prefixed labels.
+    """
+    import inspect
+
+    from requirements_graphrag_api.core import retrieval
+
+    source = inspect.getsource(retrieval)
+    assert "labels(entity)[0]" not in source, (
+        "core/retrieval.py must not contain the bare `labels(entity)[0]` pattern; "
+        "use `[lbl IN labels(entity) WHERE NOT lbl STARTS WITH '__'][0]` to skip "
+        "SimpleKGPipeline scaffolding labels (issue #362)."
+    )
+    assert "labels(n)[0]" not in source, (
+        "core/retrieval.py must not contain the bare `labels(n)[0]` pattern; "
+        "use `[lbl IN labels(n) WHERE NOT lbl STARTS WITH '__'][0]` to skip "
+        "SimpleKGPipeline scaffolding labels (issue #362)."
+    )
+    assert "STARTS WITH '__'" in source, (
+        "core/retrieval.py must filter '__'-prefixed scaffolding labels (issue #362)."
+    )

--- a/backend/tests/test_core/test_retrieval.py
+++ b/backend/tests/test_core/test_retrieval.py
@@ -1196,6 +1196,11 @@ def test_retrieval_filters_scaffolding_labels() -> None:
         "use `[lbl IN labels(n) WHERE NOT lbl STARTS WITH '__'][0]` to skip "
         "SimpleKGPipeline scaffolding labels (issue #362)."
     )
+    assert "labels(related)[0]" not in source, (
+        "core/retrieval.py must not contain the bare `labels(related)[0]` pattern; "
+        "use `[lbl IN labels(related) WHERE NOT lbl STARTS WITH '__'][0]` to skip "
+        "SimpleKGPipeline scaffolding labels (issue #362)."
+    )
     assert "STARTS WITH '__'" in source, (
         "core/retrieval.py must filter '__'-prefixed scaffolding labels (issue #362)."
     )


### PR DESCRIPTION
## Summary

The actual user-visible fix for the Concept-badge-not-purple symptom. PR #361 addressed a sibling latent bug in `format_context()` but did not fix the symptom because the SSE entities payload is built by `streaming.py:256-273` (a separate code path), which gets its label values upstream from `_enrich_with_entities` Cypher in `retrieval.py`.

## Root cause

`neo4j-graphrag`'s SimpleKGPipeline adds scaffolding labels `__KGBuilder__` and `__Entity__` alongside the domain label on every typed entity node. The Cypher pattern `labels(entity)[0]` was returning `"__KGBuilder__"` for ~99% of typed nodes (Concept, Outcome, Challenge, Bestpractice, Standard, etc.) instead of the actual domain label. The frontend has no color mapping for `__KGBuilder__`, so all these entities fell through to the slate default styling, indistinguishable from the teal Entity fallback.

Definition nodes were unaffected — their only label is `["Definition"]`, so `labels(n)[0]` returned the right value. That asymmetry hid the bug.

## Data probe (production Neo4j)

| Domain type | Label list | `labels(n)[0]` |
| --- | --- | --- |
| Concept (3,076 nodes) | `[__KGBuilder__, Concept, __Entity__]` | `__KGBuilder__` |
| Outcome (2,147) | `[__KGBuilder__, __Entity__, Outcome]` | `__KGBuilder__` |
| Challenge (1,826) | `[__KGBuilder__, __Entity__, Challenge]` | `__KGBuilder__` |
| Bestpractice (714), Standard (191), Artifact (1,207), Processstage (1,028), Role (362), Organization (213), Tool (212), Methodology (124), Industry (71) | same pattern | `__KGBuilder__` |
| **Definition (134)** | `[Definition]` | `Definition` |

## Fix

Replace `labels(X)[0]` with `[lbl IN labels(X) WHERE NOT lbl STARTS WITH '__'][0]` in 5 Cypher sites in `backend/src/requirements_graphrag_api/core/retrieval.py`:

- L828: `_enrich_with_entities` (`type` field) — the SSE path
- L901: `_enrich_with_semantic_relationships` (`to_type` field) — related-entity payloads
- L1389: anonymous top-entities helper (`label` field)
- L1431: `search_entities_by_name` (`label` field)
- L1470: `get_related_entities` (`related_label` field)

`explore_entity` at L1521/L1555 was audited and left alone — it returns the full labels list and no downstream consumer indexes `[0]` from it (confirmed `routes/schema.py:143-148`).

For Definition nodes (only one label), the filter returns "Definition" unchanged — no regression.

## Test

Source-inspection regression in `backend/tests/test_core/test_retrieval.py` (same pattern as `test_synthesis_module_has_no_sources_footer` from PR #361). Asserts the module does NOT contain bare `labels(entity)[0]`, `labels(n)[0]`, or `labels(related)[0]` patterns, AND DOES contain `STARTS WITH '__'` (positive proof the filter is in use).

Suite count: **854 -> 855 passing.**

## Workflow

- Implementation: `general-purpose` subagent (commit `a17b86e`). Subagent expanded scope from the briefed 2 sites to 5 after discovering identical bugs at the other 3 sites — flagged and justified in its commit message.
- Independent review: `pr-review-toolkit:code-reviewer` subagent — APPROVED. Flagged a coverage gap in the regression test (missing `labels(related)[0]` assertion); orchestrator patched inline as commit `424db0d`.
- Orchestration (issue, branch, push, PR, monitor, merge): main session.

## Test plan

- [x] Backend pytest 854 -> 855 passing locally
- [x] Ruff check + format clean locally
- [x] Independent code review APPROVED
- [ ] CI: Lint & Format + Test must pass
- [ ] Post-merge production verification: user submits explanatory query at https://graphrag.norfolkaibi.com/, expands Concepts accordion, confirms purple Concept badges + indigo Standard / green Bestpractice / amber Challenge etc. badges now render (alongside the existing blue Definition badges)

## HITL gate sequence

Backend-only PR — no Vercel Preview path (preview frontend talks to production Railway). Pre-merge confidence = CI green + 855 passing + APPROVED review. Post-merge HITL = user manually exercises production after Railway redeploys.

Closes #362
Refs #361 (fixed sibling latent bug; did not affect user-visible symptom)

🤖 Generated with [Claude Code](https://claude.com/claude-code)