### PR TITLE
feat(ui): extend EntityBadges palette — 8 additional Neo4j domain types

### DIFF
--- a/frontend/src/components/metadata/EntityBadges.jsx
+++ b/frontend/src/components/metadata/EntityBadges.jsx
@@ -45,6 +45,15 @@ function ChevronIcon({ isOpen }) {
  * - Teal: Entities (general extracted terms)
  * - Amber: Challenges (problems/issues)
  * - Green: Best Practices (recommendations)
+ * - Indigo: Standards (formal specifications)
+ * - Orange: Industries (vertical markets)
+ * - Cyan: Artifacts (produced deliverables)
+ * - Fuchsia: Process Stages (workflow phases)
+ * - Yellow: Methodologies (structured approaches)
+ * - Rose: Tools (software/equipment)
+ * - Lime: Roles (job functions)
+ * - Emerald: Organizations (companies/groups)
+ * - Sky: Outcomes (results/effects)
  * - Slate: Fallback for unknown labels
  */
 const LABEL_COLORS = {
@@ -101,6 +110,78 @@ const LABEL_COLORS = {
     hoverBorder: 'hover:border-indigo-300',
     indicator: 'text-indigo-400',
     tooltipColor: 'purple',
+  },
+  Industry: {
+    bg: 'bg-orange-50',
+    text: 'text-orange-700',
+    border: 'border-orange-200',
+    hoverBg: 'hover:bg-orange-100',
+    hoverBorder: 'hover:border-orange-300',
+    indicator: 'text-orange-400',
+    tooltipColor: 'amber',
+  },
+  Artifact: {
+    bg: 'bg-cyan-50',
+    text: 'text-cyan-700',
+    border: 'border-cyan-200',
+    hoverBg: 'hover:bg-cyan-100',
+    hoverBorder: 'hover:border-cyan-300',
+    indicator: 'text-cyan-400',
+    tooltipColor: 'teal',
+  },
+  Processstage: {
+    bg: 'bg-fuchsia-50',
+    text: 'text-fuchsia-700',
+    border: 'border-fuchsia-200',
+    hoverBg: 'hover:bg-fuchsia-100',
+    hoverBorder: 'hover:border-fuchsia-300',
+    indicator: 'text-fuchsia-400',
+    tooltipColor: 'purple',
+  },
+  Methodology: {
+    bg: 'bg-yellow-50',
+    text: 'text-yellow-700',
+    border: 'border-yellow-200',
+    hoverBg: 'hover:bg-yellow-100',
+    hoverBorder: 'hover:border-yellow-300',
+    indicator: 'text-yellow-400',
+    tooltipColor: 'amber',
+  },
+  Tool: {
+    bg: 'bg-rose-50',
+    text: 'text-rose-700',
+    border: 'border-rose-200',
+    hoverBg: 'hover:bg-rose-100',
+    hoverBorder: 'hover:border-rose-300',
+    indicator: 'text-rose-400',
+    tooltipColor: 'rose',
+  },
+  Role: {
+    bg: 'bg-lime-50',
+    text: 'text-lime-700',
+    border: 'border-lime-200',
+    hoverBg: 'hover:bg-lime-100',
+    hoverBorder: 'hover:border-lime-300',
+    indicator: 'text-lime-400',
+    tooltipColor: 'green',
+  },
+  Organization: {
+    bg: 'bg-emerald-50',
+    text: 'text-emerald-700',
+    border: 'border-emerald-200',
+    hoverBg: 'hover:bg-emerald-100',
+    hoverBorder: 'hover:border-emerald-300',
+    indicator: 'text-emerald-400',
+    tooltipColor: 'emerald',
+  },
+  Outcome: {
+    bg: 'bg-sky-50',
+    text: 'text-sky-700',
+    border: 'border-sky-200',
+    hoverBg: 'hover:bg-sky-100',
+    hoverBorder: 'hover:border-sky-300',
+    indicator: 'text-sky-400',
+    tooltipColor: 'blue',
   },
   // Default fallback for unknown labels
   default: {


### PR DESCRIPTION
## Summary

Pure-frontend additive palette extension. PR #363 fixed the Cypher scaffolding-label leak; the frontend now receives correct domain labels for 8 entity types (Industry, Artifact, Processstage, Methodology, Tool, Role, Organization, Outcome) that the `LABEL_COLORS` dict had no mapping for. They were falling through to the slate default, leaving ~35% of returned entities visually uncolored despite correct data.

Adds 8 entries to `LABEL_COLORS` in `frontend/src/components/metadata/EntityBadges.jsx` following the existing 7-property shape:

| Type | Color |
| --- | --- |
| Industry | orange |
| Artifact | cyan |
| Processstage | fuchsia |
| Methodology | yellow |
| Tool | rose |
| Role | lime |
| Organization | emerald |
| Outcome | sky |

`tooltipColor` uses the nearest existing value from `TooltipContent.colorStyles`.

## Test plan

- Frontend: ESLint clean on modified file; vite build succeeds (503 modules, 631.34 kB JS / 61.70 kB CSS — within normal range).
- No backend changes.
- Cannot regress existing badge behavior (pure additive).

## Workflow

Subagent-driven implementation (commit `9cbaf46`). Closing the cosmetic palette gap surfaced after PR #363.

Closes #364
Refs #363

🤖 Generated with [Claude Code](https://claude.com/claude-code)