### PR TITLE
fix: sanitize LLM provider errors before they reach end users

### DIFF
--- a/backend/src/requirements_graphrag_api/core/agentic/streaming.py
+++ b/backend/src/requirements_graphrag_api/core/agentic/streaming.py
@@ -32,6 +32,8 @@ from typing import TYPE_CHECKING, Any
 
 import structlog
 
+from requirements_graphrag_api.core.errors import classify_llm_error
+
 if TYPE_CHECKING:
     from collections.abc import AsyncGenerator
 
@@ -386,7 +388,8 @@ async def stream_agentic_events(
 
     except Exception as e:
         logger.exception("Agentic stream error")
-        yield create_error_event(str(e)).to_sse()
+        safe_message, _category = classify_llm_error(e)
+        yield create_error_event(safe_message).to_sse()
 
 
 __all__ = [

--- a/backend/src/requirements_graphrag_api/core/agentic/subgraphs/rag.py
+++ b/backend/src/requirements_graphrag_api/core/agentic/subgraphs/rag.py
@@ -27,6 +27,7 @@ from requirements_graphrag_api.core.agentic.state import (
     RAGState,
     RetrievedDocument,
 )
+from requirements_graphrag_api.core.errors import classify_llm_error
 from requirements_graphrag_api.evaluation.cost_analysis import get_global_cost_tracker
 from requirements_graphrag_api.prompts import PromptName, get_prompt
 
@@ -115,10 +116,11 @@ def create_rag_subgraph(
             }
 
         except Exception as e:
-            logger.exception("Query expansion failed")
+            _safe_msg, category = classify_llm_error(e)
+            logger.exception("Query expansion failed", error_category=category)
             return {
                 "expanded_queries": [query],
-                "retrieval_metadata": {"expansion_error": str(e)},
+                "retrieval_metadata": {"expansion_error": category},
             }
 
     # -------------------------------------------------------------------------

--- a/backend/src/requirements_graphrag_api/core/errors.py
+++ b/backend/src/requirements_graphrag_api/core/errors.py
@@ -1,0 +1,36 @@
+"""LLM provider error classification — maps raw exceptions to safe user messages.
+
+The CALLER is responsible for logging the real exception via logger.exception()
+before calling classify_llm_error(). This module only produces the safe outbound text.
+"""
+
+from __future__ import annotations
+
+_CAPACITY_MESSAGE = "The assistant is temporarily at capacity. Please try again shortly."
+_CONFIG_MESSAGE = "The assistant is temporarily unavailable."
+_UNKNOWN_MESSAGE = "Something went wrong generating a response."
+
+
+def classify_llm_error(exc: BaseException) -> tuple[str, str]:
+    """Map an LLM provider exception to a safe user message and a category string.
+
+    Args:
+        exc: The caught exception from an LLM provider call.
+
+    Returns:
+        ``(user_safe_message, category)`` where category is one of
+        ``"capacity"``, ``"config"``, or ``"unknown"``.
+    """
+    try:
+        import openai
+
+        if isinstance(exc, openai.RateLimitError):
+            return _CAPACITY_MESSAGE, "capacity"
+
+        if isinstance(exc, (openai.AuthenticationError, openai.PermissionDeniedError)):
+            return _CONFIG_MESSAGE, "config"
+
+    except ImportError:
+        pass
+
+    return _UNKNOWN_MESSAGE, "unknown"

--- a/backend/src/requirements_graphrag_api/core/routing.py
+++ b/backend/src/requirements_graphrag_api/core/routing.py
@@ -19,6 +19,7 @@ from typing import TYPE_CHECKING, Any
 import structlog
 from langchain_openai import ChatOpenAI
 
+from requirements_graphrag_api.core.errors import classify_llm_error
 from requirements_graphrag_api.evaluation.cost_analysis import get_global_cost_tracker
 from requirements_graphrag_api.observability import traceable_safe
 from requirements_graphrag_api.prompts import PromptName, get_prompt
@@ -206,7 +207,13 @@ async def classify_intent(
 
     chain = prompt_template | llm
 
-    llm_response = await chain.ainvoke({"question": question})
+    try:
+        llm_response = await chain.ainvoke({"question": question})
+    except Exception as e:
+        _safe_msg, category = classify_llm_error(e)
+        logger.exception("Intent classification LLM call failed", category=category)
+        return QueryIntent.EXPLANATORY
+
     get_global_cost_tracker().record_from_response(
         config.chat_model, llm_response, operation="intent_classification"
     )

--- a/backend/src/requirements_graphrag_api/core/text2cypher.py
+++ b/backend/src/requirements_graphrag_api/core/text2cypher.py
@@ -25,6 +25,7 @@ from langsmith import get_current_run_tree
 from neo4j import Query
 from neo4j.exceptions import ClientError, CypherSyntaxError, DatabaseError, ServiceUnavailable
 
+from requirements_graphrag_api.core.errors import classify_llm_error
 from requirements_graphrag_api.evaluation.cost_analysis import get_global_cost_tracker
 from requirements_graphrag_api.observability import traceable_safe
 from requirements_graphrag_api.prompts import PromptName, get_prompt
@@ -288,8 +289,12 @@ async def text2cypher_query(
             return error_response
         except Exception as e:
             # Non-timeout LLM failure (API error, auth error, etc.)
-            logger.error(
-                "Text2Cypher LLM error (attempt %d/%d): %s", attempt + 1, max_retries + 1, e
+            _safe_msg, category = classify_llm_error(e)
+            logger.exception(
+                "Text2Cypher LLM error (attempt %d/%d)",
+                attempt + 1,
+                max_retries + 1,
+                error_category=category,
             )
             if attempt < max_retries:
                 continue
@@ -298,7 +303,7 @@ async def text2cypher_query(
                 cypher="",
                 results=[],
                 row_count=0,
-                error=f"Query generation failed after {max_retries + 1} attempts: {e}",
+                error=_safe_msg,
             )
 
         # LLM succeeded — no retry for validation/execution errors

--- a/backend/tests/test_core/test_agentic/test_streaming_safety.py
+++ b/backend/tests/test_core/test_agentic/test_streaming_safety.py
@@ -1,0 +1,185 @@
+"""Regression tests: raw LLM provider errors must never reach end users via SSE.
+
+Covers the streaming.py catch-all (the critical net) and the routing fail-soft.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import json
+from unittest.mock import MagicMock
+
+import httpx
+import openai
+import pytest
+
+from requirements_graphrag_api.core.agentic.streaming import stream_agentic_events
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_response(status_code: int, body: dict) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        json=body,
+        request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions"),
+    )
+
+
+async def _collect_sse(generator) -> list[dict]:
+    """Collect SSE payloads from an async SSE generator into a list of parsed dicts."""
+    events = []
+    async for raw_line in generator:
+        stripped = raw_line.strip()
+        if stripped.startswith("data: "):
+            payload = stripped[len("data: ") :]
+            with contextlib.suppress(json.JSONDecodeError):
+                events.append(json.loads(payload))
+    return events
+
+
+def _make_raising_graph(exc: BaseException) -> MagicMock:
+    """Return a mock graph whose astream_events raises the given exception."""
+
+    async def _raising(*_args, **_kwargs):
+        # astream_events is an async generator; raise on first iteration
+        raise exc
+        yield  # makes this an async generator
+
+    graph = MagicMock()
+    graph.astream_events = _raising
+    return graph
+
+
+def _make_initial_state(query: str = "What is requirements traceability?") -> dict:
+    return {"query": query, "messages": []}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestStreamingCatchAllSafety:
+    """stream_agentic_events must never forward raw provider error text as SSE."""
+
+    @pytest.mark.asyncio
+    async def test_insufficient_quota_error_emits_safe_message(self) -> None:
+        response = _make_response(
+            429,
+            {"error": {"type": "insufficient_quota", "code": "insufficient_quota"}},
+        )
+        exc = openai.RateLimitError(
+            "You exceeded your current quota, please check your plan and billing details",
+            response=response,
+            body={"error": {"type": "insufficient_quota", "code": "insufficient_quota"}},
+        )
+
+        graph = _make_raising_graph(exc)
+        events = await _collect_sse(
+            stream_agentic_events(
+                graph,
+                _make_initial_state(),
+                config={"configurable": {"thread_id": "t1"}},
+            )
+        )
+
+        error_events = [e for e in events if "error" in e]
+        assert error_events, "Expected at least one error event"
+
+        for event in error_events:
+            error_text = event["error"]
+            assert "insufficient_quota" not in error_text, f"Raw quota error leaked: {error_text!r}"
+            assert "Error code: 429" not in error_text, f"Raw error code leaked: {error_text!r}"
+            assert "exceeded your current quota" not in error_text.lower(), (
+                f"Raw quota message leaked: {error_text!r}"
+            )
+            assert "billing" not in error_text.lower(), f"Billing detail leaked: {error_text!r}"
+            assert "check your plan" not in error_text.lower(), (
+                f"Plan detail leaked: {error_text!r}"
+            )
+
+    @pytest.mark.asyncio
+    async def test_insufficient_quota_error_message_is_user_friendly(self) -> None:
+        response = _make_response(
+            429,
+            {"error": {"type": "insufficient_quota", "code": "insufficient_quota"}},
+        )
+        exc = openai.RateLimitError(
+            "You exceeded your current quota",
+            response=response,
+            body={"error": {"type": "insufficient_quota", "code": "insufficient_quota"}},
+        )
+
+        graph = _make_raising_graph(exc)
+        events = await _collect_sse(
+            stream_agentic_events(
+                graph,
+                _make_initial_state(),
+                config={"configurable": {"thread_id": "t2"}},
+            )
+        )
+
+        error_events = [e for e in events if "error" in e]
+        assert error_events
+
+        error_text = error_events[-1]["error"]
+        is_friendly = (
+            "temporarily at capacity" in error_text.lower()
+            or "unavailable" in error_text.lower()
+            or "went wrong" in error_text.lower()
+        )
+        assert is_friendly, f"Expected user-friendly error message, got: {error_text!r}"
+
+    @pytest.mark.asyncio
+    async def test_authentication_error_emits_safe_message(self) -> None:
+        body = {"error": {"type": "invalid_api_key", "code": "invalid_api_key"}}
+        response = _make_response(401, body)
+        exc = openai.AuthenticationError(
+            "Incorrect API key provided: sk-real****key",
+            response=response,
+            body=body,
+        )
+
+        graph = _make_raising_graph(exc)
+        events = await _collect_sse(
+            stream_agentic_events(
+                graph,
+                _make_initial_state(),
+                config={"configurable": {"thread_id": "t3"}},
+            )
+        )
+
+        error_events = [e for e in events if "error" in e]
+        assert error_events
+
+        for event in error_events:
+            error_text = event["error"]
+            assert "sk-" not in error_text, f"API key fragment leaked: {error_text!r}"
+            assert "invalid_api_key" not in error_text, f"Auth detail leaked: {error_text!r}"
+            assert "Incorrect" not in error_text, f"Raw auth message leaked: {error_text!r}"
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_emits_safe_message(self) -> None:
+        exc = RuntimeError("internal connection pool exhausted at host neo4j://prod:7687")
+
+        graph = _make_raising_graph(exc)
+        events = await _collect_sse(
+            stream_agentic_events(
+                graph,
+                _make_initial_state(),
+                config={"configurable": {"thread_id": "t4"}},
+            )
+        )
+
+        error_events = [e for e in events if "error" in e]
+        assert error_events
+
+        for event in error_events:
+            error_text = event["error"]
+            assert "neo4j://prod" not in error_text, f"Internal host leaked: {error_text!r}"
+            assert "connection pool" not in error_text.lower(), (
+                f"Internal detail leaked: {error_text!r}"
+            )

--- a/backend/tests/test_core/test_errors.py
+++ b/backend/tests/test_core/test_errors.py
@@ -1,0 +1,116 @@
+"""Unit tests for core/errors.py — LLM provider error classifier."""
+
+from __future__ import annotations
+
+import httpx
+import openai
+
+from requirements_graphrag_api.core.errors import classify_llm_error
+
+
+def _make_response(status_code: int, body: dict) -> httpx.Response:
+    return httpx.Response(
+        status_code,
+        json=body,
+        request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions"),
+    )
+
+
+class TestClassifyLlmError:
+    """Tests for the classify_llm_error classifier mapping table."""
+
+    def test_rate_limit_insufficient_quota_returns_capacity(self) -> None:
+        response = _make_response(
+            429,
+            {"error": {"type": "insufficient_quota", "code": "insufficient_quota"}},
+        )
+        exc = openai.RateLimitError(
+            "You exceeded your current quota",
+            response=response,
+            body={"error": {"type": "insufficient_quota", "code": "insufficient_quota"}},
+        )
+        message, category = classify_llm_error(exc)
+
+        assert category == "capacity"
+        assert "insufficient_quota" not in message
+        assert "Error code" not in message
+        assert "429" not in message
+        assert message == "The assistant is temporarily at capacity. Please try again shortly."
+
+    def test_rate_limit_generic_returns_capacity(self) -> None:
+        response = _make_response(
+            429, {"error": {"type": "requests", "code": "rate_limit_exceeded"}}
+        )
+        exc = openai.RateLimitError(
+            "Rate limit exceeded",
+            response=response,
+            body={"error": {"type": "requests", "code": "rate_limit_exceeded"}},
+        )
+        message, category = classify_llm_error(exc)
+
+        assert category == "capacity"
+        assert "rate_limit_exceeded" not in message
+        assert "Rate limit" not in message
+
+    def test_authentication_error_returns_config(self) -> None:
+        response = _make_response(401, {"error": {"type": "invalid_api_key"}})
+        exc = openai.AuthenticationError(
+            "Invalid API key",
+            response=response,
+            body={"error": {"type": "invalid_api_key"}},
+        )
+        message, category = classify_llm_error(exc)
+
+        assert category == "config"
+        assert "key" not in message.lower()
+        assert "api" not in message.lower()
+        assert message == "The assistant is temporarily unavailable."
+
+    def test_permission_denied_returns_config(self) -> None:
+        response = _make_response(403, {"error": {"type": "permission_denied"}})
+        exc = openai.PermissionDeniedError(
+            "Permission denied",
+            response=response,
+            body={"error": {"type": "permission_denied"}},
+        )
+        message, category = classify_llm_error(exc)
+
+        assert category == "config"
+        assert message == "The assistant is temporarily unavailable."
+
+    def test_unknown_exception_returns_unknown(self) -> None:
+        exc = RuntimeError("something unexpected")
+        message, category = classify_llm_error(exc)
+
+        assert category == "unknown"
+        assert "unexpected" not in message
+        assert message == "Something went wrong generating a response."
+
+    def test_connection_error_returns_unknown(self) -> None:
+        response = _make_response(500, {"error": {"type": "server_error"}})
+        exc = openai.InternalServerError(
+            "Internal server error",
+            response=response,
+            body={"error": {"type": "server_error"}},
+        )
+        message, category = classify_llm_error(exc)
+
+        assert category == "unknown"
+        assert "Internal" not in message
+        assert "server" not in message.lower()
+
+    def test_safe_messages_never_contain_raw_error_text(self) -> None:
+        raw_text = "You exceeded your current quota, please check your plan"
+        response = _make_response(
+            429,
+            {"error": {"message": raw_text, "type": "insufficient_quota"}},
+        )
+        exc = openai.RateLimitError(
+            raw_text,
+            response=response,
+            body={"error": {"message": raw_text, "type": "insufficient_quota"}},
+        )
+        message, _category = classify_llm_error(exc)
+
+        assert raw_text not in message
+        assert "quota" not in message

--- a/backend/tests/test_core/test_routing.py
+++ b/backend/tests/test_core/test_routing.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 from unittest.mock import AsyncMock, MagicMock, patch
 
+import httpx
+import openai
 import pytest
 
 from requirements_graphrag_api.core.routing import (
@@ -346,3 +348,109 @@ class TestClassifyIntentConversational:
         ):
             result = await classify_intent(mock_config, "Can you go back to my earlier point?")
             assert result == QueryIntent.CONVERSATIONAL
+
+
+class TestClassifyIntentLlmFailure:
+    """Tests for fail-soft behaviour when the classification LLM raises a provider error."""
+
+    @pytest.fixture
+    def mock_config(self) -> MagicMock:
+        config = MagicMock()
+        config.chat_model = "gpt-4o-mini"
+        config.openai_api_key = "test-key"
+        return config
+
+    def _make_response(self, status_code: int, body: dict) -> httpx.Response:
+        return httpx.Response(
+            status_code,
+            json=body,
+            request=httpx.Request("POST", "https://api.openai.com/v1/chat/completions"),
+        )
+
+    @pytest.mark.asyncio
+    async def test_rate_limit_insufficient_quota_defaults_explanatory(
+        self, mock_config: MagicMock
+    ) -> None:
+        response = self._make_response(
+            429,
+            {"error": {"type": "insufficient_quota", "code": "insufficient_quota"}},
+        )
+        exc = openai.RateLimitError(
+            "You exceeded your current quota",
+            response=response,
+            body={"error": {"type": "insufficient_quota", "code": "insufficient_quota"}},
+        )
+
+        mock_chain = MagicMock()
+        mock_chain.ainvoke = AsyncMock(side_effect=exc)
+        mock_prompt = MagicMock()
+        mock_prompt.__or__ = MagicMock(return_value=mock_chain)
+
+        with (
+            patch(
+                "requirements_graphrag_api.core.routing._quick_classify",
+                return_value=None,
+            ),
+            patch(
+                "requirements_graphrag_api.core.routing.get_prompt",
+                new_callable=AsyncMock,
+                return_value=mock_prompt,
+            ),
+            patch("requirements_graphrag_api.core.routing.ChatOpenAI"),
+        ):
+            result = await classify_intent(mock_config, "What is requirements traceability?")
+
+        assert result == QueryIntent.EXPLANATORY
+
+    @pytest.mark.asyncio
+    async def test_authentication_error_defaults_explanatory(self, mock_config: MagicMock) -> None:
+        response = self._make_response(401, {"error": {"type": "invalid_api_key"}})
+        exc = openai.AuthenticationError(
+            "Invalid API key",
+            response=response,
+            body={"error": {"type": "invalid_api_key"}},
+        )
+
+        mock_chain = MagicMock()
+        mock_chain.ainvoke = AsyncMock(side_effect=exc)
+        mock_prompt = MagicMock()
+        mock_prompt.__or__ = MagicMock(return_value=mock_chain)
+
+        with (
+            patch(
+                "requirements_graphrag_api.core.routing._quick_classify",
+                return_value=None,
+            ),
+            patch(
+                "requirements_graphrag_api.core.routing.get_prompt",
+                new_callable=AsyncMock,
+                return_value=mock_prompt,
+            ),
+            patch("requirements_graphrag_api.core.routing.ChatOpenAI"),
+        ):
+            result = await classify_intent(mock_config, "What is requirements traceability?")
+
+        assert result == QueryIntent.EXPLANATORY
+
+    @pytest.mark.asyncio
+    async def test_generic_exception_defaults_explanatory(self, mock_config: MagicMock) -> None:
+        mock_chain = MagicMock()
+        mock_chain.ainvoke = AsyncMock(side_effect=RuntimeError("unexpected"))
+        mock_prompt = MagicMock()
+        mock_prompt.__or__ = MagicMock(return_value=mock_chain)
+
+        with (
+            patch(
+                "requirements_graphrag_api.core.routing._quick_classify",
+                return_value=None,
+            ),
+            patch(
+                "requirements_graphrag_api.core.routing.get_prompt",
+                new_callable=AsyncMock,
+                return_value=mock_prompt,
+            ),
+            patch("requirements_graphrag_api.core.routing.ChatOpenAI"),
+        ):
+            result = await classify_intent(mock_config, "What is requirements traceability?")
+
+        assert result == QueryIntent.EXPLANATORY

--- a/backend/tests/test_core/test_text2cypher.py
+++ b/backend/tests/test_core/test_text2cypher.py
@@ -499,7 +499,9 @@ class TestText2CypherTimeout:
             result = await text2cypher_query(mock_config, MagicMock(), "test", max_retries=1)
 
             assert mock_gen.call_count == 2
-            assert "failed" in result["error"]
+            # Error is now a safe user message — must not expose raw exception text
+            assert "API is down" not in result["error"]
+            assert result["error"] != ""
             assert result["row_count"] == 0
 
 


### PR DESCRIPTION
Closes #366

## Summary

During a quota-exhaustion incident, raw provider error text (`Error code: 429 - {'error': {'message': 'You exceeded your current quota...', 'type': 'insufficient_quota', ...}}`) reached the chat UI verbatim. Three code defects combined to produce this; all three are fixed here.

- **New `core/errors.py`** — pure classifier `classify_llm_error(exc) -> (user_safe_message, category)` mapping openai exception types to one of three safe messages. The caller logs the real exception; this module only produces the outbound text.
- **`streaming.py` catch-all** (the critical net) — replaces `create_error_event(str(e))` with the classifier's safe message. Nothing raw can escape the SSE stream again.
- **`routing.py`** — wraps `chain.ainvoke()` in try/except; on any provider error, logs and returns `QueryIntent.EXPLANATORY` so the request still proceeds (fail soft).
- **`rag.py`** — stores the classifier category string in `retrieval_metadata["expansion_error"]` instead of `str(e)`.
- **`text2cypher.py`** — returns the classifier safe message in the `error` field instead of `f"...{e}"`.

## Test plan

- [x] `test_core/test_errors.py` — unit tests for all three classifier buckets (capacity, config, unknown) including negative assertions that raw error text is never returned
- [x] `test_core/test_agentic/test_streaming_safety.py` — inject `openai.RateLimitError(insufficient_quota)`, `openai.AuthenticationError`, and `RuntimeError` at `graph.astream_events`; assert SSE `error` field is safe and contains no raw exception text, provider codes, or internal host names
- [x] `test_core/test_routing.py` — three new tests verifying `classify_intent` defaults to `QueryIntent.EXPLANATORY` when the LLM raises `RateLimitError`, `AuthenticationError`, or a generic exception
- [x] `test_core/test_text2cypher.py` — updated to assert error field no longer exposes raw exception text
- [x] 868 tests passing (855 baseline + 13 new); 1 pre-existing failure in `test_evaluation/test_ragas_evaluators.py::TestGetJudgeLlm::test_returns_chat_openai` (no `OPENAI_API_KEY` in test environment — unrelated to this change)

Note: Slack delivery to `claudecode-dev` failed — channel not found in workspace. Final PR URL is logged here instead.

https://claude.ai/code/session_014g6JWQ3849ZavPeMsuHfLc

---
_Generated by [Claude Code](https://claude.ai/code/session_014g6JWQ3849ZavPeMsuHfLc)_